### PR TITLE
Log API calls rejected before the handler runs

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -69,7 +69,7 @@ def _get_base_engine() -> Engine:
         # one connection per thread
         poolclass=QueuePool,
         # each process keeps its own pool, so total connections ~= process count * pool_size, kept under postgres
-        # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _store_log,
+        # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _log_call,
         # or the jobs worker's own session_scope + the handler's).
         pool_size=DB_POOL_SIZE,
         max_overflow=0,

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -79,6 +79,18 @@ class UserAuthInfo:
     is_api_key: bool
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CouchersHeaders:
+    user_id: str | None
+    token: str | None = field(repr=False)
+    sofa: str | None
+    is_api_key: bool
+    ip_address: str | None
+    user_agent: str | None
+    client_platform: ClientPlatform | None
+    ui_lang: str | None
+
+
 def _binned_now() -> Function[Any]:
     return func.date_bin(
         literal_column("interval '1 hour'"),
@@ -269,31 +281,34 @@ def _sanitized_bytes(proto: Message | None) -> bytes | None:
     return new_proto.SerializeToString()
 
 
-def _store_log(
+def _log_call(
     *,
     method: str,
-    status_code: str | None = None,
-    duration: float,
+    status_code: str | None,
     user_id: int | None,
     is_api_key: bool,
-    request: Message,
-    response: Message | None,
-    traceback: str | None = None,
-    perf_report: str | None = None,
-    perf: PerfResult | None = None,
-    client_platform: ClientPlatform | None = None,
-    ip_address: str | None,
-    user_agent: str | None,
     sofa: str | None,
+    headers: CouchersHeaders | None,
+    start: int,
+    perf: PerfResult | None,
+    request: Message | None = None,
+    response: Message | None = None,
+    exception: Exception | None = None,
 ) -> None:
+    """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
+    duration = (perf_counter_ns() - start) / 1e6  # ms
+
     req_bytes = _sanitized_bytes(request)
     res_bytes = _sanitized_bytes(response)
+    response_truncated = False
+    truncate_res_bytes_length = 16 * 1024  # 16 kB
+    if res_bytes and len(res_bytes) > truncate_res_bytes_length:
+        res_bytes = res_bytes[:truncate_res_bytes_length]
+        response_truncated = True
+
+    traceback = "".join(format_exception(type(exception), exception, exception.__traceback__)) if exception else None
+
     with session_scope() as session:
-        response_truncated = False
-        truncate_res_bytes_length = 16 * 1024  # 16 kB
-        if res_bytes and len(res_bytes) > truncate_res_bytes_length:
-            res_bytes = res_bytes[:truncate_res_bytes_length]
-            response_truncated = True
         session.add(
             APICall(
                 is_api_key=is_api_key,
@@ -305,18 +320,74 @@ def _store_log(
                 response=res_bytes,
                 response_truncated=response_truncated,
                 traceback=traceback,
-                perf_report=perf_report,
                 db_query_count=perf.db_query_count if perf else None,
                 db_write_query_count=perf.db_write_query_count if perf else None,
                 db_time_ms=perf.db_time_ms if perf else None,
                 cpu_ms=perf.cpu_ms if perf else None,
-                client_platform=client_platform,
-                ip_address=ip_address,
-                user_agent=user_agent,
+                client_platform=headers.client_platform if headers else None,
+                ip_address=headers.ip_address if headers else None,
+                user_agent=headers.user_agent if headers else None,
                 sofa=sofa,
             )
         )
+
+    observe_in_servicer_duration_histogram(
+        method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
+    )
+    observe_api_call(method, headers.client_platform if headers else None)
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
+
+
+def _log_rejected_call(
+    *,
+    method: str,
+    code: grpc.StatusCode,
+    start: int,
+    headers: CouchersHeaders | None,
+    auth_info: UserAuthInfo | None = None,
+    exception: Exception | None = None,
+) -> None:
+    """
+    Log a call rejected during auth/setup.
+
+    No servicer ran, so there is no request or response to store, and the perf numbers cover the auth/setup phase,
+    which is all the work the call did.
+    """
+    perf = read_perf()
+    _log_call(
+        method=method,
+        status_code=code.name,
+        user_id=auth_info.user_id if auth_info else None,
+        is_api_key=headers.is_api_key if headers else False,
+        sofa=headers.sofa if headers else None,
+        headers=headers,
+        start=start,
+        perf=perf,
+        exception=exception,
+    )
+    observe_in_servicer_setup_histogram(method, perf)
+
+
+def _rejected_call_handler[T, R](
+    *,
+    method: str,
+    message: str,
+    code: grpc.StatusCode,
+    start: int,
+    handler_call_details: grpc.HandlerCallDetails,
+) -> grpc.RpcMethodHandler[T, R]:
+    """Terminate a call that has no handler to run, logging it from the pool thread rather than the serving one."""
+
+    def f(request: Any, context: grpc.ServicerContext) -> NoReturn:
+        start_perf()
+        try:
+            headers: CouchersHeaders | None = parse_headers(dict(handler_call_details.invocation_metadata))
+        except BadHeaders:
+            headers = None
+        _log_rejected_call(method=method, code=code, start=start, headers=headers)
+        context.abort(code, message)
+
+    return grpc.unary_unary_rpc_method_handler(f)
 
 
 type Cont[T, R] = Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[T, R] | None]
@@ -333,17 +404,29 @@ class AdmittedCall:
     localization: LocalizationContext
 
 
-def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall:
-    """Pre-RPC setup handling."""
-    auth_level = find_auth_level(pool, handler_call_details.method)
+@dataclass(slots=True)
+class SetupProgress:
+    """Filled in as setup runs, so a call rejected partway through can be logged with whatever was resolved by then."""
 
+    headers: CouchersHeaders | None = None
+    auth_info: UserAuthInfo | None = None
+
+
+def admit_call(
+    pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails, progress: SetupProgress
+) -> AdmittedCall:
+    """Pre-RPC setup handling."""
+    # parsed before anything else so client details are available on every reject path
     try:
         headers = parse_headers(dict(handler_call_details.invocation_metadata))
     except BadHeaders:
         raise CallRejectedError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
+    progress.headers = headers
 
     # if this is not present in prod, it's a Big Bug in config
     assert config.DEV or headers.ip_address is not None
+
+    auth_level = find_auth_level(pool, handler_call_details.method)
 
     auth_info = _try_get_and_update_user_details(
         headers.token,
@@ -353,6 +436,7 @@ def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetai
         headers.sofa,
         headers.client_platform,
     )
+    progress.auth_info = auth_info
 
     check_permissions(auth_info, auth_level)
 
@@ -410,22 +494,43 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         # only the handler lookup happens here, the rest waits for the handler thread; see the class docstring
         handler = continuation(handler_call_details)
         if not handler or not (prev_function := handler.unary_unary):
-            return abort_handler(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED)
+            return _rejected_call_handler(
+                method=method,
+                message=NONEXISTENT_API_CALL_ERROR_MESSAGE,
+                code=grpc.StatusCode.UNIMPLEMENTED,
+                start=start,
+                handler_call_details=handler_call_details,
+            )
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             # accounting for the auth/setup phase; the handler re-arms its own below
             start_perf()
 
+            # bound as setup progresses so the reject paths below, and the catch-all, can log what is known so far
+            progress = SetupProgress()
+
             try:
-                call = admit_call(self._pool, handler_call_details)
+                call = admit_call(self._pool, handler_call_details, progress)
                 observe_in_servicer_setup_histogram(method, read_perf())
             except CallRejectedError as ae:
+                _log_rejected_call(
+                    method=method, code=ae.code, start=start, headers=progress.headers, auth_info=progress.auth_info
+                )
                 grpc_context.abort(ae.code, ae.msg)
             except Exception as e:
                 observe_in_servicer_setup_errors_counter(method, type(e).__name__)
                 sentry_sdk.set_tag("context", "servicer_setup")
                 sentry_sdk.set_tag("method", method)
                 sentry_sdk.capture_exception(e)
+                # reported to Sentry first: if the DB is what's broken, logging the call below fails too
+                _log_rejected_call(
+                    method=method,
+                    code=grpc.StatusCode.INTERNAL,
+                    start=start,
+                    headers=progress.headers,
+                    auth_info=progress.auth_info,
+                    exception=e,
+                )
                 grpc_context.abort(grpc.StatusCode.INTERNAL, UNKNOWN_ERROR_MESSAGE)
 
             headers = call.headers
@@ -448,64 +553,42 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 session.connection()
                 observe_in_servicer_pool_wait_histogram(method, (perf_counter_ns() - pool_wait_start) / 1e9)
                 start_perf()
+
+                res: Message | None = None
+                exception: Exception | None = None
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
-                    res = cast(Message, _res)
                     # flush so pending ORM writes execute (and are counted) before we snapshot; a handler that only
                     # session.add(...)s and returns would otherwise flush at commit, after read_perf()
                     session.flush()
-                    perf = read_perf()
-                    finished = perf_counter_ns()
-                    duration = (finished - start) / 1e6  # ms
-                    _store_log(
-                        method=method,
-                        duration=duration,
-                        user_id=couchers_context._user_id,
-                        is_api_key=cast(bool, couchers_context._is_api_key),
-                        request=req,
-                        response=res,
-                        perf=perf,
-                        client_platform=headers.client_platform,
-                        ip_address=headers.ip_address,
-                        user_agent=headers.user_agent,
-                        sofa=sofa,
-                    )
-                    observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
-                    observe_api_call(method, headers.client_platform)
-                    observe_in_servicer_perf_histograms(method, perf)
+                    res = cast(Message, _res)
                 except Exception as e:
-                    perf = read_perf()
-                    finished = perf_counter_ns()
-                    duration = (finished - start) / 1e6  # ms
+                    exception = e
 
-                    if couchers_context._grpc_context:
-                        context_code = couchers_context._grpc_context.code()  # type: ignore[attr-defined]
-                        code = getattr(context_code, "name", None)
-                    else:
-                        code = None
+                perf = read_perf()
 
-                    traceback = "".join(format_exception(type(e), e, e.__traceback__))
-                    _store_log(
-                        method=method,
-                        status_code=code,
-                        duration=duration,
-                        user_id=couchers_context._user_id,
-                        is_api_key=cast(bool, couchers_context._is_api_key),
-                        request=req,
-                        response=None,
-                        traceback=traceback,
-                        perf=perf,
-                        client_platform=headers.client_platform,
-                        ip_address=headers.ip_address,
-                        user_agent=headers.user_agent,
-                        sofa=sofa,
-                    )
-                    observe_in_servicer_duration_histogram(
-                        method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
-                    )
-                    observe_api_call(method, headers.client_platform)
-                    observe_in_servicer_perf_histograms(method, perf)
+                if exception and couchers_context._grpc_context:
+                    context_code = couchers_context._grpc_context.code()  # type: ignore[attr-defined]
+                    code = getattr(context_code, "name", None)
+                else:
+                    code = None
 
+                _log_call(
+                    method=method,
+                    status_code=code,
+                    user_id=couchers_context._user_id,
+                    is_api_key=cast(bool, couchers_context._is_api_key),
+                    sofa=sofa,
+                    headers=headers,
+                    start=start,
+                    perf=perf,
+                    request=req,
+                    response=res,
+                    exception=exception,
+                )
+                observe_in_servicer_perf_histograms(method, perf)
+
+                if exception:
                     if not code:
                         sentry_sdk.set_tag("context", "servicer")
                         sentry_sdk.set_tag("method", method)
@@ -518,9 +601,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                                 "sofa": sofa[:12],
                             }
                         )
-                        sentry_sdk.capture_exception(e)
+                        sentry_sdk.capture_exception(exception)
 
-                    raise e
+                    raise exception
 
             if auth_info and not auth_info.is_api_key:
                 # check the two cookies are in sync & that language preference cookie is correct
@@ -559,18 +642,6 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         )
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
-class CouchersHeaders:
-    token: str | None = field(repr=False)
-    is_api_key: bool
-    ip_address: str | None
-    user_agent: str | None
-    client_platform: ClientPlatform | None
-    ui_lang: str | None
-    user_id: str | None
-    sofa: str | None
-
-
 def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:
     if "cookie" in headers and "authorization" in headers:
         # for security reasons, only one of "cookie" or "authorization" can be present
@@ -601,14 +672,14 @@ def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:
     sofa = parse_sofa_cookie(headers)
 
     return CouchersHeaders(
+        user_id=user_id,
         token=token,
+        sofa=sofa,
         is_api_key=is_api_key,
         ip_address=ip_address if isinstance(ip_address, str) else None,
         user_agent=user_agent if isinstance(user_agent, str) else None,
         client_platform=client_platform,
         ui_lang=ui_lang,
-        user_id=user_id,
-        sofa=sofa,
     )
 
 

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -712,9 +712,6 @@ def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
 
     try:
         service: ServiceDescriptor = pool.FindServiceByName(service_name)  # type: ignore[no-untyped-call]
-        # checked so a probe for a method that doesn't exist on a real service aborts here, rather than reaching the
-        # missing-handler RuntimeError below and being reported as an internal error
-        service.FindMethodByName(method_name)  # type: ignore[no-untyped-call]
         service_options = service.GetOptions()
     except KeyError:
         raise CallRejectedError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -420,39 +420,72 @@ class AdmittedCall:
     localization: LocalizationContext
 
 
-def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall:
-    """Pre-RPC setup handling."""
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RejectedCall:
+    """What a call that didn't clear setup gets terminated and logged with."""
+
+    code: grpc.StatusCode
+    message: str
+    user_id: int | None
+    exception: Exception | None
+    """Set when setup broke rather than turned the call away, so the caller can report it."""
+
+
+def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall | RejectedCall:
+    """
+    Pre-RPC setup handling.
+
+    Never raises: a call that doesn't make it through comes back as a RejectedCall carrying whatever setup had
+    resolved before it stopped, so the caller can log the call it never ran.
+    """
+    auth_info = None
     try:
         headers = parse_headers(dict(handler_call_details.invocation_metadata))
+
+        # if this is not present in prod, it's a Big Bug in config
+        assert config.DEV or headers.ip_address is not None
+
+        auth_level = find_auth_level(pool, handler_call_details.method)
+
+        auth_info = _try_get_and_update_user_details(
+            headers.token,
+            headers.is_api_key,
+            headers.ip_address,
+            headers.user_agent,
+            headers.sofa,
+            headers.client_platform,
+        )
+
+        check_permissions(auth_info, auth_level)
+
+        if headers.sofa:
+            sofa = headers.sofa
+            new_sofa_cookie = None
+        else:
+            sofa, new_sofa_cookie = generate_sofa_cookie()
+
+        loc_context = LocalizationContext(
+            locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
+            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+        )
     except BadHeaders:
-        raise CallRejectedError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
-
-    # if this is not present in prod, it's a Big Bug in config
-    assert config.DEV or headers.ip_address is not None
-
-    auth_level = find_auth_level(pool, handler_call_details.method)
-
-    auth_info = _try_get_and_update_user_details(
-        headers.token,
-        headers.is_api_key,
-        headers.ip_address,
-        headers.user_agent,
-        headers.sofa,
-        headers.client_platform,
-    )
-
-    check_permissions(auth_info, auth_level)
-
-    if headers.sofa:
-        sofa = headers.sofa
-        new_sofa_cookie = None
-    else:
-        sofa, new_sofa_cookie = generate_sofa_cookie()
-
-    loc_context = LocalizationContext(
-        locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
-        timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-    )
+        return RejectedCall(
+            code=grpc.StatusCode.UNAUTHENTICATED,
+            message=COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
+            user_id=None,
+            exception=None,
+        )
+    except CallRejectedError as e:
+        return RejectedCall(
+            code=e.code, message=e.msg, user_id=auth_info.user_id if auth_info else None, exception=None
+        )
+    except Exception as e:
+        return RejectedCall(
+            code=grpc.StatusCode.INTERNAL,
+            message=UNKNOWN_ERROR_MESSAGE,
+            user_id=auth_info.user_id if auth_info else None,
+            exception=e,
+        )
 
     return AdmittedCall(
         headers=headers,
@@ -509,33 +542,27 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             # accounting for the auth/setup phase; the handler re-arms its own below
             start_perf()
 
-            try:
-                call = admit_call(self._pool, handler_call_details)
-                observe_in_servicer_setup_histogram(method, read_perf())
-            except CallRejectedError as ae:
+            call = admit_call(self._pool, handler_call_details)
+
+            if isinstance(call, RejectedCall):
+                if call.exception:
+                    observe_in_servicer_setup_errors_counter(method, type(call.exception).__name__)
+                    sentry_sdk.set_tag("context", "servicer_setup")
+                    sentry_sdk.set_tag("method", method)
+                    sentry_sdk.capture_exception(call.exception)
+                # anything unexpected is reported to Sentry first: if the DB is what's broken, logging fails too
                 _log_rejected_call(
                     method=method,
-                    code=ae.code,
+                    code=call.code,
                     start=start,
                     handler_call_details=handler_call_details,
-                    user_id=ae.user_id,
-                    nonexistent_method=ae.code == grpc.StatusCode.UNIMPLEMENTED,
+                    user_id=call.user_id,
+                    exception=call.exception,
+                    nonexistent_method=call.code == grpc.StatusCode.UNIMPLEMENTED,
                 )
-                grpc_context.abort(ae.code, ae.msg)
-            except Exception as e:
-                observe_in_servicer_setup_errors_counter(method, type(e).__name__)
-                sentry_sdk.set_tag("context", "servicer_setup")
-                sentry_sdk.set_tag("method", method)
-                sentry_sdk.capture_exception(e)
-                # reported to Sentry first: if the DB is what's broken, logging the call below fails too
-                _log_rejected_call(
-                    method=method,
-                    code=grpc.StatusCode.INTERNAL,
-                    start=start,
-                    handler_call_details=handler_call_details,
-                    exception=e,
-                )
-                grpc_context.abort(grpc.StatusCode.INTERNAL, UNKNOWN_ERROR_MESSAGE)
+                grpc_context.abort(call.code, call.message)
+
+            observe_in_servicer_setup_histogram(method, read_perf())
 
             headers = call.headers
             auth_info = call.auth_info
@@ -692,11 +719,9 @@ class BadHeaders(Exception):
 
 
 class CallRejectedError(Exception):
-    def __init__(self, msg: str, code: grpc.StatusCode, user_id: int | None = None):
+    def __init__(self, msg: str, code: grpc.StatusCode):
         self.msg = msg
         self.code = code
-        # set when the session was authenticated before the call was rejected, so the log row can attribute it
-        self.user_id = user_id
 
 
 def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
@@ -739,21 +764,17 @@ def check_permissions(auth_info: UserAuthInfo | None, auth_level: AuthLevel.Valu
     else:
         # a valid user session was found - check permissions
         if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser:
-            raise CallRejectedError(
-                PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED, auth_info.user_id
-            )
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
 
         if auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor:
-            raise CallRejectedError(
-                PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED, auth_info.user_id
-            )
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
 
         # if the user is jailed and this isn't an open or jailed service, fail
         if auth_info.is_jailed and auth_level not in [
             annotations_pb2.AUTH_LEVEL_OPEN,
             annotations_pb2.AUTH_LEVEL_JAILED,
         ]:
-            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED, auth_info.user_id)
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
 
 
 class MediaInterceptor(grpc.ServerInterceptor):

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -349,8 +349,8 @@ def _log_rejected_call(
     method: str,
     code: grpc.StatusCode,
     start: int,
-    headers: CouchersHeaders | None,
-    auth_info: UserAuthInfo | None = None,
+    handler_call_details: grpc.HandlerCallDetails,
+    user_id: int | None = None,
     exception: Exception | None = None,
     nonexistent_method: bool = False,
 ) -> None:
@@ -358,13 +358,19 @@ def _log_rejected_call(
     Log a call rejected during auth/setup.
 
     No servicer ran, so there is no request or response to store, and the perf numbers cover the auth/setup phase,
-    which is all the work the call did.
+    which is all the work the call did. The headers are parsed again here rather than handed over by the setup code,
+    since parsing is cheap and the call may well have been rejected before it got that far.
     """
+    try:
+        headers: CouchersHeaders | None = parse_headers(dict(handler_call_details.invocation_metadata))
+    except BadHeaders:
+        headers = None
+
     perf = read_perf()
     _log_call(
         method=method,
         status_code=code.name,
-        user_id=auth_info.user_id if auth_info else None,
+        user_id=user_id,
         is_api_key=headers.is_api_key if headers else False,
         sofa=headers.sofa if headers else None,
         headers=headers,
@@ -388,11 +394,13 @@ def _rejected_call_handler[T, R](
 
     def f(request: Any, context: grpc.ServicerContext) -> NoReturn:
         start_perf()
-        try:
-            headers: CouchersHeaders | None = parse_headers(dict(handler_call_details.invocation_metadata))
-        except BadHeaders:
-            headers = None
-        _log_rejected_call(method=method, code=code, start=start, headers=headers, nonexistent_method=True)
+        _log_rejected_call(
+            method=method,
+            code=code,
+            start=start,
+            handler_call_details=handler_call_details,
+            nonexistent_method=True,
+        )
         context.abort(code, message)
 
     return grpc.unary_unary_rpc_method_handler(f)
@@ -412,24 +420,12 @@ class AdmittedCall:
     localization: LocalizationContext
 
 
-@dataclass(slots=True)
-class SetupProgress:
-    """Filled in as setup runs, so a call rejected partway through can be logged with whatever was resolved by then."""
-
-    headers: CouchersHeaders | None = None
-    auth_info: UserAuthInfo | None = None
-
-
-def admit_call(
-    pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails, progress: SetupProgress
-) -> AdmittedCall:
+def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall:
     """Pre-RPC setup handling."""
-    # parsed before anything else so client details are available on every reject path
     try:
         headers = parse_headers(dict(handler_call_details.invocation_metadata))
     except BadHeaders:
         raise CallRejectedError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
-    progress.headers = headers
 
     # if this is not present in prod, it's a Big Bug in config
     assert config.DEV or headers.ip_address is not None
@@ -444,7 +440,6 @@ def admit_call(
         headers.sofa,
         headers.client_platform,
     )
-    progress.auth_info = auth_info
 
     check_permissions(auth_info, auth_level)
 
@@ -514,19 +509,16 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             # accounting for the auth/setup phase; the handler re-arms its own below
             start_perf()
 
-            # bound as setup progresses so the reject paths below, and the catch-all, can log what is known so far
-            progress = SetupProgress()
-
             try:
-                call = admit_call(self._pool, handler_call_details, progress)
+                call = admit_call(self._pool, handler_call_details)
                 observe_in_servicer_setup_histogram(method, read_perf())
             except CallRejectedError as ae:
                 _log_rejected_call(
                     method=method,
                     code=ae.code,
                     start=start,
-                    headers=progress.headers,
-                    auth_info=progress.auth_info,
+                    handler_call_details=handler_call_details,
+                    user_id=ae.user_id,
                     nonexistent_method=ae.code == grpc.StatusCode.UNIMPLEMENTED,
                 )
                 grpc_context.abort(ae.code, ae.msg)
@@ -540,8 +532,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     method=method,
                     code=grpc.StatusCode.INTERNAL,
                     start=start,
-                    headers=progress.headers,
-                    auth_info=progress.auth_info,
+                    handler_call_details=handler_call_details,
                     exception=e,
                 )
                 grpc_context.abort(grpc.StatusCode.INTERNAL, UNKNOWN_ERROR_MESSAGE)
@@ -701,9 +692,11 @@ class BadHeaders(Exception):
 
 
 class CallRejectedError(Exception):
-    def __init__(self, msg: str, code: grpc.StatusCode):
+    def __init__(self, msg: str, code: grpc.StatusCode, user_id: int | None = None):
         self.msg = msg
         self.code = code
+        # set when the session was authenticated before the call was rejected, so the log row can attribute it
+        self.user_id = user_id
 
 
 def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
@@ -746,17 +739,21 @@ def check_permissions(auth_info: UserAuthInfo | None, auth_level: AuthLevel.Valu
     else:
         # a valid user session was found - check permissions
         if auth_level == annotations_pb2.AUTH_LEVEL_ADMIN and not auth_info.is_superuser:
-            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+            raise CallRejectedError(
+                PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED, auth_info.user_id
+            )
 
         if auth_level == annotations_pb2.AUTH_LEVEL_EDITOR and not auth_info.is_editor:
-            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED)
+            raise CallRejectedError(
+                PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.PERMISSION_DENIED, auth_info.user_id
+            )
 
         # if the user is jailed and this isn't an open or jailed service, fail
         if auth_info.is_jailed and auth_level not in [
             annotations_pb2.AUTH_LEVEL_OPEN,
             annotations_pb2.AUTH_LEVEL_JAILED,
         ]:
-            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED)
+            raise CallRejectedError(PERMISSION_DENIED_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED, auth_info.user_id)
 
 
 class MediaInterceptor(grpc.ServerInterceptor):

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -420,8 +420,8 @@ class RejectedCall:
     code: grpc.StatusCode
     message: str
     user_id: int | None
+    # set when setup broke rather than turned the call away, so the caller can report it
     exception: Exception | None
-    """Set when setup broke rather than turned the call away, so the caller can report it."""
 
 
 def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall | RejectedCall:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -63,8 +63,7 @@ from couchers.utils import (
 
 logger = logging.getLogger(__name__)
 
-# nonexistent method names are arbitrary strings off the wire, so they share one prometheus label rather than
-# spawning one per name; the api_calls row keeps the real one
+# the prometheus label shared by all calls to methods that don't exist
 NONEXISTENT_METHOD_LABEL = "<nonexistent>"
 
 
@@ -354,13 +353,7 @@ def _log_rejected_call(
     exception: Exception | None = None,
     nonexistent_method: bool = False,
 ) -> None:
-    """
-    Log a call rejected during auth/setup.
-
-    No servicer ran, so there is no request or response to store, and the perf numbers cover the auth/setup phase,
-    which is all the work the call did. The headers are parsed again here rather than handed over by the setup code,
-    since parsing is cheap and the call may well have been rejected before it got that far.
-    """
+    """Log a call rejected during auth/setup."""
     try:
         headers: CouchersHeaders | None = parse_headers(dict(handler_call_details.invocation_metadata))
     except BadHeaders:

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -63,8 +63,8 @@ from couchers.utils import (
 
 logger = logging.getLogger(__name__)
 
-# a call to a method that doesn't exist carries an arbitrary string off the wire, so it's bucketed under this rather
-# than used as a prometheus label; the api_calls row still records what was actually asked for
+# nonexistent method names are arbitrary strings off the wire, so they share one prometheus label rather than
+# spawning one per name; the api_calls row keeps the real one
 NONEXISTENT_METHOD_LABEL = "<nonexistent>"
 
 

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -63,6 +63,10 @@ from couchers.utils import (
 
 logger = logging.getLogger(__name__)
 
+# a call to a method that doesn't exist carries an arbitrary string off the wire, so it's bucketed under this rather
+# than used as a prometheus label; the api_calls row still records what was actually asked for
+NONEXISTENT_METHOD_LABEL = "<nonexistent>"
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class UserAuthInfo:
@@ -294,8 +298,10 @@ def _log_call(
     request: Message | None = None,
     response: Message | None = None,
     exception: Exception | None = None,
+    nonexistent_method: bool = False,
 ) -> None:
     """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
+    metric_method = NONEXISTENT_METHOD_LABEL if nonexistent_method else method
     duration = (perf_counter_ns() - start) / 1e6  # ms
 
     req_bytes = _sanitized_bytes(request)
@@ -332,9 +338,9 @@ def _log_call(
         )
 
     observe_in_servicer_duration_histogram(
-        method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
+        metric_method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
     )
-    observe_api_call(method, headers.client_platform if headers else None)
+    observe_api_call(metric_method, headers.client_platform if headers else None)
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
 
 
@@ -346,6 +352,7 @@ def _log_rejected_call(
     headers: CouchersHeaders | None,
     auth_info: UserAuthInfo | None = None,
     exception: Exception | None = None,
+    nonexistent_method: bool = False,
 ) -> None:
     """
     Log a call rejected during auth/setup.
@@ -364,8 +371,9 @@ def _log_rejected_call(
         start=start,
         perf=perf,
         exception=exception,
+        nonexistent_method=nonexistent_method,
     )
-    observe_in_servicer_setup_histogram(method, perf)
+    observe_in_servicer_setup_histogram(NONEXISTENT_METHOD_LABEL if nonexistent_method else method, perf)
 
 
 def _rejected_call_handler[T, R](
@@ -384,7 +392,7 @@ def _rejected_call_handler[T, R](
             headers: CouchersHeaders | None = parse_headers(dict(handler_call_details.invocation_metadata))
         except BadHeaders:
             headers = None
-        _log_rejected_call(method=method, code=code, start=start, headers=headers)
+        _log_rejected_call(method=method, code=code, start=start, headers=headers, nonexistent_method=True)
         context.abort(code, message)
 
     return grpc.unary_unary_rpc_method_handler(f)
@@ -514,7 +522,12 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 observe_in_servicer_setup_histogram(method, read_perf())
             except CallRejectedError as ae:
                 _log_rejected_call(
-                    method=method, code=ae.code, start=start, headers=progress.headers, auth_info=progress.auth_info
+                    method=method,
+                    code=ae.code,
+                    start=start,
+                    headers=progress.headers,
+                    auth_info=progress.auth_info,
+                    nonexistent_method=ae.code == grpc.StatusCode.UNIMPLEMENTED,
                 )
                 grpc_context.abort(ae.code, ae.msg)
             except Exception as e:
@@ -699,6 +712,9 @@ def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
 
     try:
         service: ServiceDescriptor = pool.FindServiceByName(service_name)  # type: ignore[no-untyped-call]
+        # checked so a probe for a method that doesn't exist on a real service aborts here, rather than reaching the
+        # missing-handler RuntimeError below and being reported as an internal error
+        service.FindMethodByName(method_name)  # type: ignore[no-untyped-call]
         service_options = service.GetOptions()
     except KeyError:
         raise CallRejectedError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -7,7 +7,7 @@ from sqlalchemy import Engine, event
 # Per-request resource accounting. The gRPC server is thread-per-request with synchronous psycopg, so the SQLAlchemy
 # cursor-execute listeners fire on the same thread that runs the handler. We keep a thread-local accumulator that the
 # interceptor arms (start_perf) right before invoking the handler and reads back (read_perf) right after, so the
-# captured numbers cover the handler span only (not auth lookup or the _store_log insert that runs afterwards).
+# captured numbers cover the handler span only (not auth lookup or the _log_call insert that runs afterwards).
 
 _local = threading.local()
 
@@ -36,7 +36,7 @@ def start_perf() -> None:
 def read_perf() -> PerfResult | None:
     """Snapshot and clear the current thread's accumulator, or None if accounting wasn't armed.
 
-    Clearing means queries that run after this (e.g. the _store_log insert, or background work reusing the thread)
+    Clearing means queries that run after this (e.g. the _log_call insert, or background work reusing the thread)
     aren't attributed to the just-finished request.
     """
     acc: _PerfAccumulator | None = getattr(_local, "acc", None)

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -999,35 +999,6 @@ def test_rejected_call_logged_nonexistent_rpc(db):
     )
 
 
-def test_rejected_call_logged_nonexistent_method_on_real_service(db):
-    """A real service with a method that doesn't exist is rejected too, rather than admitted under the service's auth level."""
-    method = "/org.couchers.api.core.API/GetNothing"
-    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
-
-    def TestRpc(request, context, session):
-        return empty_pb2.Empty()
-
-    with interceptor_dummy_api(
-        TestRpc,
-        interceptors=[CouchersMiddlewareInterceptor()],
-        service_name="org.couchers.api.core.API",
-        method_name="GetNothing",
-    ) as call_rpc:
-        with pytest.raises(grpc.RpcError) as e:
-            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
-        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
-        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
-
-    with session_scope() as session:
-        trace = session.execute(select(APICall)).scalar_one()
-        assert trace.method == method
-        assert trace.status_code == "UNIMPLEMENTED"
-        assert not trace.traceback
-
-    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
-    assert _get_histogram_labels_value(method, "False", "", "UNIMPLEMENTED") == 0
-
-
 def test_rejected_call_logged_unregistered_method(db):
     """A method with no servicer registered is terminated by the interceptor itself, and still logged."""
     hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -23,6 +23,7 @@ from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.interceptors import (
+    NONEXISTENT_METHOD_LABEL,
     BadHeaders,
     CallRejectedError,
     CouchersMiddlewareInterceptor,
@@ -957,6 +958,9 @@ def test_rejected_call_logged_permission_denied(db):
 
 
 def test_rejected_call_logged_nonexistent_rpc(db):
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+    api_calls_before = _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown")
+
     def TestRpc(request, context, session):
         return empty_pb2.Empty()
 
@@ -980,9 +984,53 @@ def test_rejected_call_logged_nonexistent_rpc(db):
         assert trace.ip_address == "1.1.1.1"
         assert trace.user_agent is not None
 
+    # the caller picks the method, so it's bucketed in prometheus instead of becoming a label of its own
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown") == api_calls_before + 1
+    assert _get_histogram_labels_value("/org.couchers.nonexistent.NA/GetNothing", "False", "", "UNIMPLEMENTED") == 0
+    assert _get_api_call_count("/org.couchers.nonexistent.NA/GetNothing", "unknown") == 0
+    assert (
+        _get_histogram_count(
+            servicer_setup_db_time_histogram,
+            "couchers_servicer_setup_db_time_seconds_count",
+            method="/org.couchers.nonexistent.NA/GetNothing",
+        )
+        == 0
+    )
+
+
+def test_rejected_call_logged_nonexistent_method_on_real_service(db):
+    """A real service with a method that doesn't exist is rejected too, rather than admitted under the service's auth level."""
+    method = "/org.couchers.api.core.API/GetNothing"
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.api.core.API",
+        method_name="GetNothing",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert not trace.traceback
+
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_histogram_labels_value(method, "False", "", "UNIMPLEMENTED") == 0
+
 
 def test_rejected_call_logged_unregistered_method(db):
     """A method with no servicer registered is terminated by the interceptor itself, and still logged."""
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
 
     def TestRpc(request, context, session):
         return empty_pb2.Empty()
@@ -1005,6 +1053,9 @@ def test_rejected_call_logged_unregistered_method(db):
         assert trace.ip_address == "1.1.1.1"
         # no servicer was found, so the request was never deserialized
         assert trace.request is None
+
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_histogram_labels_value("/org.couchers.auth.Auth/NotRegistered", "False", "", "UNIMPLEMENTED") == 0
 
 
 def test_rejected_call_logged_missing_auth_level(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -14,6 +14,7 @@ from google.protobuf.descriptor_pool import DescriptorPool
 from sqlalchemy import select, text, update
 
 from couchers.constants import (
+    COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
     MISSING_AUTH_LEVEL_ERROR_MESSAGE,
     NONEXISTENT_API_CALL_ERROR_MESSAGE,
     UNKNOWN_ERROR_MESSAGE,
@@ -66,6 +67,7 @@ def interceptor_dummy_api(
     request_type=empty_pb2.Empty,
     response_type=empty_pb2.Empty,
     creds=None,
+    call_method_name=None,
 ) -> Generator[Callable[..., Any]]:
     with futures.ThreadPoolExecutor(1) as executor:
         server = grpc.server(executor, interceptors=interceptors)
@@ -86,7 +88,7 @@ def interceptor_dummy_api(
         try:
             with grpc.secure_channel(f"localhost:{port}", creds or grpc.local_channel_credentials()) as channel:
                 yield channel.unary_unary(
-                    f"/{service_name}/{method_name}",
+                    f"/{service_name}/{call_method_name or method_name}",
                     request_serializer=request_type.SerializeToString,
                     response_deserializer=response_type.FromString,
                 )
@@ -494,6 +496,13 @@ def test_setup_phase_exception_observed(db):
 
     assert _get_setup_errors_value(method, "ValueError") == val + 1
 
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "INTERNAL"
+        assert trace.traceback
+        assert "expected only letters" in trace.traceback
+
 
 def test_tracing_interceptor_abort(db):
     val = _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "Exception", "FAILED_PRECONDITION")
@@ -877,6 +886,168 @@ def test_auth_levels(db):
             call_rpc(empty_pb2.Empty())
         assert err.value.code() == grpc.StatusCode.INTERNAL
         assert err.value.details() == "Internal authentication error."
+
+
+def test_rejected_call_logged_unauthenticated(db):
+    method = "/org.couchers.api.account.Account/GetAccountInfo"
+    hist_before = _get_histogram_labels_value(method, "False", "", "UNAUTHENTICATED")
+    api_calls_before = _get_api_call_count(method, "unknown")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.api.account.Account",
+        method_name="GetAccountInfo",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "UNAUTHENTICATED"
+        assert trace.user_id is None
+        assert not trace.is_api_key
+        # the request is never deserialized on a reject path
+        assert trace.request is None
+        assert trace.response is None
+        assert not trace.traceback
+        assert trace.duration > 0
+
+    assert _get_histogram_labels_value(method, "False", "", "UNAUTHENTICATED") == hist_before + 1
+    assert _get_api_call_count(method, "unknown") == api_calls_before + 1
+
+
+def test_rejected_call_logged_permission_denied(db):
+    """A rejected call from a valid session is attributed to that user."""
+    user, token = generate_user()
+    method = "/org.couchers.admin.Admin/GetUserDetails"
+    hist_before = _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.admin.Admin",
+        method_name="GetUserDetails",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(cookie_auth(token), ("x-couchers-client-platform", "web_mobile")))
+        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "PERMISSION_DENIED"
+        assert trace.user_id == user.id
+        assert trace.client_platform == ClientPlatform.web_mobile
+        assert not trace.traceback
+
+        # the same call is also counted in the per-user activity table, so the two agree
+        api_calls = session.execute(select(UserActivity.api_calls).where(UserActivity.user_id == user.id)).scalar_one()
+        assert api_calls == 1
+
+    assert _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED") == hist_before + 1
+
+
+def test_rejected_call_logged_nonexistent_rpc(db):
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.nonexistent.NA",
+        method_name="GetNothing",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.nonexistent.NA/GetNothing"
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert trace.user_id is None
+        # headers are parsed before the method is looked up, so we know who called a method that doesn't exist
+        assert trace.ip_address == "1.1.1.1"
+        assert trace.user_agent is not None
+
+
+def test_rejected_call_logged_unregistered_method(db):
+    """A method with no servicer registered is terminated by the interceptor itself, and still logged."""
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        call_method_name="NotRegistered",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.auth.Auth/NotRegistered"
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert trace.user_id is None
+        assert trace.ip_address == "1.1.1.1"
+        # no servicer was found, so the request was never deserialized
+        assert trace.request is None
+
+
+def test_rejected_call_logged_missing_auth_level(db):
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.media.Media",
+        method_name="UploadConfirmation",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.INTERNAL
+        assert e.value.details() == MISSING_AUTH_LEVEL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.media.Media/UploadConfirmation"
+        assert trace.status_code == "INTERNAL"
+
+
+def test_rejected_call_logged_bad_headers(db):
+    _, token = generate_user()
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(cookie_auth(token), api_auth(token)))
+        assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+        assert e.value.details() == COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.auth.Auth/SignupFlow"
+        assert trace.status_code == "UNAUTHENTICATED"
+        assert trace.user_id is None
+        # the headers couldn't be parsed, so nothing is known about the client
+        assert trace.ip_address is None
+        assert trace.user_agent is None
 
 
 def test_parse_headers_with_session_cookie():


### PR DESCRIPTION
Every call into the API workers passes through the Couchers middleware interceptor, which authenticates the session before recording the call in `logging.api_calls` and its Prometheus counters. Calls rejected during that setup — unauthenticated or expired-session calls to secure endpoints, jailed users hitting non-jailed endpoints, non-admins hitting admin endpoints, probes for methods that don't exist — were aborted without any of it, so they appeared in neither the table nor the metrics. That also left the counters disagreeing with each other: the session lookup runs before the permission check, so a rejected call had already incremented `user_sessions.api_calls` and `logging.user_activity` while never showing up in `logging.api_calls`. All five reject paths now log the call before terminating it.

A rejected call's method name comes off the wire, so it is bucketed under `<nonexistent>` in the Prometheus method label rather than used verbatim, though the `logging.api_calls` row still records what was asked for. An unauthenticated request to a secure endpoint now costs an INSERT, where before a request with no token did no database work at all.

Stacked on #9561 and targets that branch.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._