### PR TITLE
Add user accounts as a moderation object type

### DIFF
--- a/app/backend/src/couchers/i18n/admin_locales/en.json
+++ b/app/backend/src/couchers/i18n/admin_locales/en.json
@@ -5,6 +5,7 @@
     "blog_title_too_long": "The blog post title is too long.",
     "cannot_edit_badge": "Admins cannot edit that badge.",
     "cannot_reinstate_and_set_stopped_date": "Cannot reinstate a volunteer and set a stopped date at the same time.",
+    "cannot_set_visibility_on_state": "This object type cannot be approved or hidden, its visibility is not decided by the moderation system.",
     "content_report_not_found": "Content report not found.",
     "deletereference_deprecated_use_ums": "DeleteReference is deprecated. Use the Unified Moderation System (UMS) to hide a reference.",
     "event_community_invite_already_decided": "That event community invite was already approved/denied.",

--- a/app/backend/src/couchers/jobs/handlers.py
+++ b/app/backend/src/couchers/jobs/handlers.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql import (
     func,
     literal,
     not_,
+    or_,
     union_all,
     update,
 )
@@ -103,6 +104,7 @@ from couchers.models import (
     User,
     UserBadge,
     Volunteer,
+    get_moderated_models,
 )
 from couchers.models.notifications import NotificationTopicAction
 from couchers.notifications.expo_api import get_expo_push_receipts
@@ -1416,11 +1418,16 @@ def check_database_consistency(payload: empty_pb2.Empty) -> None:
 
         # === Moderation System Consistency Checks ===
 
+        types_with_own_visibility = [
+            entry.object_type for entry in get_moderated_models().values() if entry.has_own_visibility_mechanism
+        ]
+
         # Check every ModerationState has at least one INITIAL_REVIEW queue item
         # Skip items with ID < 2000000 as they were created before this check was introduced
         states_without_initial_review = session.execute(
             select(ModerationState.id, ModerationState.object_type, ModerationState.object_id).where(
                 ModerationState.id >= 2000000,
+                ModerationState.object_type.not_in(types_with_own_visibility),
                 ~exists(
                     select(1)
                     .where(ModerationQueueItem.moderation_state_id == ModerationState.id)
@@ -1430,6 +1437,26 @@ def check_database_consistency(payload: empty_pb2.Empty) -> None:
         ).all()
         if states_without_initial_review:
             errors.append(f"ModerationStates without INITIAL_REVIEW queue item: {states_without_initial_review}")
+
+        # Check states with their own visibility mechanism have no visibility and no INITIAL_REVIEW item
+        states_with_spurious_visibility = session.execute(
+            select(ModerationState.id, ModerationState.object_type, ModerationState.object_id).where(
+                ModerationState.object_type.in_(types_with_own_visibility),
+                or_(
+                    ModerationState.visibility.is_not(None),
+                    exists(
+                        select(1)
+                        .where(ModerationQueueItem.moderation_state_id == ModerationState.id)
+                        .where(ModerationQueueItem.trigger == ModerationTrigger.initial_review)
+                    ),
+                ),
+            )
+        ).all()
+        if states_with_spurious_visibility:
+            errors.append(
+                f"ModerationStates with a visibility or INITIAL_REVIEW item for an object type that has its own "
+                f"visibility mechanism: {states_with_spurious_visibility}"
+            )
 
         # Check every ModerationState has a CREATE log entry
         # Skip items with ID < 2000000 as they were created before this check was introduced

--- a/app/backend/src/couchers/migrations/versions/0181_moderation_states_for_users.py
+++ b/app/backend/src/couchers/migrations/versions/0181_moderation_states_for_users.py
@@ -1,0 +1,128 @@
+"""Backend/moderation: moderation states for users
+
+Revision ID: 0181
+Revises: 0180
+Create Date: 2026-08-15 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0181"
+down_revision = "0180"
+branch_labels = None
+depends_on = None
+
+CONTENT_OBJECT_TYPES = (
+    "'host_request', 'group_chat', 'friend_request', 'event_occurrence', "
+    "'comment', 'reply', 'discussion', 'reference', 'public_trip'"
+)
+
+VISIBILITY_CHECK_NAME = "ck_moderation_states_check_visibility_null_iff_own_mechanism"
+
+# moderation_states, moderation_queue and moderation_log share one sequence, so backfilled IDs
+# have to be unique across all three. The sequence starts at 2_000_000 and supplies IDs for new
+# rows; backfills take the < 2_000_000 range.
+NEXT_BACKFILL_ID = """
+    (SELECT GREATEST(
+        COALESCE((SELECT MAX(id) FROM moderation_states WHERE id < 2000000), 0),
+        COALESCE((SELECT MAX(id) FROM moderation_queue WHERE id < 2000000), 0),
+        COALESCE((SELECT MAX(id) FROM moderation_log WHERE id < 2000000), 0)
+    ))
+"""
+
+
+def _recreate_object_type_enum(values: str) -> None:
+    # Rename/recreate rather than ADD VALUE, because ADD VALUE cannot be used in the same
+    # transaction as DML that references the new value.
+    op.execute("ALTER TYPE moderationobjecttype RENAME TO moderationobjecttype_old")
+    op.execute(f"CREATE TYPE moderationobjecttype AS ENUM ({values})")
+    op.execute("""
+        ALTER TABLE moderation_states
+        ALTER COLUMN object_type TYPE moderationobjecttype
+        USING object_type::text::moderationobjecttype
+    """)
+    op.execute("DROP TYPE moderationobjecttype_old")
+
+
+def upgrade() -> None:
+    _recreate_object_type_enum(f"{CONTENT_OBJECT_TYPES}, 'user'")
+
+    op.alter_column("moderation_states", "visibility", nullable=True)
+
+    op.add_column("users", sa.Column("moderation_state_id", sa.BigInteger(), nullable=True))
+
+    op.execute(f"""
+        INSERT INTO moderation_states (id, object_type, object_id, visibility)
+        SELECT
+            {NEXT_BACKFILL_ID} + ROW_NUMBER() OVER (ORDER BY id),
+            'user',
+            id,
+            NULL
+        FROM users
+    """)
+    op.execute("""
+        UPDATE users
+        SET moderation_state_id = moderation_states.id
+        FROM moderation_states
+        WHERE moderation_states.object_type = 'user'
+        AND moderation_states.object_id = users.id
+    """)
+    op.execute(f"""
+        INSERT INTO moderation_log (id, moderation_state_id, action, moderator_user_id, new_visibility, reason)
+        SELECT
+            {NEXT_BACKFILL_ID} + ROW_NUMBER() OVER (ORDER BY id),
+            id,
+            'create',
+            object_id,
+            NULL,
+            'Migration: existing user'
+        FROM moderation_states
+        WHERE object_type = 'user'
+    """)
+
+    op.alter_column("users", "moderation_state_id", nullable=False)
+    op.create_index(op.f("ix_users_moderation_state_id"), "users", ["moderation_state_id"], unique=False)
+    op.create_foreign_key(
+        op.f("fk_users_moderation_state_id_moderation_states"),
+        "users",
+        "moderation_states",
+        ["moderation_state_id"],
+        ["id"],
+    )
+
+    op.create_check_constraint(
+        op.f(VISIBILITY_CHECK_NAME),
+        "moderation_states",
+        "(object_type = 'user') = (visibility IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f(VISIBILITY_CHECK_NAME), "moderation_states", type_="check")
+
+    op.drop_constraint(op.f("fk_users_moderation_state_id_moderation_states"), "users", type_="foreignkey")
+    op.drop_index(op.f("ix_users_moderation_state_id"), table_name="users")
+    op.drop_column("users", "moderation_state_id")
+
+    # moderation_log.queue_item_id has to be cleared before the queue items it points at can go
+    op.execute("""
+        UPDATE moderation_log
+        SET queue_item_id = NULL
+        WHERE moderation_state_id IN (SELECT id FROM moderation_states WHERE object_type = 'user')
+    """)
+    op.execute("""
+        DELETE FROM moderation_queue
+        WHERE moderation_state_id IN (SELECT id FROM moderation_states WHERE object_type = 'user')
+    """)
+    op.execute("""
+        DELETE FROM moderation_log
+        WHERE moderation_state_id IN (SELECT id FROM moderation_states WHERE object_type = 'user')
+    """)
+    op.execute("DELETE FROM moderation_states WHERE object_type = 'user'")
+
+    op.alter_column("moderation_states", "visibility", nullable=False)
+
+    _recreate_object_type_enum(CONTENT_OBJECT_TYPES)

--- a/app/backend/src/couchers/models/conversations.py
+++ b/app/backend/src/couchers/models/conversations.py
@@ -40,6 +40,7 @@ class GroupChat(Base, kw_only=True):
     __tablename__ = "group_chats"
     __moderation_author_column__ = "creator_id"
     __moderation_object_type__ = ModerationObjectType.group_chat
+    __moderation_has_own_visibility_mechanism__ = False
 
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
 

--- a/app/backend/src/couchers/models/discussions.py
+++ b/app/backend/src/couchers/models/discussions.py
@@ -20,6 +20,7 @@ class Discussion(Base, kw_only=True):
     __tablename__ = "discussions"
     __moderation_author_column__ = "creator_user_id"
     __moderation_object_type__ = ModerationObjectType.discussion
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(
         BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value(), init=False
@@ -90,6 +91,7 @@ class Comment(Base, kw_only=True):
     __tablename__ = "comments"
     __moderation_author_column__ = "author_user_id"
     __moderation_object_type__ = ModerationObjectType.comment
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
@@ -112,6 +114,7 @@ class Reply(Base, kw_only=True):
     __tablename__ = "replies"
     __moderation_author_column__ = "author_user_id"
     __moderation_object_type__ = ModerationObjectType.reply
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 

--- a/app/backend/src/couchers/models/events.py
+++ b/app/backend/src/couchers/models/events.py
@@ -114,6 +114,7 @@ class EventOccurrence(Base, kw_only=True):
     __tablename__ = "event_occurrences"
     __moderation_author_column__ = "creator_user_id"
     __moderation_object_type__ = ModerationObjectType.event_occurrence
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(
         BigInteger, communities_seq, primary_key=True, server_default=communities_seq.next_value(), init=False

--- a/app/backend/src/couchers/models/host_requests.py
+++ b/app/backend/src/couchers/models/host_requests.py
@@ -64,6 +64,7 @@ class HostRequest(Base, kw_only=True):
     __tablename__ = "host_requests"
     __moderation_author_column__ = "initiator_user_id"
     __moderation_object_type__ = ModerationObjectType.host_request
+    __moderation_has_own_visibility_mechanism__ = False
 
     conversation_id: Mapped[int] = mapped_column("id", ForeignKey("conversations.id"), primary_key=True)
     initiator_user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -11,7 +11,18 @@ from datetime import datetime
 from functools import cache
 from typing import TYPE_CHECKING, Protocol
 
-from sqlalchemy import BigInteger, ColumnElement, DateTime, Enum, ForeignKey, Index, Integer, String, func
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    ColumnElement,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers.models.base import Base, moderation_seq
@@ -75,6 +86,7 @@ class ModerationObjectType(enum.Enum):
     discussion = enum.auto()
     reference = enum.auto()
     public_trip = enum.auto()
+    user = enum.auto()
 
 
 class ModerationState(Base, kw_only=True):
@@ -95,7 +107,7 @@ class ModerationState(Base, kw_only=True):
     object_type: Mapped[ModerationObjectType] = mapped_column(Enum(ModerationObjectType))
     object_id: Mapped[int] = mapped_column(BigInteger)
 
-    visibility: Mapped[ModerationVisibility] = mapped_column(Enum(ModerationVisibility))
+    visibility: Mapped[ModerationVisibility | None] = mapped_column(Enum(ModerationVisibility))
 
     created: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), init=False)
     updated: Mapped[datetime] = mapped_column(
@@ -109,6 +121,10 @@ class ModerationState(Base, kw_only=True):
         Index("ix_moderation_states_id_visibility", id, visibility),
         # Fast filtering by object type and visibility
         Index("ix_moderation_states_type_visibility", object_type, visibility),
+        CheckConstraint(
+            "(object_type = 'user') = (visibility IS NULL)",
+            name="check_visibility_null_iff_own_mechanism",
+        ),
     )
 
     def __repr__(self) -> str:
@@ -205,6 +221,7 @@ class ModeratedContent(Protocol):
 
     __moderation_object_type__: ModerationObjectType
     __moderation_author_column__: str
+    __moderation_has_own_visibility_mechanism__: bool
 
 
 @dataclass(frozen=True)
@@ -216,6 +233,8 @@ class ModeratedModel:
     author_column: ColumnElement[int]
     object_id_column: ColumnElement[int]
     moderation_state_id_column: ColumnElement[int]
+    # Visibility not determined by the moderation state, they have some other visibility logic
+    has_own_visibility_mechanism: bool
 
 
 @cache
@@ -242,5 +261,6 @@ def get_moderated_models() -> dict[ModerationObjectType, ModeratedModel]:
             author_column=mapper.columns[model.__moderation_author_column__],
             object_id_column=mapper.primary_key[0],
             moderation_state_id_column=mapper.columns["moderation_state_id"],
+            has_own_visibility_mechanism=model.__moderation_has_own_visibility_mechanism__,
         )
     return models

--- a/app/backend/src/couchers/models/public_trips.py
+++ b/app/backend/src/couchers/models/public_trips.py
@@ -28,6 +28,7 @@ class PublicTrip(Base, kw_only=True):
     __tablename__ = "public_trips"
     __moderation_author_column__ = "user_id"
     __moderation_object_type__ = ModerationObjectType.public_trip
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -75,6 +75,7 @@ class FriendRelationship(Base, kw_only=True):
     __tablename__ = "friend_relationships"
     __moderation_author_column__ = "from_user_id"
     __moderation_object_type__ = ModerationObjectType.friend_request
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
@@ -431,6 +432,7 @@ class Reference(Base, kw_only=True):
     __tablename__ = "references"
     __moderation_author_column__ = "from_user_id"
     __moderation_object_type__ = ModerationObjectType.reference
+    __moderation_has_own_visibility_mechanism__ = False
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
     # timezone should always be UTC

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -42,6 +42,7 @@ from couchers.constants import (
 from couchers.models.activeness_probe import ActivenessProbe
 from couchers.models.base import Base, Geom
 from couchers.models.mod_note import ModNote
+from couchers.models.moderation import ModerationObjectType, ModerationState
 from couchers.models.static import Language, Region, TimezoneArea
 from couchers.utils import get_coordinates, last_active_coarsen, now
 
@@ -104,6 +105,9 @@ class User(Base, kw_only=True):
     """
 
     __tablename__ = "users"
+    __moderation_author_column__ = "id"
+    __moderation_object_type__ = ModerationObjectType.user
+    __moderation_has_own_visibility_mechanism__ = True
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, init=False)
 
@@ -192,6 +196,9 @@ class User(Base, kw_only=True):
     banned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     shadowed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+
+    moderation_state_id: Mapped[int] = mapped_column(ForeignKey("moderation_states.id"), index=True)
+
     is_superuser: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
     is_editor: Mapped[bool] = mapped_column(Boolean, server_default=expression.false(), init=False)
 
@@ -367,6 +374,8 @@ class User(Base, kw_only=True):
     )
 
     public_trips: Mapped[list[PublicTrip]] = relationship(init=False, back_populates="user")
+
+    moderation_state: Mapped[ModerationState] = relationship(init=False)
 
     __table_args__ = (
         # Verified phone numbers should be unique

--- a/app/backend/src/couchers/moderation/utils.py
+++ b/app/backend/src/couchers/moderation/utils.py
@@ -15,6 +15,7 @@ from couchers.models import (
     ModerationState,
     ModerationTrigger,
     ModerationVisibility,
+    get_moderated_models,
 )
 
 
@@ -22,14 +23,18 @@ def create_moderation(
     session: Session,
     object_type: ModerationObjectType,
     object_id: int | Callable[[int], int],
-    creator_user_id: int,
+    # None for objects that are their own creator, whose id isn't known until the callback has run
+    creator_user_id: int | None = None,
 ) -> ModerationState:
+    has_own_visibility_mechanism = get_moderated_models()[object_type].has_own_visibility_mechanism
+    visibility = None if has_own_visibility_mechanism else ModerationVisibility.shadowed
+
     # Handle callback pattern for circular dependencies
     if callable(object_id):
         moderation_state = ModerationState(
             object_type=object_type,
             object_id=0,  # Placeholder
-            visibility=ModerationVisibility.shadowed,
+            visibility=visibility,
         )
         session.add(moderation_state)
         session.flush()
@@ -38,10 +43,11 @@ def create_moderation(
         actual_object_id = object_id(moderation_state.id)
         moderation_state.object_id = actual_object_id
     else:
+        actual_object_id = object_id
         moderation_state = ModerationState(
             object_type=object_type,
             object_id=object_id,
-            visibility=ModerationVisibility.shadowed,
+            visibility=visibility,
         )
         session.add(moderation_state)
         session.flush()
@@ -50,22 +56,24 @@ def create_moderation(
         ModerationLog(
             moderation_state_id=moderation_state.id,
             action=ModerationAction.create,
-            moderator_user_id=creator_user_id,
-            new_visibility=ModerationVisibility.shadowed,
+            moderator_user_id=creator_user_id if creator_user_id is not None else actual_object_id,
+            new_visibility=visibility,
             reason="Object created.",
         )
     )
 
-    session.add(
-        ModerationQueueItem(
-            moderation_state_id=moderation_state.id,
-            trigger=ModerationTrigger.initial_review,
-            reason="Object created.",
+    if not has_own_visibility_mechanism:
+        session.add(
+            ModerationQueueItem(
+                moderation_state_id=moderation_state.id,
+                trigger=ModerationTrigger.initial_review,
+                reason="Object created.",
+            )
         )
-    )
-    session.flush()
+        observe_moderation_queue_item_created(ModerationTrigger.initial_review, object_type)
 
     observe_moderation_action(ModerationAction.create, object_type)
-    observe_moderation_queue_item_created(ModerationTrigger.initial_review, object_type)
+
+    session.flush()
 
     return moderation_state

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -70,7 +70,7 @@ from couchers.servicers.events import generate_event_delete_notifications
 from couchers.servicers.moderation import bulk_set_user_content_visibility
 from couchers.servicers.threads import unpack_thread_id
 from couchers.sql import to_bool, username_or_email_or_id
-from couchers.utils import Timestamp_from_datetime, date_to_api, now, parse_date, to_aware_datetime
+from couchers.utils import Timestamp_from_datetime, date_to_api, not_none, now, parse_date, to_aware_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -979,7 +979,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
                 status=rel.status.name if rel.status else "",
                 time_sent=Timestamp_from_datetime(rel.time_sent),
                 time_responded=Timestamp_from_datetime(rel.time_responded) if rel.time_responded else None,
-                moderation_visibility=rel.moderation_state.visibility.name,
+                moderation_visibility=not_none(rel.moderation_state.visibility).name,
             )
 
         sent = (

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -34,6 +34,7 @@ from couchers.models import (
     AntiBotLog,
     ContributorForm,
     InviteCode,
+    ModerationObjectType,
     NonvisibleUserAccessType,
     PasswordResetToken,
     PhotoGallery,
@@ -43,6 +44,7 @@ from couchers.models import (
 )
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.uploads import get_avatar_upload
+from couchers.moderation.utils import create_moderation
 from couchers.notifications.notify import notify
 from couchers.notifications.quick_links import decode_quick_link
 from couchers.proto import auth_pb2, auth_pb2_grpc, notification_data_pb2
@@ -352,30 +354,43 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
         # finish the signup if done
         if flow.is_completed:
-            user = User(
-                name=flow.name,
-                email=flow.email,
-                username=not_none(flow.username),
-                hashed_password=not_none(flow.hashed_password),
-                birthdate=not_none(flow.birthdate),
-                gender=not_none(flow.gender),
-                hosting_status=not_none(flow.hosting_status),
-                city=not_none(flow.city),
-                geom=is_geom(flow.geom),
-                geom_radius=not_none(flow.geom_radius),
-                accepted_tos=not_none(flow.accepted_tos),
-                last_onboarding_email_sent=func.now(),
-                invite_code_id=flow.invite_code_id,
-                heard_about_couchers=flow.heard_about_couchers,
-                signup_motivations=flow.signup_motivations if flow.filled_motivations else None,
+            user: User | None = None
+
+            def create_user(moderation_state_id: int) -> int:
+                nonlocal user
+                user = User(
+                    name=flow.name,
+                    email=flow.email,
+                    username=not_none(flow.username),
+                    hashed_password=not_none(flow.hashed_password),
+                    birthdate=not_none(flow.birthdate),
+                    gender=not_none(flow.gender),
+                    hosting_status=not_none(flow.hosting_status),
+                    city=not_none(flow.city),
+                    geom=is_geom(flow.geom),
+                    geom_radius=not_none(flow.geom_radius),
+                    accepted_tos=not_none(flow.accepted_tos),
+                    last_onboarding_email_sent=func.now(),
+                    invite_code_id=flow.invite_code_id,
+                    heard_about_couchers=flow.heard_about_couchers,
+                    signup_motivations=flow.signup_motivations if flow.filled_motivations else None,
+                    moderation_state_id=moderation_state_id,
+                )
+
+                user.accepted_community_guidelines = flow.accepted_community_guidelines
+                user.onboarding_emails_sent = 1
+                user.opt_out_of_newsletter = not_none(flow.opt_out_of_newsletter)
+
+                session.add(user)
+                session.flush()
+                return user.id
+
+            create_moderation(
+                session=session,
+                object_type=ModerationObjectType.user,
+                object_id=create_user,
             )
-
-            user.accepted_community_guidelines = flow.accepted_community_guidelines
-            user.onboarding_emails_sent = 1
-            user.opt_out_of_newsletter = not_none(flow.opt_out_of_newsletter)
-
-            session.add(user)
-            session.flush()
+            assert user is not None
 
             # Create a profile gallery for the user
             profile_gallery = PhotoGallery(owner_user_id=user.id)

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -41,7 +41,7 @@ from couchers.models import (
 )
 from couchers.proto import moderation_pb2, moderation_pb2_grpc
 from couchers.proto.internal import jobs_pb2
-from couchers.utils import Timestamp_from_datetime, now
+from couchers.utils import Timestamp_from_datetime, not_none, now
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +113,7 @@ moderationobjecttype2api = {
     ModerationObjectType.discussion: moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION,
     ModerationObjectType.reference: moderation_pb2.MODERATION_OBJECT_TYPE_REFERENCE,
     ModerationObjectType.public_trip: moderation_pb2.MODERATION_OBJECT_TYPE_PUBLIC_TRIP,
+    ModerationObjectType.user: moderation_pb2.MODERATION_OBJECT_TYPE_USER,
 }
 
 moderationobjecttype2sql = {
@@ -126,6 +127,7 @@ moderationobjecttype2sql = {
     moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION: ModerationObjectType.discussion,
     moderation_pb2.MODERATION_OBJECT_TYPE_REFERENCE: ModerationObjectType.reference,
     moderation_pb2.MODERATION_OBJECT_TYPE_PUBLIC_TRIP: ModerationObjectType.public_trip,
+    moderation_pb2.MODERATION_OBJECT_TYPE_USER: ModerationObjectType.user,
 }
 
 
@@ -159,6 +161,8 @@ def bulk_set_user_content_visibility(
 
     author_exists_clauses = []
     for entry in get_moderated_models().values():
+        if entry.has_own_visibility_mechanism:
+            continue
         author_exists_clauses.append(
             exists().where(and_(entry.moderation_state_id_column == ModerationState.id, entry.author_column == user.id))
         )
@@ -172,7 +176,7 @@ def bulk_set_user_content_visibility(
         if moderation_state.visibility == new_visibility:
             continue
 
-        old_visibility = moderation_state.visibility
+        old_visibility = not_none(moderation_state.visibility)
         moderation_state.visibility = new_visibility
         moderation_state.updated = now()
 
@@ -299,6 +303,10 @@ def moderation_state_to_pb(state: ModerationState, session: Session) -> moderati
         author_user_id, content = session.execute(
             select(PublicTrip.user_id, PublicTrip.description).where(PublicTrip.id == object_id)
         ).one()
+    elif object_type == ModerationObjectType.user:
+        author_user_id = object_id
+        username = session.execute(select(User.username).where(User.id == object_id)).scalar_one()
+        content = f"@{username} / {object_id}"
     else:
         raise ValueError(f"Unsupported moderation object type: {object_type}")
 
@@ -517,11 +525,14 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         object_type = moderation_state.object_type
 
         if action in (ModerationAction.approve, ModerationAction.hide):
+            if get_moderated_models()[object_type].has_own_visibility_mechanism:
+                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:cannot_set_visibility_on_state")
+
             new_visibility = moderationvisibility2sql[request.visibility]
             if new_visibility is None:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:visibility_must_be_specified")
 
-            old_visibility = moderation_state.visibility
+            old_visibility = not_none(moderation_state.visibility)
             moderation_state.visibility = new_visibility
             moderation_state.updated = now()
 

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -150,6 +150,7 @@ def where_moderated_content_visible_to_user_column[T: tuple[Any, ...]](
     is_list_operation: bool = False,
 ) -> Select[T]:
     entry = get_moderated_models()[table.__moderation_object_type__]
+    assert not entry.has_own_visibility_mechanism, f"{table.__name__} visibility is not decided by the UMS"
     aliased_mod_state = aliased(ModerationState)
     conditions = [aliased_mod_state.visibility == ModerationVisibility.visible]
 
@@ -177,6 +178,7 @@ def where_moderated_content_visible[T: tuple[Any, ...]](
     is_list_operation: bool = False,
 ) -> Select[T]:
     entry = get_moderated_models()[table.__moderation_object_type__]
+    assert not entry.has_own_visibility_mechanism, f"{table.__name__} visibility is not decided by the UMS"
     aliased_mod_state = aliased(ModerationState)
     conditions = [aliased_mod_state.visibility == ModerationVisibility.visible]
 
@@ -219,6 +221,8 @@ def moderation_state_column_visible(
     shadowed_conditions: list[ColumnElement[bool]] = []
     if context.is_logged_in():
         for entry in get_moderated_models().values():
+            if entry.has_own_visibility_mechanism:
+                continue
             shadowed_conditions.append(
                 and_(
                     aliased_mod_state.object_type == entry.object_type,

--- a/app/backend/src/dummy_data.py
+++ b/app/backend/src/dummy_data.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from dateutil import parser
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 
 from couchers.constants import GUIDELINES_VERSION, TOS_VERSION
@@ -54,6 +55,50 @@ logger = logging.getLogger(__name__)
 SRC_DIR = os.path.dirname(__file__)
 
 
+def _add_dummy_user(session: Session, user: Any) -> User:
+    new_user: User | None = None
+
+    def create_user(moderation_state_id: int) -> int:
+        nonlocal new_user
+        new_user = User(
+            username=user["username"],
+            email=user["email"],
+            hashed_password=hash_password(f"{user['name']}'s password"),
+            name=user["name"],
+            city=user["location"]["city"],
+            geom=create_coordinate(user["location"]["lat"], user["location"]["lng"]),
+            geom_radius=user["location"]["radius"],
+            community_standing=user["community_standing"],
+            birthdate=date(
+                year=user["birthdate"]["year"], month=user["birthdate"]["month"], day=user["birthdate"]["day"]
+            ),
+            gender=user["gender"],
+            occupation=user["occupation"],
+            about_me=user["about_me"],
+            about_place=user["about_place"],
+            hosting_status=hostingstatus2sql[  # type: ignore[arg-type]
+                HostingStatus.Value(user["hosting_status"] if "hosting_status" in user else "HOSTING_STATUS_CANT_HOST")
+            ],
+            accepted_tos=TOS_VERSION,
+            moderation_state_id=moderation_state_id,
+        )
+        new_user.accepted_community_guidelines = GUIDELINES_VERSION
+        new_user.is_superuser = user.get("is_superuser", False)
+        new_user.is_editor = user.get("is_editor", user.get("is_superuser", False))
+
+        session.add(new_user)
+        session.flush()
+        return new_user.id
+
+    create_moderation(
+        session=session,
+        object_type=ModerationObjectType.user,
+        object_id=create_user,
+    )
+    assert new_user is not None
+    return new_user
+
+
 def add_dummy_users() -> None:
     logger.info("Adding dummy users")
     with session_scope() as session:
@@ -65,35 +110,7 @@ def add_dummy_users() -> None:
             data = json.loads(f.read())
 
         for user in data["users"]:
-            new_user = User(
-                username=user["username"],
-                email=user["email"],
-                hashed_password=hash_password(f"{user['name']}'s password"),
-                name=user["name"],
-                city=user["location"]["city"],
-                geom=create_coordinate(user["location"]["lat"], user["location"]["lng"]),
-                geom_radius=user["location"]["radius"],
-                community_standing=user["community_standing"],
-                birthdate=date(
-                    year=user["birthdate"]["year"], month=user["birthdate"]["month"], day=user["birthdate"]["day"]
-                ),
-                gender=user["gender"],
-                occupation=user["occupation"],
-                about_me=user["about_me"],
-                about_place=user["about_place"],
-                hosting_status=hostingstatus2sql[  # type: ignore[arg-type]
-                    HostingStatus.Value(
-                        user["hosting_status"] if "hosting_status" in user else "HOSTING_STATUS_CANT_HOST"
-                    )
-                ],
-                accepted_tos=TOS_VERSION,
-            )
-            new_user.accepted_community_guidelines = GUIDELINES_VERSION
-            new_user.is_superuser = user.get("is_superuser", False)
-            new_user.is_editor = user.get("is_editor", user.get("is_superuser", False))
-
-            session.add(new_user)
-            session.flush()
+            new_user = _add_dummy_user(session, user)
 
             # Create profile gallery for the user (same as in signup flow)
             profile_gallery = PhotoGallery(owner_user_id=new_user.id)

--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -38,6 +38,7 @@ from couchers.models import (
     UserSession,
     Volunteer,
 )
+from couchers.moderation.utils import create_moderation
 from couchers.servicers.auth import create_session
 from couchers.utils import create_coordinate, now
 from tests.fixtures.sessions import _MockCouchersContext
@@ -165,10 +166,12 @@ def autocommit_engine(url: str):
     engine.dispose()
 
 
-def make_user(**kwargs: Any) -> User:
+def make_user(moderation_state_id: int = 0, **kwargs: Any) -> User:
+    """Build an unsaved user. Pass a real moderation_state_id if you intend to save it."""
     username = "test_user_" + random_hex(16)
 
     user = User(
+        moderation_state_id=moderation_state_id,
         username=username,
         email=f"{username}@dev.couchers.org",
         hashed_password=b"$argon2id$v=19$m=65536,t=2,p=1$4cjGg1bRaZ10k+7XbIDmFg$tZG7JaLrkfyfO7cS233ocq7P8rf3znXR7SAfUt34kJg",
@@ -223,10 +226,21 @@ def generate_user(
     Use this most of the time
     """
     with session_scope() as session:
-        user = make_user(**kwargs)
+        user: User | None = None
 
-        session.add(user)
-        session.flush()
+        def create_user(moderation_state_id: int) -> int:
+            nonlocal user
+            user = make_user(moderation_state_id=moderation_state_id, **kwargs)
+            session.add(user)
+            session.flush()
+            return user.id
+
+        create_moderation(
+            session=session,
+            object_type=ModerationObjectType.user,
+            object_id=create_user,
+        )
+        assert user is not None
 
         # Create a profile gallery for the user and link it
         profile_gallery = PhotoGallery(owner_user_id=user.id)

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -15,6 +15,8 @@ from couchers.models import (
     ContributeOption,
     ContributorForm,
     LoginToken,
+    ModerationObjectType,
+    ModerationState,
     NonvisibleUserAccess,
     NonvisibleUserAccessType,
     NonvisibleUserState,
@@ -375,6 +377,19 @@ def _quick_signup() -> int:
 
 def test_signup(db):
     _quick_signup()
+
+
+def test_signup_creates_user_moderation_state(db):
+    user_id = _quick_signup()
+
+    with session_scope() as session:
+        state = session.execute(
+            select(ModerationState)
+            .where(ModerationState.object_type == ModerationObjectType.user)
+            .where(ModerationState.object_id == user_id)
+        ).scalar_one()
+        assert state.visibility is None
+        assert session.execute(select(User.moderation_state_id).where(User.id == user_id)).scalar_one() == state.id
 
 
 def test_basic_login(db):

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import grpc
 import pytest
 from google.protobuf import empty_pb2
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql import select
 
 from couchers.config import config
@@ -28,6 +29,7 @@ from couchers.models import (
     ModerationTrigger,
     ModerationVisibility,
     User,
+    get_moderated_models,
 )
 from couchers.moderation.utils import create_moderation
 from couchers.proto import (
@@ -3379,12 +3381,22 @@ def test_SetUserContentVisibility_from_visibility_unspecified_rejected(db):
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
 
 
-def test_ListModerationStates_empty(db):
+def _content_state_ids(res: moderation_pb2.ListModerationStatesRes) -> list[int]:
+    """Every user has a moderation state, so listings mix them in with the content states."""
+    return [
+        s.moderation_state_id
+        for s in res.moderation_states
+        if s.object_type != moderation_pb2.MODERATION_OBJECT_TYPE_USER
+    ]
+
+
+def test_ListModerationStates_with_no_content(db):
     super_user, super_token = generate_user(is_superuser=True)
 
     with real_moderation_session(super_token) as api:
         res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq())
-    assert len(res.moderation_states) == 0
+    assert [s.object_id for s in res.moderation_states] == [super_user.id]
+    assert _content_state_ids(res) == []
     assert res.next_page_token == ""
 
 
@@ -3399,10 +3411,10 @@ def test_ListModerationStates_returns_states_chronologically(db):
 
     with real_moderation_session(super_token) as api:
         res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq())
-        assert [s.moderation_state_id for s in res.moderation_states] == [state1_id, state2_id, state3_id]
+        assert _content_state_ids(res) == [state1_id, state2_id, state3_id]
 
         res_newest = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(newest_first=True))
-        assert [s.moderation_state_id for s in res_newest.moderation_states] == [state3_id, state2_id, state1_id]
+        assert _content_state_ids(res_newest) == [state3_id, state2_id, state1_id]
 
 
 def test_ListModerationStates_filter_by_author(db):
@@ -3417,10 +3429,12 @@ def test_ListModerationStates_filter_by_author(db):
 
     with real_moderation_session(super_token) as api:
         res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(author_user_id=surfer1.id))
-        assert {s.moderation_state_id for s in res.moderation_states} == {state1_id, state3_id}
+        assert set(_content_state_ids(res)) == {state1_id, state3_id}
+        user_states = [s for s in res.moderation_states if s.object_type == moderation_pb2.MODERATION_OBJECT_TYPE_USER]
+        assert [s.object_id for s in user_states] == [surfer1.id]
 
         res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(author_user_id=surfer2.id))
-        assert [s.moderation_state_id for s in res.moderation_states] == [state2_id]
+        assert _content_state_ids(res) == [state2_id]
 
 
 def test_ListModerationStates_pagination(db):
@@ -3428,15 +3442,223 @@ def test_ListModerationStates_pagination(db):
     surfer, surfer_token = generate_user()
     host, _ = generate_user()
 
-    state_ids = [create_test_host_request_with_moderation(surfer_token, host.id) for _ in range(3)]
+    for _ in range(3):
+        create_test_host_request_with_moderation(surfer_token, host.id)
 
     with real_moderation_session(super_token) as api:
-        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(page_size=2))
-        assert [s.moderation_state_id for s in res.moderation_states] == state_ids[:2]
-        assert res.next_page_token != ""
+        # 3 users plus 3 host requests
+        all_ids = [
+            s.moderation_state_id
+            for s in api.ListModerationStates(moderation_pb2.ListModerationStatesReq()).moderation_states
+        ]
+        assert len(all_ids) == 6
 
-        res2 = api.ListModerationStates(
-            moderation_pb2.ListModerationStatesReq(page_size=2, page_token=res.next_page_token)
+        paged_ids = []
+        page_token = ""
+        while True:
+            res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(page_size=2, page_token=page_token))
+            assert len(res.moderation_states) == 2
+            paged_ids += [s.moderation_state_id for s in res.moderation_states]
+            page_token = res.next_page_token
+            if not page_token:
+                break
+
+        assert paged_ids == all_ids
+
+
+# ============================================================================
+# Tests for user account moderation states
+# ============================================================================
+
+
+def test_user_moderation_state_created_with_the_account(db):
+    user, _ = generate_user()
+
+    with session_scope() as session:
+        state = session.execute(
+            select(ModerationState)
+            .where(ModerationState.object_type == ModerationObjectType.user)
+            .where(ModerationState.object_id == user.id)
+        ).scalar_one()
+
+        assert state.visibility is None
+        assert session.execute(select(User.moderation_state_id).where(User.id == user.id)).scalar_one() == state.id
+
+        log_entries = (
+            session.execute(select(ModerationLog).where(ModerationLog.moderation_state_id == state.id)).scalars().all()
         )
-        assert [s.moderation_state_id for s in res2.moderation_states] == [state_ids[2]]
-        assert res2.next_page_token == ""
+        assert len(log_entries) == 1
+        assert log_entries[0].action == ModerationAction.create
+        assert log_entries[0].moderator_user_id == user.id
+
+        queue_items = (
+            session.execute(select(ModerationQueueItem).where(ModerationQueueItem.moderation_state_id == state.id))
+            .scalars()
+            .all()
+        )
+        assert queue_items == []
+
+
+def test_GetModerationState_for_user(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    user, _ = generate_user()
+
+    with real_moderation_session(super_token) as api:
+        state = api.GetModerationState(
+            moderation_pb2.GetModerationStateReq(
+                object_type=moderation_pb2.MODERATION_OBJECT_TYPE_USER,
+                object_id=user.id,
+            )
+        ).moderation_state
+        assert state.object_type == moderation_pb2.MODERATION_OBJECT_TYPE_USER
+        assert state.object_id == user.id
+        assert state.author_user_id == user.id
+        assert state.author.user_id == user.id
+        assert state.content == f"@{user.username} / {user.id}"
+        assert state.visibility == moderation_pb2.MODERATION_VISIBILITY_UNSPECIFIED
+
+
+def test_GetModerationState_for_nonexistent_user(db):
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_moderation_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.GetModerationState(
+                moderation_pb2.GetModerationStateReq(
+                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_USER,
+                    object_id=999999,
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+
+def test_flag_user_shows_up_in_queue_and_author_filters(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+    other, _ = generate_user()
+
+    content_state_id = create_test_host_request_with_moderation(surfer_token, host.id)
+
+    with real_moderation_session(super_token) as api:
+        user_state_id = api.GetModerationState(
+            moderation_pb2.GetModerationStateReq(
+                object_type=moderation_pb2.MODERATION_OBJECT_TYPE_USER,
+                object_id=surfer.id,
+            )
+        ).moderation_state.moderation_state_id
+
+        api.ModerateContent(
+            moderation_pb2.ModerateContentReq(
+                moderation_state_id=user_state_id,
+                action=moderation_pb2.MODERATION_ACTION_FLAG,
+                trigger=moderation_pb2.MODERATION_TRIGGER_USER_FLAG,
+                reason="Reported for spamming hosts",
+            )
+        )
+
+        res = api.GetModerationQueue(moderation_pb2.GetModerationQueueReq(item_author_user_id=surfer.id))
+        assert {item.moderation_state_id for item in res.queue_items} == {content_state_id, user_state_id}
+        user_item = next(item for item in res.queue_items if item.moderation_state_id == user_state_id)
+        assert user_item.trigger == moderation_pb2.MODERATION_TRIGGER_USER_FLAG
+        assert user_item.reason == "Reported for spamming hosts"
+        assert user_item.moderation_state.author.user_id == surfer.id
+
+        res = api.GetModerationQueue(moderation_pb2.GetModerationQueueReq(item_author_user_id=other.id))
+        assert len(res.queue_items) == 0
+
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(author_user_id=surfer.id))
+        assert {s.moderation_state_id for s in res.moderation_states} == {content_state_id, user_state_id}
+
+        res = api.ListModerationStates(moderation_pb2.ListModerationStatesReq(author_user_id=other.id))
+        assert [s.object_id for s in res.moderation_states] == [other.id]
+
+
+@pytest.mark.parametrize("action", [moderation_pb2.MODERATION_ACTION_APPROVE, moderation_pb2.MODERATION_ACTION_HIDE])
+def test_ModerateContent_cannot_set_visibility_on_user_state(db, action):
+    super_user, super_token = generate_user(is_superuser=True)
+    user, _ = generate_user()
+
+    with real_moderation_session(super_token) as api:
+        user_state_id = api.GetModerationState(
+            moderation_pb2.GetModerationStateReq(
+                object_type=moderation_pb2.MODERATION_OBJECT_TYPE_USER,
+                object_id=user.id,
+            )
+        ).moderation_state.moderation_state_id
+
+        with pytest.raises(grpc.RpcError) as e:
+            api.ModerateContent(
+                moderation_pb2.ModerateContentReq(
+                    moderation_state_id=user_state_id,
+                    action=action,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+    with session_scope() as session:
+        state = session.execute(select(ModerationState).where(ModerationState.id == user_state_id)).scalar_one()
+        assert state.visibility is None
+
+
+def test_SetUserContentVisibility_leaves_user_state_alone(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    surfer, surfer_token = generate_user()
+    host, _ = generate_user()
+
+    content_state_id = create_test_host_request_with_moderation(surfer_token, host.id)
+
+    with real_moderation_session(super_token) as api:
+        user_state_id = api.GetModerationState(
+            moderation_pb2.GetModerationStateReq(
+                object_type=moderation_pb2.MODERATION_OBJECT_TYPE_USER,
+                object_id=surfer.id,
+            )
+        ).moderation_state.moderation_state_id
+
+        res = api.SetUserContentVisibility(
+            moderation_pb2.SetUserContentVisibilityReq(
+                user_id=surfer.id,
+                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            )
+        )
+        assert res.updated_count == 1
+
+    with session_scope() as session:
+        content_state = session.execute(
+            select(ModerationState).where(ModerationState.id == content_state_id)
+        ).scalar_one()
+        assert content_state.visibility == ModerationVisibility.hidden
+
+        user_state = session.execute(select(ModerationState).where(ModerationState.id == user_state_id)).scalar_one()
+        assert user_state.visibility is None
+
+
+# ============================================================================
+# Tests for the moderation model metadata
+# ============================================================================
+
+
+def test_every_object_type_has_a_model():
+    """A type in the enum with no model behind it is accepted everywhere and understood nowhere."""
+    assert set(get_moderated_models()) == set(ModerationObjectType)
+
+
+@pytest.mark.parametrize("object_type", list(ModerationObjectType))
+def test_visibility_check_constraint_matches_the_models(db, object_type):
+    """The check constraint spells out the types with their own visibility mechanism; this makes sure it agrees with the models."""
+    has_own_visibility_mechanism = get_moderated_models()[object_type].has_own_visibility_mechanism
+
+    def add_state(object_id: int, visibility: ModerationVisibility | None) -> None:
+        with session_scope() as session:
+            session.add(ModerationState(object_type=object_type, object_id=object_id, visibility=visibility))
+
+    if has_own_visibility_mechanism:
+        add_state(1, None)
+        with pytest.raises(IntegrityError):
+            add_state(2, ModerationVisibility.visible)
+    else:
+        add_state(1, ModerationVisibility.visible)
+        with pytest.raises(IntegrityError):
+            add_state(2, None)

--- a/app/proto/moderation.proto
+++ b/app/proto/moderation.proto
@@ -66,6 +66,8 @@ enum ModerationObjectType {
   MODERATION_OBJECT_TYPE_DISCUSSION = 7;
   MODERATION_OBJECT_TYPE_REFERENCE = 8;
   MODERATION_OBJECT_TYPE_PUBLIC_TRIP = 9;
+  // The UMS does not handle visibility for these, so APPROVE/HIDE are rejected
+  MODERATION_OBJECT_TYPE_USER = 10;
 }
 
 message ModerationStateInfo {


### PR DESCRIPTION
The Unified Moderation System only covers content — host requests, discussions, events, references and so on — so account-level signal has nowhere to go and moderators end up working a second inbox for it. This adds user accounts as a moderation object type, so an account can be flagged into the same queue as its owner's content and turns up under the existing "flagged about user X" filters in `GetModerationQueue` and `ListModerationStates`.

Whether an account is shown stays with ban, shadowban and deletion, so an account's moderation state carries no visibility: `ModerateContent` rejects approve and hide on these, and they open no initial review. `moderation_states.visibility` is nullable as a result, and which object types leave it null is declared on the models rather than special-cased for accounts. Every account gets its state at signup, with existing ones backfilled.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
