### PR TITLE
Record a history of hosting and meetup status changes

### DIFF
--- a/app/backend/src/couchers/helpers/hosting_meetup_status.py
+++ b/app/backend/src/couchers/helpers/hosting_meetup_status.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select
+from sqlalchemy import insert, literal, select
 from sqlalchemy.orm import Session
 
 from couchers.models import HostingMeetupStatusHistory, HostingMeetupStatusSource, User
@@ -10,22 +10,32 @@ def record_hosting_meetup_status(session: Session, user: User, source: HostingMe
 
     Call this after any code path that may change either status; it's a no-op if the statuses are unchanged since the
     last recorded row, so it's safe to call unconditionally.
+
+    The snapshot is read from the user's row rather than the in-memory object, so a pending status change has to be
+    flushed first -- the execute below autoflushes, so this only matters under `no_autoflush`.
     """
-    latest = session.execute(
-        select(HostingMeetupStatusHistory)
+    latest = (
+        select(HostingMeetupStatusHistory.hosting_status, HostingMeetupStatusHistory.meetup_status)
         .where(HostingMeetupStatusHistory.user_id == user.id)
         .order_by(HostingMeetupStatusHistory.time.desc(), HostingMeetupStatusHistory.id.desc())
         .limit(1)
-    ).scalar_one_or_none()
-
-    if latest and latest.hosting_status == user.hosting_status and latest.meetup_status == user.meetup_status:
-        return
-
-    session.add(
-        HostingMeetupStatusHistory(
-            user_id=user.id,
-            source=source,
-            hosting_status=user.hosting_status,
-            meetup_status=user.meetup_status,
+        .subquery()
+    )
+    session.execute(
+        insert(HostingMeetupStatusHistory).from_select(
+            ["user_id", "source", "hosting_status", "meetup_status"],
+            select(
+                User.id,
+                literal(source, HostingMeetupStatusHistory.source.type),
+                User.hosting_status,
+                User.meetup_status,
+            )
+            .where(User.id == user.id)
+            .where(
+                ~select(latest)
+                .where(latest.c.hosting_status == User.hosting_status)
+                .where(latest.c.meetup_status == User.meetup_status)
+                .exists()
+            ),
         )
     )

--- a/app/backend/src/couchers/helpers/hosting_meetup_status.py
+++ b/app/backend/src/couchers/helpers/hosting_meetup_status.py
@@ -1,0 +1,31 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from couchers.models import HostingMeetupStatusHistory, HostingMeetupStatusSource, User
+
+
+def record_hosting_meetup_status(session: Session, user: User, source: HostingMeetupStatusSource) -> None:
+    """
+    Append the user's current hosting and meetup statuses to their history.
+
+    Call this after any code path that may change either status; it's a no-op if the statuses are unchanged since the
+    last recorded row, so it's safe to call unconditionally.
+    """
+    latest = session.execute(
+        select(HostingMeetupStatusHistory)
+        .where(HostingMeetupStatusHistory.user_id == user.id)
+        .order_by(HostingMeetupStatusHistory.time.desc(), HostingMeetupStatusHistory.id.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+    if latest and latest.hosting_status == user.hosting_status and latest.meetup_status == user.meetup_status:
+        return
+
+    session.add(
+        HostingMeetupStatusHistory(
+            user_id=user.id,
+            source=source,
+            hosting_status=user.hosting_status,
+            meetup_status=user.meetup_status,
+        )
+    )

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -58,6 +58,7 @@ from couchers.event_log import log_event
 from couchers.helpers.badges import user_add_badge, user_remove_badge
 from couchers.helpers.completed_profile import has_completed_profile_expression
 from couchers.helpers.group_chats import is_newest_subscription, is_unseen
+from couchers.helpers.hosting_meetup_status import record_hosting_meetup_status
 from couchers.materialized_views import (
     UserResponseRate,
 )
@@ -78,6 +79,7 @@ from couchers.models import (
     EventOccurrenceAttendee,
     GroupChat,
     GroupChatSubscription,
+    HostingMeetupStatusSource,
     HostingStatus,
     HostRequest,
     HostRequestStatus,
@@ -1131,6 +1133,7 @@ def send_activeness_probes(payload: empty_pb2.Empty) -> None:
                 probe.user.hosting_status = HostingStatus.maybe
             if probe.user.meetup_status == MeetupStatus.wants_to_meetup:
                 probe.user.meetup_status = MeetupStatus.open_to_meetup
+            record_hosting_meetup_status(session, probe.user, HostingMeetupStatusSource.activeness_probe_expired)
             session.commit()
 
 

--- a/app/backend/src/couchers/migrations/versions/0182_add_hosting_meetup_status_history.py
+++ b/app/backend/src/couchers/migrations/versions/0182_add_hosting_meetup_status_history.py
@@ -1,0 +1,62 @@
+"""Add hosting_meetup_status_history table
+
+Revision ID: 0182
+Revises: 0181
+Create Date: 2026-08-15 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0182"
+down_revision = "0181"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hosting_meetup_status_history",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("time", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "source",
+            sa.Enum(
+                "backfill",
+                "signup",
+                "profile_edit",
+                "do_not_email",
+                "unsubscribe_link",
+                "activeness_probe_response",
+                "activeness_probe_expired",
+                name="hostingmeetupstatussource",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "hosting_status",
+            postgresql.ENUM("can_host", "maybe", "cant_host", name="hostingstatus", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "meetup_status",
+            postgresql.ENUM(
+                "wants_to_meetup", "open_to_meetup", "does_not_want_to_meetup", name="meetupstatus", create_type=False
+            ),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name=op.f("fk_hosting_meetup_status_history_user_id_users")),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_hosting_meetup_status_history")),
+    )
+    op.create_index(
+        "ix_hosting_meetup_status_history_user_id_time", "hosting_meetup_status_history", ["user_id", "time"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("hosting_meetup_status_history")
+    sa.Enum(name="hostingmeetupstatussource").drop(op.get_bind())

--- a/app/backend/src/couchers/migrations/versions/0182_add_hosting_meetup_status_history.py
+++ b/app/backend/src/couchers/migrations/versions/0182_add_hosting_meetup_status_history.py
@@ -58,4 +58,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("hosting_meetup_status_history")
-    sa.Enum(name="hostingmeetupstatussource").drop(op.get_bind())
+    sa.Enum(name="hostingmeetupstatussource").drop(op.get_bind(), checkfirst=True)

--- a/app/backend/src/couchers/migrations/versions/0182_add_hosting_meetup_status_history.py
+++ b/app/backend/src/couchers/migrations/versions/0182_add_hosting_meetup_status_history.py
@@ -26,7 +26,6 @@ def upgrade() -> None:
         sa.Column(
             "source",
             sa.Enum(
-                "backfill",
                 "signup",
                 "profile_edit",
                 "do_not_email",

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -66,6 +66,23 @@ class MeetupStatus(enum.Enum):
     does_not_want_to_meetup = enum.auto()
 
 
+class HostingMeetupStatusSource(enum.Enum):
+    # reconstructed from other data, not observed live
+    backfill = enum.auto()
+    # the statuses the account was created with
+    signup = enum.auto()
+    # the user edited their profile
+    profile_edit = enum.auto()
+    # the user enabled "do not email" in their notification settings
+    do_not_email = enum.auto()
+    # the user used the "do not email" quick link in an email
+    unsubscribe_link = enum.auto()
+    # the user responded to an activeness probe saying they're no longer active
+    activeness_probe_response = enum.auto()
+    # the user let an activeness probe expire, so we downgraded them
+    activeness_probe_expired = enum.auto()
+
+
 class SmokingLocation(enum.Enum):
     yes = enum.auto()
     window = enum.auto()
@@ -637,3 +654,23 @@ class RegionLived(Base, kw_only=True):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
     region_code: Mapped[str] = mapped_column(ForeignKey("regions.code", deferrable=True))
+
+
+class HostingMeetupStatusHistory(Base, kw_only=True):
+    """
+    Append-only snapshot log of users' hosting and meetup statuses. A row is written whenever either status changes, so
+    a user's statuses at any past time are those of their newest row at or before that time.
+    """
+
+    __tablename__ = "hosting_meetup_status_history"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
+    time: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    source: Mapped[HostingMeetupStatusSource] = mapped_column(Enum(HostingMeetupStatusSource))
+    hosting_status: Mapped[HostingStatus] = mapped_column(Enum(HostingStatus))
+    meetup_status: Mapped[MeetupStatus] = mapped_column(Enum(MeetupStatus))
+
+    user: Mapped[User] = relationship(init=False)
+
+    __table_args__ = (Index("ix_hosting_meetup_status_history_user_id_time", user_id, time),)

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -67,8 +67,6 @@ class MeetupStatus(enum.Enum):
 
 
 class HostingMeetupStatusSource(enum.Enum):
-    # reconstructed from other data, not observed live
-    backfill = enum.auto()
     # the statuses the account was created with
     signup = enum.auto()
     # the user edited their profile

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -75,7 +75,7 @@ class HostingMeetupStatusSource(enum.Enum):
     do_not_email = enum.auto()
     # the user used the "do not email" quick link in an email
     unsubscribe_link = enum.auto()
-    # the user responded to an activeness probe saying they're no longer active
+    # the user responded to an activeness probe
     activeness_probe_response = enum.auto()
     # the user let an activeness probe expire, so we downgraded them
     activeness_probe_expired = enum.auto()

--- a/app/backend/src/couchers/servicers/api.py
+++ b/app/backend/src/couchers/servicers/api.py
@@ -25,6 +25,7 @@ from couchers.helpers.host_requests import (
     is_public_trip_offer_recipient,
     is_surfing_party,
 )
+from couchers.helpers.hosting_meetup_status import record_hosting_meetup_status
 from couchers.helpers.references import where_reference_user_visible, where_references_not_hidden_by_reciprocity
 from couchers.helpers.strong_verification import get_strong_verification_fields
 from couchers.materialized_views import LiteUser, UserResponseRate
@@ -33,6 +34,7 @@ from couchers.models import (
     FriendStatus,
     GroupChat,
     GroupChatSubscription,
+    HostingMeetupStatusSource,
     HostingStatus,
     HostRequest,
     InitiatedUpload,
@@ -437,6 +439,12 @@ class API(api_pb2_grpc.APIServicer):
             if user.do_not_email and request.meetup_status != api_pb2.MEETUP_STATUS_DOES_NOT_WANT_TO_MEETUP:
                 context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "do_not_email_cannot_meet")
             user.meetup_status = meetupstatus2sql[request.meetup_status]  # type: ignore[assignment]
+
+        if (
+            request.hosting_status != api_pb2.HOSTING_STATUS_UNSPECIFIED
+            or request.meetup_status != api_pb2.MEETUP_STATUS_UNSPECIFIED
+        ):
+            record_hosting_meetup_status(session, user, HostingMeetupStatusSource.profile_edit)
 
         if request.HasField("language_abilities"):
             # delete all existing abilities

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -13,6 +13,7 @@ from couchers.constants import ANTIBOT_FREQ, BANNED_USERNAME_PHRASES, GUIDELINES
 from couchers.context import CouchersContext
 from couchers.crypto import cookiesafe_secure_token, hash_password, urlsafe_secure_token, verify_password
 from couchers.event_log import log_event
+from couchers.helpers.hosting_meetup_status import record_hosting_meetup_status
 from couchers.metrics import (
     account_deletion_completions_counter,
     account_recoveries_counter,
@@ -33,6 +34,7 @@ from couchers.models import (
     AccountDeletionToken,
     AntiBotLog,
     ContributorForm,
+    HostingMeetupStatusSource,
     InviteCode,
     ModerationObjectType,
     NonvisibleUserAccessType,
@@ -391,6 +393,8 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 object_id=create_user,
             )
             assert user is not None
+
+            record_hosting_meetup_status(session, user, HostingMeetupStatusSource.signup)
 
             # Create a profile gallery for the user
             profile_gallery = PhotoGallery(owner_user_id=user.id)

--- a/app/backend/src/couchers/servicers/auth_unsubscribe.py
+++ b/app/backend/src/couchers/servicers/auth_unsubscribe.py
@@ -10,9 +10,11 @@ from sqlalchemy.orm import Session
 
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import CouchersContext, make_one_off_interactive_user_context
+from couchers.helpers.hosting_meetup_status import record_hosting_meetup_status
 from couchers.models import (
     GroupChat,
     GroupChatSubscription,
+    HostingMeetupStatusSource,
     HostingStatus,
     MeetupStatus,
     NotificationDeliveryType,
@@ -39,6 +41,7 @@ def handle_unsubscribe(payload: unsubscribe_pb2.UnsubscribePayload, context: Cou
         user.do_not_email = True
         user.hosting_status = HostingStatus.cant_host
         user.meetup_status = MeetupStatus.does_not_want_to_meetup
+        record_hosting_meetup_status(session, user, HostingMeetupStatusSource.unsubscribe_link)
         return context.localization.localize_string("quick_links.do_not_email")
 
     if payload.HasField("topic_action"):

--- a/app/backend/src/couchers/servicers/jail.py
+++ b/app/backend/src/couchers/servicers/jail.py
@@ -7,7 +7,15 @@ from sqlalchemy.orm import Session
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
 from couchers.context import CouchersContext
-from couchers.models import ActivenessProbe, ActivenessProbeStatus, HostingStatus, ModNote, User
+from couchers.helpers.hosting_meetup_status import record_hosting_meetup_status
+from couchers.models import (
+    ActivenessProbe,
+    ActivenessProbeStatus,
+    HostingMeetupStatusSource,
+    HostingStatus,
+    ModNote,
+    User,
+)
 from couchers.proto import jail_pb2, jail_pb2_grpc
 from couchers.servicers.account import mod_note_to_pb
 from couchers.utils import create_coordinate, now
@@ -134,5 +142,8 @@ class Jail(jail_pb2_grpc.JailServicer):
             context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "probe_response_invalid")
 
         probe.responded = now()
+
+        # after `responded` is set, otherwise the autoflush inside would trip the probe's check constraint
+        record_hosting_meetup_status(session, user, HostingMeetupStatusSource.activeness_probe_response)
 
         return _get_jail_info(user)

--- a/app/backend/src/couchers/servicers/notifications.py
+++ b/app/backend/src/couchers/servicers/notifications.py
@@ -11,9 +11,11 @@ from sqlalchemy.sql import or_
 from couchers.config import config
 from couchers.constants import DATETIME_INFINITY
 from couchers.context import CouchersContext
+from couchers.helpers.hosting_meetup_status import record_hosting_meetup_status
 from couchers.i18n import LocalizationContext
 from couchers.models import (
     DeviceType,
+    HostingMeetupStatusSource,
     HostingStatus,
     MeetupStatus,
     Notification,
@@ -80,6 +82,7 @@ class Notifications(notifications_pb2_grpc.NotificationsServicer):
         if request.enable_do_not_email:
             user.hosting_status = HostingStatus.cant_host
             user.meetup_status = MeetupStatus.does_not_want_to_meetup
+            record_hosting_meetup_status(session, user, HostingMeetupStatusSource.do_not_email)
         for preference in request.preferences:
             topic_action = enum_from_topic_action.get((preference.topic, preference.action), None)
             if not topic_action:

--- a/app/backend/src/tests/test_hosting_meetup_status_history.py
+++ b/app/backend/src/tests/test_hosting_meetup_status_history.py
@@ -1,0 +1,178 @@
+from datetime import timedelta
+
+import pytest
+from google.protobuf import empty_pb2, wrappers_pb2
+from sqlalchemy import select
+
+from couchers.crypto import UNSUBSCRIBE_KEY_NAME, generate_hash_signature, get_secret
+from couchers.db import session_scope
+from couchers.jobs.enqueue import queue_job
+from couchers.jobs.handlers import send_activeness_probes
+from couchers.models import (
+    ActivenessProbe,
+    HostingMeetupStatusHistory,
+    HostingMeetupStatusSource,
+    HostingStatus,
+    MeetupStatus,
+    User,
+)
+from couchers.proto import api_pb2, auth_pb2, jail_pb2, notifications_pb2
+from couchers.proto.internal import unsubscribe_pb2
+from couchers.utils import now
+from tests.fixtures.db import generate_user
+from tests.fixtures.misc import PushCollector, process_jobs
+from tests.fixtures.sessions import (
+    api_session,
+    auth_api_session,
+    notifications_session,
+    real_jail_session,
+)
+from tests.test_auth import _quick_signup
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+def get_history(user_id: int) -> list[tuple[HostingMeetupStatusSource, HostingStatus, MeetupStatus]]:
+    with session_scope() as session:
+        return [
+            (row.source, row.hosting_status, row.meetup_status)
+            for row in session.execute(
+                select(HostingMeetupStatusHistory)
+                .where(HostingMeetupStatusHistory.user_id == user_id)
+                .order_by(HostingMeetupStatusHistory.id)
+            ).scalars()
+        ]
+
+
+def test_history_recorded_on_signup(db):
+    user_id = _quick_signup()
+
+    assert get_history(user_id) == [
+        (HostingMeetupStatusSource.signup, HostingStatus.can_host, MeetupStatus.open_to_meetup)
+    ]
+
+
+def test_history_recorded_on_profile_edit(db):
+    user, token = generate_user(hosting_status=HostingStatus.cant_host, meetup_status=MeetupStatus.open_to_meetup)
+
+    with api_session(token) as api:
+        api.UpdateProfile(api_pb2.UpdateProfileReq(hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST))
+        api.UpdateProfile(api_pb2.UpdateProfileReq(meetup_status=api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP))
+
+    assert get_history(user.id) == [
+        (HostingMeetupStatusSource.profile_edit, HostingStatus.can_host, MeetupStatus.open_to_meetup),
+        (HostingMeetupStatusSource.profile_edit, HostingStatus.can_host, MeetupStatus.wants_to_meetup),
+    ]
+
+
+def test_history_not_recorded_when_unchanged(db):
+    user, token = generate_user(hosting_status=HostingStatus.can_host, meetup_status=MeetupStatus.wants_to_meetup)
+
+    with api_session(token) as api:
+        # neither status is touched
+        api.UpdateProfile(api_pb2.UpdateProfileReq(name=wrappers_pb2.StringValue(value="Frodo Baggins")))
+        assert get_history(user.id) == []
+
+        # both statuses set to what they already are, but nothing has ever been recorded for this user, so this
+        # becomes their first row
+        api.UpdateProfile(
+            api_pb2.UpdateProfileReq(
+                hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
+                meetup_status=api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP,
+            )
+        )
+        assert get_history(user.id) == [
+            (HostingMeetupStatusSource.profile_edit, HostingStatus.can_host, MeetupStatus.wants_to_meetup)
+        ]
+
+        # now that it's been recorded, a no-op edit doesn't add another
+        api.UpdateProfile(
+            api_pb2.UpdateProfileReq(
+                hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
+                meetup_status=api_pb2.MEETUP_STATUS_WANTS_TO_MEETUP,
+            )
+        )
+        assert len(get_history(user.id)) == 1
+
+
+def test_history_recorded_on_do_not_email(db):
+    user, token = generate_user(hosting_status=HostingStatus.can_host, meetup_status=MeetupStatus.wants_to_meetup)
+
+    with notifications_session(token) as notifications:
+        notifications.SetNotificationSettings(notifications_pb2.SetNotificationSettingsReq(enable_do_not_email=True))
+
+    assert get_history(user.id) == [
+        (HostingMeetupStatusSource.do_not_email, HostingStatus.cant_host, MeetupStatus.does_not_want_to_meetup)
+    ]
+
+
+def test_history_recorded_on_unsubscribe_link(db):
+    user, token = generate_user(hosting_status=HostingStatus.can_host, meetup_status=MeetupStatus.wants_to_meetup)
+
+    payload = unsubscribe_pb2.UnsubscribePayload(
+        user_id=user.id, do_not_email=unsubscribe_pb2.DoNotEmail()
+    ).SerializeToString()
+    sig = generate_hash_signature(message=payload, key=get_secret(UNSUBSCRIBE_KEY_NAME))
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        auth_api.Unsubscribe(auth_pb2.UnsubscribeReq(payload=payload, sig=sig))
+
+    assert get_history(user.id) == [
+        (HostingMeetupStatusSource.unsubscribe_link, HostingStatus.cant_host, MeetupStatus.does_not_want_to_meetup)
+    ]
+
+
+def test_history_recorded_on_activeness_probe_response(db, push_collector: PushCollector):
+    user, token = generate_user(
+        hosting_status=HostingStatus.can_host,
+        meetup_status=MeetupStatus.wants_to_meetup,
+        last_active=now() - timedelta(days=335),
+    )
+
+    with session_scope() as session:
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
+
+    process_jobs()
+
+    with real_jail_session(token) as jail:
+        jail.RespondToActivenessProbe(
+            jail_pb2.RespondToActivenessProbeReq(response=jail_pb2.ACTIVENESS_PROBE_RESPONSE_NO_LONGER_ACTIVE)
+        )
+
+    assert get_history(user.id) == [
+        (HostingMeetupStatusSource.activeness_probe_response, HostingStatus.cant_host, MeetupStatus.wants_to_meetup)
+    ]
+
+
+def test_history_recorded_on_activeness_probe_expiry(db, push_collector: PushCollector):
+    user, token = generate_user(
+        hosting_status=HostingStatus.can_host,
+        meetup_status=MeetupStatus.wants_to_meetup,
+        last_active=now() - timedelta(days=335),
+    )
+
+    with session_scope() as session:
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
+
+    process_jobs()
+
+    with session_scope() as session:
+        probe = session.execute(select(ActivenessProbe)).scalar_one()
+        probe.probe_initiated = now() - timedelta(days=15)
+        probe.notifications_sent = 2
+
+        queue_job(session, job=send_activeness_probes, payload=empty_pb2.Empty())
+
+    process_jobs()
+
+    with session_scope() as session:
+        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+        assert db_user.hosting_status == HostingStatus.maybe
+        assert db_user.meetup_status == MeetupStatus.open_to_meetup
+
+    assert get_history(user.id) == [
+        (HostingMeetupStatusSource.activeness_probe_expired, HostingStatus.maybe, MeetupStatus.open_to_meetup)
+    ]


### PR DESCRIPTION
Hosting and meetup statuses drive a lot of the platform — who appears in search, who gets activeness probes, who we may email — but we only ever store the current value, so every edit discards what came before. This adds an append-only `hosting_meetup_status_history` table so we can reconstruct what any user's statuses were at any point in time: whenever either status changes, a row snapshots both, tagged with why it changed (signup, a profile edit, the do-not-email setting, the unsubscribe link, or an activeness probe response or expiry). A user's statuses at a given moment are those of their newest row at or before it.

Nothing user-facing changes. A follow-up will backfill baseline rows for existing users; until then, an existing user's first status change is recorded with no preceding row, so that one transition's starting point isn't recoverable from the table alone.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
