### PR TITLE
Backend/events: Replace ics with icalendar for calendar generation

### DIFF
--- a/app/backend/pyproject.toml
+++ b/app/backend/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "geoip2>=5.1.0",
     "grpcio>=1.80.0",
     "http-ece>=1.2.1",
-    "ics>=0.7.3",
+    "icalendar>=7.2.2",
     "Jinja2>=3.1.6",
     "luhn>=0.2.0",
     "markdown-it-py>=4.2.0",
@@ -139,7 +139,7 @@ module = ["couchers.migrations.versions.*"]
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*", "growthbook", "user_agents", "pyroscope", "ics"]
+module = ["http_ece", "py_vapid", "luhn", "sqlalchemy_utils.*", "growthbook", "user_agents", "pyroscope"]
 # These libraries don't have type stubs or py.typed markers
 ignore_missing_imports = true
 

--- a/app/backend/src/couchers/email/calendar_events.py
+++ b/app/backend/src/couchers/email/calendar_events.py
@@ -1,10 +1,9 @@
-from datetime import UTC, datetime
+from datetime import date, datetime, timedelta
 from email.headerregistry import Address
 from typing import Literal
 from zoneinfo import ZoneInfo
 
-from ics import Calendar, Event, Geo
-from ics.grammar.parse import ContentLine  # type: ignore[import-untyped]
+from icalendar import Calendar, Event
 
 from couchers import urls
 from couchers.config import config
@@ -41,8 +40,8 @@ def create_host_request_ics_event(
 ) -> Event:
     """Creates an ics event for a host request."""
 
-    event = Event()
-    event.uid = _event_uid(host_request.host_request_id, kind="host_request")
+    event = Event()  # type: ignore[no-untyped-call]
+    event.add("uid", _event_uid(host_request.host_request_id, kind="host_request"))
     _set_sequence_timestamp(event, now())
 
     title: str
@@ -57,26 +56,28 @@ def create_host_request_ics_event(
             substitutions={"name": other_name},
         )
 
-    event.name = _final_title(
-        title,
-        loc_context,
-        is_cancelled=host_request.status == messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
+    event.add(
+        "summary",
+        _final_title(
+            title,
+            loc_context,
+            is_cancelled=host_request.status == messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
+        ),
     )
 
-    # Our to_date is inclusive, iCalendar's DTEND is exclusive (for full-day events)
-    # make_all_day will adjust the end date by one day accordingly.
-    event.begin = host_request.from_date
-    event.end = host_request.to_date
-    event.make_all_day()
+    # Our to_date is inclusive, iCalendar's DTEND is exclusive (for full-day events), hence the +1 day.
+    event.add("dtstart", date.fromisoformat(host_request.from_date))
+    event.add("dtend", date.fromisoformat(host_request.to_date) + timedelta(days=1))
 
-    event.location = host_request.hosting_city
-    event.url = urls.host_request(host_request_id=str(host_request.host_request_id))
+    event.add("location", host_request.hosting_city)
+    url = urls.host_request(host_request_id=str(host_request.host_request_id))
+    event.add("url", url)
 
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
-    event.description = event.url
+    event.add("description", url)
 
     if host_request.status == messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED:
-        event.status = "CANCELLED"
+        event.add("status", "CANCELLED")
 
     return event
 
@@ -92,27 +93,27 @@ def create_event_ics_calendar(event: events_pb2.Event, loc_context: Localization
 def create_event_ics_event(event: events_pb2.Event, loc_context: LocalizationContext) -> Event:
     """Creates an ics event for a host request."""
 
-    ics_event = Event()
-    ics_event.uid = _event_uid(event.event_id, kind="event")
-    ics_event.name = _final_title(event.title, loc_context, is_cancelled=event.is_cancelled)
+    ics_event = Event()  # type: ignore[no-untyped-call]
+    ics_event.add("uid", _event_uid(event.event_id, kind="event"))
+    ics_event.add("summary", _final_title(event.title, loc_context, is_cancelled=event.is_cancelled))
 
     last_update_datetime = to_aware_datetime(event.created if event.last_edited.seconds == 0 else event.last_edited)
-    ics_event.last_modified = last_update_datetime
+    ics_event.add("last-modified", last_update_datetime)
     _set_sequence_timestamp(ics_event, last_update_datetime)
 
     timezone = ZoneInfo(event.timezone)
-    _set_datetime_with_timezone(ics_event, "DTSTART", to_aware_datetime(event.start_time).astimezone(timezone))
-    _set_datetime_with_timezone(ics_event, "DTEND", to_aware_datetime(event.end_time).astimezone(timezone))
+    ics_event.add("dtstart", to_aware_datetime(event.start_time).astimezone(timezone))
+    ics_event.add("dtend", to_aware_datetime(event.end_time).astimezone(timezone))
 
-    ics_event.location = event.location.address
-    ics_event.geo = Geo(event.location.lat, event.location.lng)
+    ics_event.add("location", event.location.address)
+    ics_event.add("geo", (event.location.lat, event.location.lng))
     url = urls.event_link(occurrence_id=event.event_id, slug=event.slug)
-    ics_event.url = url
+    ics_event.add("url", url)
     # Google Calendar™ will hide the URL if there is a location, so also include it in the description
-    ics_event.description = markdown_to_plaintext(event.content) + "\n\n" + url
+    ics_event.add("description", markdown_to_plaintext(event.content) + "\n\n" + url)
 
     if event.is_cancelled:
-        ics_event.status = "CANCELLED"
+        ics_event.add("status", "CANCELLED")
 
     return ics_event
 
@@ -134,41 +135,28 @@ def _set_sequence_timestamp(event: Event, dt: datetime) -> None:
     # SEQUENCE is 32-bit, so only support second granularity to avoid overflows
     # A better implementation would need to reply on a stored sequence number.
     timestamp = round(dt.timestamp())
-    event.extra.append(ContentLine(name="SEQUENCE", value=str(timestamp)))
-
-
-def _set_datetime_with_timezone(event: Event, name: str, dt: datetime) -> None:
-    """
-    Adds a property whose value is a datetime with a timezone.
-    Working around that ics's native Event.begin/end properties don't encode the timezone.
-    """
-    datetime_format = "%Y%m%dT%H%M%S"
-    params: dict[str, list[str]] = {}
-    value: str
-    if isinstance(dt.tzinfo, ZoneInfo) and dt.tzinfo.key != "Etc/UTC":
-        params["TZID"] = [dt.tzinfo.key]
-        value = dt.strftime(datetime_format)
-    else:
-        value = dt.astimezone(UTC).strftime(datetime_format) + "Z"
-    event.extra.append(ContentLine(name, params, value=value))
+    event.add("sequence", timestamp)
 
 
 def ics_event_to_calendar(event: Event, method: str | None, loc_context: LocalizationContext) -> Calendar:
+    calendar = Calendar()  # type: ignore[no-untyped-call]
     # PRODID is mandatory and generally follows "-//[Organization]//[Product Name]//[Language]"
-    calendar = Calendar(creator=f"-//Couchers.org//Couchers//{loc_context.preferred_locale.upper()}")
+    calendar.add("prodid", f"-//Couchers.org//Couchers//{loc_context.preferred_locale.upper()}")
+    calendar.add("version", "2.0")
     if method:
-        calendar.method = method
-    calendar.events.add(event)
+        calendar.add("method", method)
+    calendar.add_component(event)
     return calendar
 
 
 def ics_calendar_to_attachment(calendar: Calendar, filename: str) -> EmailPart:
-    data = calendar.serialize().encode("utf-8")
+    data = calendar.to_ical()
     content_disposition = f'attachment; filename="{filename}"'
     content_type = 'text/calendar; charset="utf-8"'
-    if calendar.method:
+    method = calendar.get("method")
+    if method:
         # The SMTP Content-Type "method" parameter must match the value in the ics file.
         # AI recommends avoiding quotes on this parameter for backwards compatibility with old email clients.
-        content_type += f"; method={calendar.method}"
+        content_type += f"; method={method}"
 
     return EmailPart(data=data, content_disposition=content_disposition, content_type=content_type)

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -1406,5 +1406,5 @@ class Events(events_pb2_grpc.EventsServicer):
         _, occurrence_db = res
 
         event_pb = event_to_pb(session, occurrence_db, context)
-        ics_data = create_event_ics_calendar(event_pb, context.localization).serialize().encode("utf-8")
+        ics_data = create_event_ics_calendar(event_pb, context.localization).to_ical()
         return httpbody_pb2.HttpBody(content_type="text/calendar", data=ics_data)

--- a/app/backend/src/tests/test_calendar_events.py
+++ b/app/backend/src/tests/test_calendar_events.py
@@ -1,7 +1,7 @@
 import re
 from datetime import UTC, datetime, timedelta
 
-import ics
+import icalendar
 import pytest
 
 from couchers.email.calendar_events import create_event_ics_calendar, create_host_request_ics_calendar
@@ -24,9 +24,13 @@ def test_host_request_ics_content():
         host_request_id=42, from_date="2000-01-01", to_date="2000-01-02", hosting_city="New York"
     )
 
-    ics: str = create_host_request_ics_calendar(
-        host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
-    ).serialize()
+    ics: str = (
+        create_host_request_ics_calendar(
+            host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
+        )
+        .to_ical()
+        .decode()
+    )
     _assert_ics_matches_pattern(
         ics,
         """
@@ -58,9 +62,13 @@ def test_host_request_cancelled_ics_content():
         status=messages_pb2.HostRequestStatus.HOST_REQUEST_STATUS_CANCELLED,
     )
 
-    ics: str = create_host_request_ics_calendar(
-        host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
-    ).serialize()
+    ics: str = (
+        create_host_request_ics_calendar(
+            host_request, other_name="Bob", hosting=True, loc_context=LocalizationContext.en_utc()
+        )
+        .to_ical()
+        .decode()
+    )
     _assert_ics_matches_pattern(
         ics,
         """
@@ -97,7 +105,7 @@ def test_event_ics_content():
         timezone="Etc/GMT-1",  # Confusingly represents GMT+1, no DST
     )
 
-    ics: str = create_event_ics_calendar(event, loc_context=LocalizationContext.en_utc()).serialize()
+    ics: str = create_event_ics_calendar(event, loc_context=LocalizationContext.en_utc()).to_ical().decode()
     _assert_ics_matches_pattern(
         ics,
         """
@@ -113,7 +121,7 @@ DTSTART;TZID=Etc/GMT-1:20000102T130000
 DTEND;TZID=Etc/GMT-1:20000103T130000
 LAST-MODIFIED:20000101T000000Z
 LOCATION:City\\, Country
-GEO:0.100000;0.100000
+GEO:0.1;0.1
 URL:***/event/42/event-slug
 END:VEVENT
 METHOD:PUBLISH
@@ -175,11 +183,11 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
     email = email_collector.pop_for_recipient(surfer.email, last=True)
     assert "accept" in email.subject and host.name in email.subject
     accepted_ics_event = _get_email_ics_attachment_calendar_event(email)
-    assert not accepted_ics_event.status
-    assert accepted_ics_event.begin.date() == from_date
-    assert accepted_ics_event.end.date() == (to_date + timedelta(days=1))
-    assert accepted_ics_event.name == f"Surfing with {host.name}"
-    assert accepted_ics_event.location == host.city
+    assert not accepted_ics_event.get("status")
+    assert accepted_ics_event.get("dtstart").dt == from_date
+    assert accepted_ics_event.get("dtend").dt == (to_date + timedelta(days=1))
+    assert accepted_ics_event.get("summary") == f"Surfing with {host.name}"
+    assert accepted_ics_event.get("location") == host.city
 
     # Surfer confirms, host gets a calendar attachment
     with requests_session(surfer_token) as api:
@@ -194,8 +202,8 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
     email = email_collector.pop_for_recipient(host.email, last=True)
     assert "confirm" in email.subject and surfer.name in email.subject
     confirmed_ics_event = _get_email_ics_attachment_calendar_event(email)
-    assert not confirmed_ics_event.status
-    assert confirmed_ics_event.name == f"Hosting {surfer.name}"
+    assert not confirmed_ics_event.get("status")
+    assert confirmed_ics_event.get("summary") == f"Hosting {surfer.name}"
 
     # Surfer cancels, host gets a calendar attachment
     with requests_session(surfer_token) as api:
@@ -212,7 +220,7 @@ def test_host_request_attachments(db, email_collector: EmailCollector, moderator
     cancelled_ics_event = _get_email_ics_attachment_calendar_event(email)
     # Ideally the sequence number are strictly ascending, but they are based on timestamps so in tests they could be equal.
     assert (_get_ics_event_sequence(cancelled_ics_event) or 0) >= (_get_ics_event_sequence(accepted_ics_event) or 0)
-    assert cancelled_ics_event.status == "CANCELLED"
+    assert cancelled_ics_event.get("status") == "CANCELLED"
 
 
 def test_host_request_attachments_disabled(db, email_collector: EmailCollector, feature_flags, moderator: Moderator):
@@ -253,18 +261,19 @@ def test_host_request_attachments_disabled(db, email_collector: EmailCollector, 
     assert not email.attachments
 
 
-def _get_email_ics_attachment_calendar_event(e) -> ics.Event:
+def _get_email_ics_attachment_calendar_event(e) -> icalendar.Event:
     assert len(e.attachments or []) == 1
     ics_attachment = e.attachments[0]
     assert ics_attachment.content_type.startswith("text/calendar")
-    ics_calendar = ics.Calendar(ics_attachment.data.decode("utf-8"))
-    assert f"method={ics_calendar.method}" in ics_attachment.content_type
-    assert len(ics_calendar.events) == 1
-    return next(iter(ics_calendar.events))
+    ics_calendar = icalendar.Calendar.from_ical(ics_attachment.data.decode("utf-8"))
+    assert f"method={ics_calendar.get('method')}" in ics_attachment.content_type
+    events = list(ics_calendar.walk("VEVENT"))
+    assert len(events) == 1
+    event = events[0]
+    assert isinstance(event, icalendar.Event)
+    return event
 
 
-def _get_ics_event_sequence(event: ics.Event) -> int | None:
-    for x in event.extra:
-        if x.name == "SEQUENCE":
-            return int(x.value)
-    return None
+def _get_ics_event_sequence(event: icalendar.Event) -> int | None:
+    sequence = event.get("sequence")
+    return int(sequence) if sequence is not None else None

--- a/app/backend/uv.lock
+++ b/app/backend/uv.lock
@@ -89,19 +89,6 @@ wheels = [
 ]
 
 [[package]]
-name = "arrow"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-    { name = "tzdata" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -268,7 +255,7 @@ dependencies = [
     { name = "growthbook" },
     { name = "grpcio" },
     { name = "http-ece" },
-    { name = "ics" },
+    { name = "icalendar" },
     { name = "jinja2" },
     { name = "luhn" },
     { name = "markdown-it-py" },
@@ -332,7 +319,7 @@ requires-dist = [
     { name = "growthbook", specifier = ">=2.3.1" },
     { name = "grpcio", specifier = ">=1.80.0" },
     { name = "http-ece", specifier = ">=1.2.1" },
-    { name = "ics", specifier = ">=0.7.3" },
+    { name = "icalendar", specifier = ">=7.2.2" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "luhn", specifier = ">=0.2.0" },
     { name = "markdown-it-py", specifier = ">=4.2.0" },
@@ -582,6 +569,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
     { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
     { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/d2c70cae6e823fac36c3bbc9077962105052b7ef81db2f01ec3b9bf17e2b/greenlet-3.3.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dcd2bdbd444ff340e8d6bdf54d2f206ccddbb3ccfdcd3c25bf4afaa7b8f0cf45", size = 671388, upload-time = "2025-12-04T15:07:15.789Z" },
     { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
     { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
     { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
@@ -589,6 +577,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
     { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cc/1e4bae2e45ca2fa55299f4e85854606a78ecc37fead20d69322f96000504/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2662433acbca297c9153a4023fe2161c8dcfdcc91f10433171cf7e7d94ba2221", size = 662506, upload-time = "2025-12-04T15:07:16.906Z" },
     { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
     { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
     { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
@@ -640,19 +629,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/af/249d1576653b69c20b9ac30e284b63bd94af6a175d72d87813235caf2482/http_ece-1.2.1.tar.gz", hash = "sha256:8c6ab23116bbf6affda894acfd5f2ca0fb8facbcbb72121c11c75c33e7ce8cff", size = 8830, upload-time = "2024-08-08T00:10:47.301Z" }
 
 [[package]]
-name = "ics"
-version = "0.7.3"
+name = "icalendar"
+version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "arrow" },
-    { name = "attrs" },
     { name = "python-dateutil" },
-    { name = "six" },
-    { name = "tatsu" },
+    { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/9d/f1fa704c153351f679245c0f1dc0099df2d5e3ddb94a06810403a8931bef/ics-0.7.3.tar.gz", hash = "sha256:2dcd6876e8c913d40db76f1f1ca47bccd1c162178c73f69fbbedca1b844eface", size = 191007, upload-time = "2026-04-15T09:44:43.042Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/37/4c43e9534a4d43f8cde8f0fd7f869628b45f63f27c5b040230c8f1d90b3d/icalendar-7.2.2.tar.gz", hash = "sha256:6cf904a928881e20c89b682e75bca2eb97e8c5ca629782ed44a519abf4cac1cc", size = 491618, upload-time = "2026-07-20T12:04:05.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/cd/b8b730bd5804554643610d15954c0fe4eac6ddfe8e78b4396a67c3cae93d/ics-0.7.3-py2.py3-none-any.whl", hash = "sha256:519f633f2e3d7b1528847e990a58dcb8807a2fffdcfd9dd880d1d5094d456af7", size = 40173, upload-time = "2026-04-15T09:44:41.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/8cbebc368afc020c979e5f9433348531215c65df93b0d6d6f1a1b13a39eb/icalendar-7.2.2-py3-none-any.whl", hash = "sha256:90dd280cb4f67d1ef07b5178c2c33db4fc0a05627e50a3758b6b2aa9b117bc07", size = 502831, upload-time = "2026-07-20T12:04:03.796Z" },
 ]
 
 [[package]]
@@ -1662,15 +1648,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/ec/0f17cff3f7c91b0215266959c5a2a96b0bf9f45ac041c50b99ad8f9b5047/stripe-14.4.0.tar.gz", hash = "sha256:ddaa06f5e38a582bef7e93e06fc304ba8ae3b4c0c2aac43da02c84926f05fa0a", size = 1472370, upload-time = "2026-02-25T17:52:40.905Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/09/fcecad01d76dbe027015dd559ec1b6dccfc319c2540991dde4b1de81ba34/stripe-14.4.0-py3-none-any.whl", hash = "sha256:357151a816cd0bb012d6cb29f108fae50b9f6eece8530d7bc31dfa90c9ceb84c", size = 2115405, upload-time = "2026-02-25T17:52:39.128Z" },
-]
-
-[[package]]
-name = "tatsu"
-version = "5.15.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/0b/46725961e0b77e88352e60b9e78aef268cacd6dfae7f1527a348b0247606/tatsu-5.15.1.tar.gz", hash = "sha256:38b0467dbf086f032a7321023e65a773201c1acdebe0e9ac35c5ec26637e0b0d", size = 133908, upload-time = "2026-01-04T13:39:47.97Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/2f/7afdd76cac1511c456fdd880394cd54bc27ff5d991d3cb6b2ce0720b7d80/tatsu-5.15.1-py3-none-any.whl", hash = "sha256:3a1229eec55dcb1da7ae2842b1abf26bb746e92dc6734ab6785e84cecb465f06", size = 80069, upload-time = "2026-01-04T13:39:46.358Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces the `ics` library with `icalendar` for generating `.ics` calendar attachments/exports (host request emails, event emails, and the event calendar-file endpoint).

We were evaluating a future need to evaluate RRULE for future occurrences, and found `ics` has no RRULE support at all and is effectively unmaintained. `icalendar` also lets us drop several manual workarounds that were already in `calendar_events.py` (raw `ContentLine` hacks for `SEQUENCE` and for `DTSTART`/`DTEND` with `TZID`), and ships its own type stubs so the mypy `ignore_missing_imports` override for `ics` is no longer needed.

On dependencies: `icalendar` requires `tzdata`, but that was already pulled in transitively via `ics -> arrow -> tzdata`, so it's not a new cost. Dropping `ics` also drops `arrow` and `tatsu` from the tree, which nothing else in the codebase used directly.

Related to #9545

## Testing
Updated `test_calendar_events.py` to use the `icalendar` API.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me