### PR TITLE
Backend: run auth and per-call setup on the handler thread

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -323,7 +323,7 @@ type Cont[T, R] = Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[T, R
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class _AdmittedCall:
+class AdmittedCall:
     """What a call that's cleared to run carries into the handler body."""
 
     headers: CouchersHeaders
@@ -333,14 +333,14 @@ class _AdmittedCall:
     localization: LocalizationContext
 
 
-def _admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> _AdmittedCall:
-    """Let the call through, resolving who is making it and in what locale, or raise AbortError to reject it."""
+def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall:
+    """Pre-RPC setup handling."""
     auth_level = find_auth_level(pool, handler_call_details.method)
 
     try:
         headers = parse_headers(dict(handler_call_details.invocation_metadata))
     except BadHeaders:
-        raise AbortError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
+        raise CallRejectedError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
 
     # if this is not present in prod, it's a Big Bug in config
     assert config.DEV or headers.ip_address is not None
@@ -362,15 +362,17 @@ def _admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDeta
     else:
         sofa, new_sofa_cookie = generate_sofa_cookie()
 
-    return _AdmittedCall(
+    loc_context = LocalizationContext(
+        locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
+        timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+    )
+
+    return AdmittedCall(
         headers=headers,
         auth_info=auth_info,
         sofa=sofa,
         new_sofa_cookie=new_sofa_cookie,
-        localization=LocalizationContext(
-            locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
-            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-        ),
+        localization=loc_context,
     )
 
 
@@ -415,9 +417,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             start_perf()
 
             try:
-                call = _admit_call(self._pool, handler_call_details)
+                call = admit_call(self._pool, handler_call_details)
                 observe_in_servicer_setup_histogram(method, read_perf())
-            except AbortError as ae:
+            except CallRejectedError as ae:
                 grpc_context.abort(ae.code, ae.msg)
             except Exception as e:
                 observe_in_servicer_setup_errors_counter(method, type(e).__name__)
@@ -614,7 +616,7 @@ class BadHeaders(Exception):
     pass
 
 
-class AbortError(Exception):
+class CallRejectedError(Exception):
     def __init__(self, msg: str, code: grpc.StatusCode):
         self.msg = msg
         self.code = code
@@ -628,7 +630,7 @@ def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
         service: ServiceDescriptor = pool.FindServiceByName(service_name)  # type: ignore[no-untyped-call]
         service_options = service.GetOptions()
     except KeyError:
-        raise AbortError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None
+        raise CallRejectedError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None
 
     level = service_options.Extensions[annotations_pb2.auth_level]
 
@@ -640,7 +642,7 @@ def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
 def validate_auth_level(auth_level: AuthLevel.ValueType) -> None:
     # if unknown auth level, then it wasn't set and something's wrong
     if auth_level == annotations_pb2.AUTH_LEVEL_UNKNOWN:
-        raise AbortError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+        raise CallRejectedError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
 
     if auth_level not in {
         annotations_pb2.AUTH_LEVEL_OPEN,
@@ -649,28 +651,28 @@ def validate_auth_level(auth_level: AuthLevel.ValueType) -> None:
         annotations_pb2.AUTH_LEVEL_EDITOR,
         annotations_pb2.AUTH_LEVEL_ADMIN,
     }:
-        raise AbortError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+        raise CallRejectedError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
 
 
 def check_permissions(auth_info: UserAuthInfo | None, auth_level: AuthLevel.ValueType) -> None:
     if not auth_info:
         # if this isn't an open service, fail
         if auth_level != annotations_pb2.AUTH_LEVEL_OPEN:
-            raise AbortError(UNAUTHORIZED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
+            raise CallRejectedError(UNAUTHORIZED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
     else:
         # a valid user session was found - check permissions
         if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser:
-            raise AbortError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
 
         if auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor:
-            raise AbortError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
 
         # if the user is jailed and this isn't an open or jailed service, fail
         if auth_info.is_jailed and auth_level not in [
             annotations_pb2.AUTH_LEVEL_OPEN,
             annotations_pb2.AUTH_LEVEL_JAILED,
         ]:
-            raise AbortError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
 
 
 class MediaInterceptor(grpc.ServerInterceptor):

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -322,6 +322,58 @@ def _store_log(
 type Cont[T, R] = Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[T, R] | None]
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _CallSetup:
+    """What the auth/setup phase resolves before the handler body runs."""
+
+    headers: CouchersHeaders
+    auth_info: UserAuthInfo | None
+    sofa: str
+    new_sofa_cookie: str | None
+    localization: LocalizationContext
+
+
+def _setup_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> _CallSetup:
+    """Authenticate the call and resolve its per-call context, raising AbortError to reject it."""
+    auth_level = find_auth_level(pool, handler_call_details.method)
+
+    try:
+        headers = parse_headers(dict(handler_call_details.invocation_metadata))
+    except BadHeaders:
+        raise AbortError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
+
+    # if this is not present in prod, it's a Big Bug in config
+    assert config.DEV or headers.ip_address is not None
+
+    auth_info = _try_get_and_update_user_details(
+        headers.token,
+        headers.is_api_key,
+        headers.ip_address,
+        headers.user_agent,
+        headers.sofa,
+        headers.client_platform,
+    )
+
+    check_permissions(auth_info, auth_level)
+
+    if headers.sofa:
+        sofa = headers.sofa
+        new_sofa_cookie = None
+    else:
+        sofa, new_sofa_cookie = generate_sofa_cookie()
+
+    return _CallSetup(
+        headers=headers,
+        auth_info=auth_info,
+        sofa=sofa,
+        new_sofa_cookie=new_sofa_cookie,
+        localization=LocalizationContext(
+            locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
+            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+        ),
+    )
+
+
 class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
     """
     1. Does auth: extracts a session token from a cookie, and authenticates a user with that.
@@ -334,6 +386,11 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
     3. Injects a session to get a database transaction.
 
     4. Measures and logs the time it takes to service each incoming call.
+
+    All of that happens in the returned handler, on a thread pool thread. gRPC runs intercept_service inline on the
+    server's single completion-queue thread while holding the server-wide lock, and only submits to the pool once
+    the interceptor chain has returned a handler, so blocking in the interceptor body (the auth query above all)
+    serializes call dispatch for the entire worker process.
     """
 
     def __init__(self) -> None:
@@ -348,63 +405,32 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
         method = handler_call_details.method
 
-        # accounting for the auth/setup phase; the handler re-arms its own below
-        start_perf()
-
-        try:
-            try:
-                auth_level = find_auth_level(self._pool, method)
-            except AbortError as ae:
-                return abort_handler(ae.msg, ae.code)
-
-            try:
-                headers = parse_headers(dict(handler_call_details.invocation_metadata))
-            except BadHeaders:
-                return unauthenticated_handler(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE)
-
-            # if this is not present in prod, it's a Big Bug in config
-            assert config.DEV or headers.ip_address is not None
-
-            auth_info = _try_get_and_update_user_details(
-                headers.token,
-                headers.is_api_key,
-                headers.ip_address,
-                headers.user_agent,
-                headers.sofa,
-                headers.client_platform,
-            )
-
-            try:
-                check_permissions(auth_info, auth_level)
-            except AbortError as ae:
-                return unauthenticated_handler(ae.msg, ae.code)
-
-            if not (handler := continuation(handler_call_details)):
-                raise RuntimeError(f"No handler in '{method}'")
-
-            if not (prev_function := handler.unary_unary):
-                raise RuntimeError(f"No prev_function in '{method}', {handler}")
-
-            if headers.sofa:
-                sofa = headers.sofa
-                new_sofa_cookie = None
-            else:
-                sofa, new_sofa_cookie = generate_sofa_cookie()
-
-            loc_context = LocalizationContext(
-                locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
-                timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-            )
-
-            observe_in_servicer_setup_histogram(method, read_perf())
-        except Exception as e:
-            observe_in_servicer_setup_errors_counter(method, type(e).__name__)
-            sentry_sdk.set_tag("context", "servicer_setup")
-            sentry_sdk.set_tag("method", method)
-            sentry_sdk.capture_exception(e)
-            return abort_handler(UNKNOWN_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+        # only the handler lookup happens here, the rest waits for the handler thread; see the class docstring
+        handler = continuation(handler_call_details)
+        if not handler or not (prev_function := handler.unary_unary):
+            return abort_handler(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED)
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
+            # accounting for the auth/setup phase; the handler re-arms its own below
+            start_perf()
+
+            try:
+                setup = _setup_call(self._pool, handler_call_details)
+                observe_in_servicer_setup_histogram(method, read_perf())
+            except AbortError as ae:
+                grpc_context.abort(ae.code, ae.msg)
+            except Exception as e:
+                observe_in_servicer_setup_errors_counter(method, type(e).__name__)
+                sentry_sdk.set_tag("context", "servicer_setup")
+                sentry_sdk.set_tag("method", method)
+                sentry_sdk.capture_exception(e)
+                grpc_context.abort(grpc.StatusCode.INTERNAL, UNKNOWN_ERROR_MESSAGE)
+
+            headers = setup.headers
+            auth_info = setup.auth_info
+            sofa = setup.sofa
+            loc_context = setup.localization
+
             couchers_context = make_interactive_context(
                 grpc_context=grpc_context,
                 user_id=auth_info.user_id if auth_info else None,
@@ -503,8 +529,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 if auth_info.ui_language_preference and auth_info.ui_language_preference != headers.ui_lang:
                     couchers_context.set_cookies(create_lang_cookie(auth_info.ui_language_preference))
 
-            if new_sofa_cookie:
-                couchers_context.set_cookies([new_sofa_cookie])
+            if setup.new_sofa_cookie:
+                couchers_context.set_cookies([setup.new_sofa_cookie])
 
             if not grpc_context.is_active():
                 grpc_context.abort(grpc.StatusCode.INTERNAL, CALL_CANCELLED_ERROR_MESSAGE)
@@ -713,12 +739,12 @@ class OTelInterceptor(grpc.ServerInterceptor):
 
         method = handler_call_details.method
 
-        # method is of the form "/org.couchers.api.core.API/GetUser"
-        _, service_name, method_name = method.split("/")
-
-        headers = dict(handler_call_details.invocation_metadata)
-
         def tracing_function(request: T, context: grpc.ServicerContext) -> R:
+            # method is of the form "/org.couchers.api.core.API/GetUser"
+            _, service_name, method_name = method.split("/")
+
+            headers = dict(handler_call_details.invocation_metadata)
+
             with self.tracer.start_as_current_span("handler") as rollspan:
                 rollspan.set_attribute("rpc.method_full", method)
                 rollspan.set_attribute("rpc.service", service_name)

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -323,8 +323,8 @@ type Cont[T, R] = Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[T, R
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class _CallSetup:
-    """What the auth/setup phase resolves before the handler body runs."""
+class _AdmittedCall:
+    """What a call that's cleared to run carries into the handler body."""
 
     headers: CouchersHeaders
     auth_info: UserAuthInfo | None
@@ -333,8 +333,8 @@ class _CallSetup:
     localization: LocalizationContext
 
 
-def _setup_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> _CallSetup:
-    """Authenticate the call and resolve its per-call context, raising AbortError to reject it."""
+def _admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> _AdmittedCall:
+    """Let the call through, resolving who is making it and in what locale, or raise AbortError to reject it."""
     auth_level = find_auth_level(pool, handler_call_details.method)
 
     try:
@@ -362,7 +362,7 @@ def _setup_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDeta
     else:
         sofa, new_sofa_cookie = generate_sofa_cookie()
 
-    return _CallSetup(
+    return _AdmittedCall(
         headers=headers,
         auth_info=auth_info,
         sofa=sofa,
@@ -415,7 +415,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             start_perf()
 
             try:
-                setup = _setup_call(self._pool, handler_call_details)
+                call = _admit_call(self._pool, handler_call_details)
                 observe_in_servicer_setup_histogram(method, read_perf())
             except AbortError as ae:
                 grpc_context.abort(ae.code, ae.msg)
@@ -426,10 +426,10 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 sentry_sdk.capture_exception(e)
                 grpc_context.abort(grpc.StatusCode.INTERNAL, UNKNOWN_ERROR_MESSAGE)
 
-            headers = setup.headers
-            auth_info = setup.auth_info
-            sofa = setup.sofa
-            loc_context = setup.localization
+            headers = call.headers
+            auth_info = call.auth_info
+            sofa = call.sofa
+            loc_context = call.localization
 
             couchers_context = make_interactive_context(
                 grpc_context=grpc_context,
@@ -529,8 +529,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 if auth_info.ui_language_preference and auth_info.ui_language_preference != headers.ui_lang:
                     couchers_context.set_cookies(create_lang_cookie(auth_info.ui_language_preference))
 
-            if setup.new_sofa_cookie:
-                couchers_context.set_cookies([setup.new_sofa_cookie])
+            if call.new_sofa_cookie:
+                couchers_context.set_cookies([call.new_sofa_cookie])
 
             if not grpc_context.is_active():
                 grpc_context.abort(grpc.StatusCode.INTERNAL, CALL_CANCELLED_ERROR_MESSAGE)

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -22,8 +22,8 @@ from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.interceptors import (
-    CallRejectedError,
     BadHeaders,
+    CallRejectedError,
     CouchersMiddlewareInterceptor,
     ErrorSanitizationInterceptor,
     UserAuthInfo,

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -2,6 +2,7 @@ from collections.abc import Callable, Generator
 from concurrent import futures
 from contextlib import contextmanager
 from datetime import timedelta
+from threading import current_thread
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -26,6 +27,7 @@ from couchers.interceptors import (
     CouchersMiddlewareInterceptor,
     ErrorSanitizationInterceptor,
     UserAuthInfo,
+    _try_get_and_update_user_details,
     check_permissions,
     find_auth_level,
     parse_headers,
@@ -351,6 +353,28 @@ def test_tracing_interceptor_phase_histograms(db):
         )
         == serialize_before + 1
     )
+
+
+def test_auth_runs_on_the_handler_thread(db):
+    # gRPC runs intercept_service inline on the server's single polling thread, under the server-wide lock, so the auth
+    # query has to happen in the returned handler or it serializes dispatch for every other call in the process
+    threads: dict[str, str] = {}
+
+    def TestRpc(request, context, session):
+        threads["handler"] = current_thread().name
+        return empty_pb2.Empty()
+
+    def record_thread(*args, **kwargs):
+        threads["auth"] = current_thread().name
+        return _try_get_and_update_user_details(*args, **kwargs)
+
+    with (
+        patch("couchers.interceptors._try_get_and_update_user_details", record_thread),
+        interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc,
+    ):
+        call_rpc(empty_pb2.Empty())
+
+    assert threads["auth"] == threads["handler"]
 
 
 def test_tracing_interceptor_perf_accounting_orm_write(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -22,7 +22,7 @@ from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.interceptors import (
-    AbortError,
+    CallRejectedError,
     BadHeaders,
     CouchersMiddlewareInterceptor,
     ErrorSanitizationInterceptor,
@@ -955,7 +955,7 @@ def test_find_auth_level_with_valid_service():
 def test_find_auth_level_with_nonexistent_service():
     pool = get_descriptor_pool()
 
-    with pytest.raises(AbortError) as exc:
+    with pytest.raises(CallRejectedError) as exc:
         find_auth_level(pool, "/org.couchers.nonexistent.Service/Method")
     assert exc.value.msg == NONEXISTENT_API_CALL_ERROR_MESSAGE
     assert exc.value.code == grpc.StatusCode.UNIMPLEMENTED
@@ -969,14 +969,14 @@ def test_find_auth_level_with_unknown_auth_level():
     service_desc.GetOptions.return_value = service_options
     pool.FindServiceByName.return_value = service_desc
 
-    with pytest.raises(AbortError) as exc:
+    with pytest.raises(CallRejectedError) as exc:
         find_auth_level(pool, "/org.couchers.api.core.API/GetUser")
     assert exc.value.msg == MISSING_AUTH_LEVEL_ERROR_MESSAGE
     assert exc.value.code == grpc.StatusCode.INTERNAL
 
 
 def test_validate_auth_level_with_unknown():
-    with pytest.raises(AbortError) as exc:
+    with pytest.raises(CallRejectedError) as exc:
         validate_auth_level(annotations_pb2.AUTH_LEVEL_UNKNOWN)
     assert exc.value.msg == MISSING_AUTH_LEVEL_ERROR_MESSAGE
     assert exc.value.code == grpc.StatusCode.INTERNAL
@@ -1022,7 +1022,7 @@ def test_check_auth_open_service_with_auth():
 
 
 def test_check_auth_secure_service_without_auth():
-    with pytest.raises(AbortError):
+    with pytest.raises(CallRejectedError):
         check_permissions(None, annotations_pb2.AUTH_LEVEL_SECURE)
 
 
@@ -1053,7 +1053,7 @@ def test_check_auth_secure_service_with_jailed_user():
         token="abc123",
         is_api_key=False,
     )
-    with pytest.raises(AbortError):
+    with pytest.raises(CallRejectedError):
         check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_SECURE)
 
 
@@ -1073,7 +1073,7 @@ def test_check_auth_jailed_service_with_jailed_user():
 
 
 def test_check_auth_jailed_service_without_auth():
-    with pytest.raises(AbortError):
+    with pytest.raises(CallRejectedError):
         check_permissions(None, annotations_pb2.AUTH_LEVEL_JAILED)
 
 
@@ -1089,7 +1089,7 @@ def test_check_auth_editor_service_without_editor():
         token="abc123",
         is_api_key=False,
     )
-    with pytest.raises(AbortError):
+    with pytest.raises(CallRejectedError):
         check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_EDITOR)
 
 
@@ -1120,7 +1120,7 @@ def test_check_auth_admin_service_without_superuser():
         token="abc123",
         is_api_key=False,
     )
-    with pytest.raises(AbortError):
+    with pytest.raises(CallRejectedError):
         check_permissions(auth_info, annotations_pb2.AUTH_LEVEL_ADMIN)
 
 
@@ -1140,7 +1140,7 @@ def test_check_auth_admin_service_with_superuser():
 
 
 def test_check_auth_admin_service_without_auth():
-    with pytest.raises(AbortError):
+    with pytest.raises(CallRejectedError):
         check_permissions(None, annotations_pb2.AUTH_LEVEL_ADMIN)
 
 


### PR DESCRIPTION
Every call into the API workers goes through the Couchers middleware interceptor, which authenticates the session before the servicer runs. gRPC runs server interceptors inline on the server's single completion-queue thread and only hands a call to the thread pool once the interceptor has returned a handler, so that session lookup — a query plus writes to `user_sessions` and `user_activity` — was a serialization point for the whole worker process: a worker could dispatch no more calls per second than that one round trip allows, `SERVER_THREADS` made no difference to it, and any latency spike or lock wait on it stalled every other request in the process. Authentication and the rest of the per-call setup now happen in the handler, on the pool, leaving only the handler lookup in the interceptor.

Two rejection paths change as a result: a call with missing or invalid credentials now has its request deserialized before being rejected, and a method that exists in the protos with no servicer registered returns UNIMPLEMENTED instead of an internal error.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
