### PR TITLE
Give each checkout its own backend test database

### DIFF
--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -1,5 +1,5 @@
+import hashlib
 import os
-import re
 from collections.abc import Generator
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -15,10 +15,30 @@ prometheus_multiproc_dir = TemporaryDirectory()
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = prometheus_multiproc_dir.name
 
 # Default for running with a database from docker-compose.test.yml.
-if "DATABASE_CONNECTION_STRING" not in os.environ:  # pragma: no cover
-    os.environ["DATABASE_CONNECTION_STRING"] = (
-        "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb"
-    )
+DEFAULT_DATABASE_CONNECTION_STRING = (
+    "postgresql://postgres:06b3890acd2c235c41be0bbfe22f1b386a04bf02eedf8c977486355616be2aa1@localhost:6544/testdb"
+)
+
+
+def _test_database_name() -> str:
+    """
+    The database this run owns, which it drops and rebuilds at the start of the session.
+
+    The name comes from where this file sits on disk, so suites running side by side out of
+    different checkouts can share one postgres without destroying each other's database. It's
+    printed in the pytest header. Set TEST_DB_NAME to run two suites out of the same checkout.
+    """
+    if name := os.environ.get("TEST_DB_NAME"):
+        return name
+    return "testdb_" + hashlib.blake2b(str(Path(__file__).resolve()).encode(), digest_size=4).hexdigest()
+
+
+TEST_DB_NAME = _test_database_name()
+
+# The environment says which postgres to talk to; the database name within it is always ours, so
+# pointing DATABASE_CONNECTION_STRING at a real database can't get that database dropped.
+_dsn = os.environ.get("DATABASE_CONNECTION_STRING", DEFAULT_DATABASE_CONNECTION_STRING)
+os.environ["DATABASE_CONNECTION_STRING"] = _dsn.rsplit("/", 1)[0] + "/" + TEST_DB_NAME
 
 from couchers import experimentation  # noqa: E402
 from couchers.config import config  # noqa: E402
@@ -57,6 +77,10 @@ def pytest_configure(config: pytest.Config) -> None:
         query_log.enable(_get_base_engine())
 
 
+def pytest_report_header() -> str:
+    return f"test database: {TEST_DB_NAME}"
+
+
 def pytest_sessionfinish(session: pytest.Session) -> None:
     if session.config.getoption("--query-log"):
         print(f"\nquery log written to {query_log.dump(QUERY_LOG_DIR)}")
@@ -78,11 +102,7 @@ def postgres_engine() -> Generator[Engine]:
     """
     SQLAlchemy engine connected to "postgres" database.
     """
-    dsn = config.DATABASE_CONNECTION_STRING
-    if not dsn.endswith("/testdb"):
-        raise RuntimeError(f"DATABASE_CONNECTION_STRING must point to /testdb, but was {dsn}")
-
-    postgres_dsn = re.sub(r"/testdb$", "/postgres", dsn)
+    postgres_dsn = config.DATABASE_CONNECTION_STRING.rsplit("/", 1)[0] + "/postgres"
 
     with autocommit_engine(postgres_dsn) as engine:
         yield engine
@@ -100,7 +120,7 @@ def postgres_conn(postgres_engine: Engine) -> Generator[Connection]:
 @pytest.fixture(scope="session")
 def testdb_engine() -> Generator[Engine]:
     """
-    SQLAlchemy engine connected to "testdb" database.
+    SQLAlchemy engine connected to this run's test database.
     """
     dsn = config.DATABASE_CONNECTION_STRING
     with autocommit_engine(dsn) as engine:
@@ -110,7 +130,7 @@ def testdb_engine() -> Generator[Engine]:
 @pytest.fixture(scope="session")
 def testdb_conn(testdb_engine: Engine) -> Generator[Connection]:
     """
-    Connection to testdb for truncating tables between tests.
+    Connection to the test database for truncating tables between tests.
     """
     with testdb_engine.connect() as conn:
         yield conn
@@ -130,15 +150,15 @@ def setup_testdb(postgres_conn: Connection, testdb_engine: Engine) -> None:
     # running in non-UTC catches some timezone errors
     os.environ["TZ"] = "America/New_York"
 
-    postgres_conn.execute(text("DROP DATABASE IF EXISTS testdb WITH (FORCE)"))
-    postgres_conn.execute(text("CREATE DATABASE testdb"))
+    postgres_conn.execute(text(f"DROP DATABASE IF EXISTS {TEST_DB_NAME} WITH (FORCE)"))
+    postgres_conn.execute(text(f"CREATE DATABASE {TEST_DB_NAME}"))
 
     # A column DEFAULT resolves now() once, when the column is created, and stores the function
     # identity forever after; later search_path changes don't reach it. So mock.now() has to
     # already shadow pg_catalog.now() on every connection before any DDL runs, which means
     # setting this at the database level here, ahead of the first connect. The mock schema
     # doesn't exist yet, which postgres tolerates in a search_path.
-    postgres_conn.execute(text(f"ALTER DATABASE testdb SET search_path = {MOCK_SEARCH_PATH}"))
+    postgres_conn.execute(text(f"ALTER DATABASE {TEST_DB_NAME} SET search_path = {MOCK_SEARCH_PATH}"))
 
     with testdb_engine.connect() as conn:
         conn.execute(

--- a/app/backend/src/tests/test_app.py
+++ b/app/backend/src/tests/test_app.py
@@ -16,8 +16,8 @@ def _(testconfig):
 
 
 def test_create_servers():
-    server = create_main_server(port=1751)
-    media_server = create_media_server(port=1753)
+    server = create_main_server(port=0)
+    media_server = create_media_server(port=0)
     server.start()
     media_server.start()
     server.stop(None).wait()

--- a/app/backend/src/tests/test_bg_jobs.py
+++ b/app/backend/src/tests/test_bg_jobs.py
@@ -99,8 +99,8 @@ def _(testconfig):
     pass
 
 
-def _check_job_counter(job, status, attempt, exception):
-    metrics_string = requests.get("http://localhost:8000").text
+def _check_job_counter(port, job, status, attempt, exception):
+    metrics_string = requests.get(f"http://localhost:{port}").text
     string_to_check = f'attempt="{attempt}",exception="{exception}",job="{job}",status="{status}"'
     assert string_to_check in metrics_string
 
@@ -452,7 +452,8 @@ def test_job_retry(db):
     MOCK_JOBS: dict[str, Job[Any]] = {
         "mock_job": Job(mock_job),
     }
-    create_prometheus_server(port=8000)
+    # port 0 so parallel test runs don't fight over the port
+    metrics_server = create_prometheus_server(port=0)
 
     # if IN_TEST is true, then the bg worker will raise on exceptions
     new_config = config.copy()
@@ -507,8 +508,10 @@ def test_job_retry(db):
             == 0
         )
 
-    _check_job_counter("mock_job", "error", "4", "Exception")
-    _check_job_counter("mock_job", "failed", "5", "Exception")
+    _check_job_counter(metrics_server.server_port, "mock_job", "error", "4", "Exception")
+    _check_job_counter(metrics_server.server_port, "mock_job", "failed", "5", "Exception")
+    metrics_server.shutdown()
+    metrics_server.server_close()
 
 
 def test_job_retry_backs_off_from_now_not_from_a_stale_next_attempt_after(db):

--- a/app/backend/src/tests/test_db.py
+++ b/app/backend/src/tests/test_db.py
@@ -22,6 +22,7 @@ from couchers.utils import (
     is_valid_username,
     parse_date,
 )
+from tests.conftest import TEST_DB_NAME
 from tests.fixtures.db import (
     create_schema_from_models,
     drop_database,
@@ -187,18 +188,19 @@ def migration_test_db(postgres_conn):
     """
     Points everything at a scratch database for the duration of the test.
 
-    The schemas compared here should look like production's, and testdb doesn't: its column
-    defaults bind mock.now() so the timewarp fixture can shift the clock. Building somewhere else
-    keeps the mock out of both dumps and leaves testdb alone, which this test would otherwise
-    destroy and have to rebuild.
+    The schemas compared here should look like production's, and the test database doesn't: its
+    column defaults bind mock.now() so the timewarp fixture can shift the clock. Building somewhere
+    else keeps the mock out of both dumps and leaves the test database alone, which this test would
+    otherwise destroy and have to rebuild.
     """
-    postgres_conn.execute(text("DROP DATABASE IF EXISTS migrationtestdb WITH (FORCE)"))
-    postgres_conn.execute(text("CREATE DATABASE migrationtestdb"))
+    migration_db_name = f"{TEST_DB_NAME}_migrations"
+    postgres_conn.execute(text(f"DROP DATABASE IF EXISTS {migration_db_name} WITH (FORCE)"))
+    postgres_conn.execute(text(f"CREATE DATABASE {migration_db_name}"))
 
     previous_dsn = config.DATABASE_CONNECTION_STRING
-    config.DATABASE_CONNECTION_STRING = re.sub(r"/testdb$", "/migrationtestdb", previous_dsn)
-    # the cached engine still points at testdb, and clearing the cache would drop it with its
-    # pooled connections still open
+    config.DATABASE_CONNECTION_STRING = previous_dsn.rsplit("/", 1)[0] + "/" + migration_db_name
+    # the cached engine still points at the test database, and clearing the cache would drop it
+    # with its pooled connections still open
     _get_base_engine().dispose()
     _get_base_engine.cache_clear()
     try:
@@ -207,7 +209,7 @@ def migration_test_db(postgres_conn):
         _get_base_engine().dispose()
         config.DATABASE_CONNECTION_STRING = previous_dsn
         _get_base_engine.cache_clear()
-        postgres_conn.execute(text("DROP DATABASE IF EXISTS migrationtestdb WITH (FORCE)"))
+        postgres_conn.execute(text(f"DROP DATABASE IF EXISTS {migration_db_name} WITH (FORCE)"))
 
 
 @pytest.mark.skipif(not pg_dump_is_available(), reason="Can't run migration tests without pg_dump")


### PR DESCRIPTION
The backend test suite runs against a dedicated postgres instance, and at session start it drops and recreates a database called `testdb`. That name is the same for everyone, so running two suites at once — out of separate checkouts against one local test postgres — means the second run destroys the first run's database out from under it mid-suite. Each run now owns a database named after its checkout, so `DATABASE_CONNECTION_STRING` decides only which postgres and credentials to use; `TEST_DB_NAME` overrides the name for two suites out of a single checkout. Two tests that bound the Prometheus exporter and the gRPC servers to fixed ports, which collide the same way, now take ephemeral ones.

Since the database name is always chosen by the test harness, pointing `DATABASE_CONNECTION_STRING` at a real database can no longer get that database dropped.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._