### PR TITLE
Point VSCode at the backend venv interpreter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
     "zxh404.vscode-proto3",
-    "charliermarsh.ruff"
+    "charliermarsh.ruff",
+    "ms-python.python"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,6 +56,7 @@
   "editor.insertSpaces": true,
   "files.trimTrailingWhitespace": true,
   "python-env.workspaceSearchPaths": [ "app/backend/.venv" ],
+  "python.defaultInterpreterPath": "${workspaceFolder}/app/backend/.venv/bin/python",
   "python.testing.cwd": "app/backend/src/tests",
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true


### PR DESCRIPTION
The repo ships a `.vscode` directory with recommended extensions and workspace settings so that a checkout gives roughly the same editor experience to everyone. On the Python side that has so far only covered Ruff and the pytest configuration, leaving each person to point their editor at the backend virtualenv by hand before things like imports resolving, go-to-definition and the test runner work. This adds the Python extension to the recommendations and sets the default interpreter to the backend venv, so a fresh checkout picks it up automatically.

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._