### PR TITLE
Refactor the call logging and setup rejection paths in the interceptor

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -69,7 +69,7 @@ def _get_base_engine() -> Engine:
         # one connection per thread
         poolclass=QueuePool,
         # each process keeps its own pool, so total connections ~= process count * pool_size, kept under postgres
-        # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _store_log,
+        # max_connections. ~2 per thread since a thread can hold two connections at once (handler + _log_call,
         # or the jobs worker's own session_scope + the handler's).
         pool_size=DB_POOL_SIZE,
         max_overflow=0,

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -79,6 +79,18 @@ class UserAuthInfo:
     is_api_key: bool
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CouchersHeaders:
+    user_id: str | None
+    token: str | None = field(repr=False)
+    sofa: str | None
+    is_api_key: bool
+    ip_address: str | None
+    user_agent: str | None
+    client_platform: ClientPlatform | None
+    ui_lang: str | None
+
+
 def _binned_now() -> Function[Any]:
     return func.date_bin(
         literal_column("interval '1 hour'"),
@@ -269,31 +281,34 @@ def _sanitized_bytes(proto: Message | None) -> bytes | None:
     return new_proto.SerializeToString()
 
 
-def _store_log(
+def _log_call(
     *,
     method: str,
-    status_code: str | None = None,
-    duration: float,
+    status_code: str | None,
     user_id: int | None,
     is_api_key: bool,
+    sofa: str | None,
+    headers: CouchersHeaders,
+    start: int,
+    perf: PerfResult | None,
     request: Message,
     response: Message | None,
-    traceback: str | None = None,
-    perf_report: str | None = None,
-    perf: PerfResult | None = None,
-    client_platform: ClientPlatform | None = None,
-    ip_address: str | None,
-    user_agent: str | None,
-    sofa: str | None,
+    exception: Exception | None,
 ) -> None:
+    """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
+    duration = (perf_counter_ns() - start) / 1e6  # ms
+
     req_bytes = _sanitized_bytes(request)
     res_bytes = _sanitized_bytes(response)
+    response_truncated = False
+    truncate_res_bytes_length = 16 * 1024  # 16 kB
+    if res_bytes and len(res_bytes) > truncate_res_bytes_length:
+        res_bytes = res_bytes[:truncate_res_bytes_length]
+        response_truncated = True
+
+    traceback = "".join(format_exception(type(exception), exception, exception.__traceback__)) if exception else None
+
     with session_scope() as session:
-        response_truncated = False
-        truncate_res_bytes_length = 16 * 1024  # 16 kB
-        if res_bytes and len(res_bytes) > truncate_res_bytes_length:
-            res_bytes = res_bytes[:truncate_res_bytes_length]
-            response_truncated = True
         session.add(
             APICall(
                 is_api_key=is_api_key,
@@ -305,17 +320,21 @@ def _store_log(
                 response=res_bytes,
                 response_truncated=response_truncated,
                 traceback=traceback,
-                perf_report=perf_report,
                 db_query_count=perf.db_query_count if perf else None,
                 db_write_query_count=perf.db_write_query_count if perf else None,
                 db_time_ms=perf.db_time_ms if perf else None,
                 cpu_ms=perf.cpu_ms if perf else None,
-                client_platform=client_platform,
-                ip_address=ip_address,
-                user_agent=user_agent,
+                client_platform=headers.client_platform,
+                ip_address=headers.ip_address,
+                user_agent=headers.user_agent,
                 sofa=sofa,
             )
         )
+
+    observe_in_servicer_duration_histogram(
+        method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
+    )
+    observe_api_call(method, headers.client_platform)
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
 
 
@@ -333,39 +352,59 @@ class AdmittedCall:
     localization: LocalizationContext
 
 
-def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall:
-    """Pre-RPC setup handling."""
-    auth_level = find_auth_level(pool, handler_call_details.method)
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RejectedCall:
+    """What a call that didn't clear setup gets terminated with."""
 
+    code: grpc.StatusCode
+    message: str
+    # set when setup broke rather than turned the call away, so the caller can report it
+    exception: Exception | None
+
+
+def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall | RejectedCall:
+    """
+    Pre-RPC setup handling.
+
+    Never raises: a call that doesn't make it through comes back as a RejectedCall for the caller to terminate.
+    """
     try:
         headers = parse_headers(dict(handler_call_details.invocation_metadata))
+
+        # if this is not present in prod, it's a Big Bug in config
+        assert config.DEV or headers.ip_address is not None
+
+        auth_level = find_auth_level(pool, handler_call_details.method)
+
+        auth_info = _try_get_and_update_user_details(
+            headers.token,
+            headers.is_api_key,
+            headers.ip_address,
+            headers.user_agent,
+            headers.sofa,
+            headers.client_platform,
+        )
+
+        check_permissions(auth_info, auth_level)
+
+        if headers.sofa:
+            sofa = headers.sofa
+            new_sofa_cookie = None
+        else:
+            sofa, new_sofa_cookie = generate_sofa_cookie()
+
+        loc_context = LocalizationContext(
+            locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
+            timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
+        )
     except BadHeaders:
-        raise CallRejectedError(COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, grpc.StatusCode.UNAUTHENTICATED) from None
-
-    # if this is not present in prod, it's a Big Bug in config
-    assert config.DEV or headers.ip_address is not None
-
-    auth_info = _try_get_and_update_user_details(
-        headers.token,
-        headers.is_api_key,
-        headers.ip_address,
-        headers.user_agent,
-        headers.sofa,
-        headers.client_platform,
-    )
-
-    check_permissions(auth_info, auth_level)
-
-    if headers.sofa:
-        sofa = headers.sofa
-        new_sofa_cookie = None
-    else:
-        sofa, new_sofa_cookie = generate_sofa_cookie()
-
-    loc_context = LocalizationContext(
-        locale=(auth_info.ui_language_preference if auth_info else headers.ui_lang) or "",
-        timezone=ZoneInfo((auth_info and auth_info.timezone) or "Etc/UTC"),
-    )
+        return RejectedCall(
+            code=grpc.StatusCode.UNAUTHENTICATED, message=COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, exception=None
+        )
+    except CallRejectedError as e:
+        return RejectedCall(code=e.code, message=e.msg, exception=None)
+    except Exception as e:
+        return RejectedCall(code=grpc.StatusCode.INTERNAL, message=UNKNOWN_ERROR_MESSAGE, exception=e)
 
     return AdmittedCall(
         headers=headers,
@@ -416,17 +455,17 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             # accounting for the auth/setup phase; the handler re-arms its own below
             start_perf()
 
-            try:
-                call = admit_call(self._pool, handler_call_details)
-                observe_in_servicer_setup_histogram(method, read_perf())
-            except CallRejectedError as ae:
-                grpc_context.abort(ae.code, ae.msg)
-            except Exception as e:
-                observe_in_servicer_setup_errors_counter(method, type(e).__name__)
-                sentry_sdk.set_tag("context", "servicer_setup")
-                sentry_sdk.set_tag("method", method)
-                sentry_sdk.capture_exception(e)
-                grpc_context.abort(grpc.StatusCode.INTERNAL, UNKNOWN_ERROR_MESSAGE)
+            call = admit_call(self._pool, handler_call_details)
+
+            if isinstance(call, RejectedCall):
+                if call.exception:
+                    observe_in_servicer_setup_errors_counter(method, type(call.exception).__name__)
+                    sentry_sdk.set_tag("context", "servicer_setup")
+                    sentry_sdk.set_tag("method", method)
+                    sentry_sdk.capture_exception(call.exception)
+                grpc_context.abort(call.code, call.message)
+
+            observe_in_servicer_setup_histogram(method, read_perf())
 
             headers = call.headers
             auth_info = call.auth_info
@@ -448,64 +487,42 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                 session.connection()
                 observe_in_servicer_pool_wait_histogram(method, (perf_counter_ns() - pool_wait_start) / 1e9)
                 start_perf()
+
+                res: Message | None = None
+                exception: Exception | None = None
                 try:
                     _res = prev_function(req, couchers_context, session)  # type: ignore[call-arg, arg-type]
-                    res = cast(Message, _res)
                     # flush so pending ORM writes execute (and are counted) before we snapshot; a handler that only
                     # session.add(...)s and returns would otherwise flush at commit, after read_perf()
                     session.flush()
-                    perf = read_perf()
-                    finished = perf_counter_ns()
-                    duration = (finished - start) / 1e6  # ms
-                    _store_log(
-                        method=method,
-                        duration=duration,
-                        user_id=couchers_context._user_id,
-                        is_api_key=cast(bool, couchers_context._is_api_key),
-                        request=req,
-                        response=res,
-                        perf=perf,
-                        client_platform=headers.client_platform,
-                        ip_address=headers.ip_address,
-                        user_agent=headers.user_agent,
-                        sofa=sofa,
-                    )
-                    observe_in_servicer_duration_histogram(method, couchers_context._user_id, "", "", duration / 1000)
-                    observe_api_call(method, headers.client_platform)
-                    observe_in_servicer_perf_histograms(method, perf)
+                    res = cast(Message, _res)
                 except Exception as e:
-                    perf = read_perf()
-                    finished = perf_counter_ns()
-                    duration = (finished - start) / 1e6  # ms
+                    exception = e
 
-                    if couchers_context._grpc_context:
-                        context_code = couchers_context._grpc_context.code()  # type: ignore[attr-defined]
-                        code = getattr(context_code, "name", None)
-                    else:
-                        code = None
+                perf = read_perf()
 
-                    traceback = "".join(format_exception(type(e), e, e.__traceback__))
-                    _store_log(
-                        method=method,
-                        status_code=code,
-                        duration=duration,
-                        user_id=couchers_context._user_id,
-                        is_api_key=cast(bool, couchers_context._is_api_key),
-                        request=req,
-                        response=None,
-                        traceback=traceback,
-                        perf=perf,
-                        client_platform=headers.client_platform,
-                        ip_address=headers.ip_address,
-                        user_agent=headers.user_agent,
-                        sofa=sofa,
-                    )
-                    observe_in_servicer_duration_histogram(
-                        method, couchers_context._user_id, code or "", type(e).__name__, duration / 1000
-                    )
-                    observe_api_call(method, headers.client_platform)
-                    observe_in_servicer_perf_histograms(method, perf)
+                if exception and couchers_context._grpc_context:
+                    context_code = couchers_context._grpc_context.code()  # type: ignore[attr-defined]
+                    code = getattr(context_code, "name", None)
+                else:
+                    code = None
 
+                _log_call(
+                    method=method,
+                    status_code=code,
+                    user_id=couchers_context._user_id,
+                    is_api_key=cast(bool, couchers_context._is_api_key),
+                    sofa=sofa,
+                    headers=headers,
+                    start=start,
+                    perf=perf,
+                    request=req,
+                    response=res,
+                    exception=exception,
+                )
+                observe_in_servicer_perf_histograms(method, perf)
+
+                if exception:
                     if not code:
                         sentry_sdk.set_tag("context", "servicer")
                         sentry_sdk.set_tag("method", method)
@@ -518,9 +535,9 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                                 "sofa": sofa[:12],
                             }
                         )
-                        sentry_sdk.capture_exception(e)
+                        sentry_sdk.capture_exception(exception)
 
-                    raise e
+                    raise exception
 
             if auth_info and not auth_info.is_api_key:
                 # check the two cookies are in sync & that language preference cookie is correct
@@ -559,18 +576,6 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         )
 
 
-@dataclass(frozen=True, slots=True, kw_only=True)
-class CouchersHeaders:
-    token: str | None = field(repr=False)
-    is_api_key: bool
-    ip_address: str | None
-    user_agent: str | None
-    client_platform: ClientPlatform | None
-    ui_lang: str | None
-    user_id: str | None
-    sofa: str | None
-
-
 def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:
     if "cookie" in headers and "authorization" in headers:
         # for security reasons, only one of "cookie" or "authorization" can be present
@@ -601,14 +606,14 @@ def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:
     sofa = parse_sofa_cookie(headers)
 
     return CouchersHeaders(
+        user_id=user_id,
         token=token,
+        sofa=sofa,
         is_api_key=is_api_key,
         ip_address=ip_address if isinstance(ip_address, str) else None,
         user_agent=user_agent if isinstance(user_agent, str) else None,
         client_platform=client_platform,
         ui_lang=ui_lang,
-        user_id=user_id,
-        sofa=sofa,
     )
 
 

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -81,9 +81,12 @@ class UserAuthInfo:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class CouchersHeaders:
-    user_id: str | None
+    # the user id cookie: client-supplied and unauthenticated, only good for spotting a desynced cookie
+    user_id_str: str | None
     token: str | None = field(repr=False)
     sofa: str | None
+    # which mechanism the token came in on, not whether it authenticated: a bad key still reads True here, while
+    # the context's is_api_key is False whenever there's no session at all
     is_api_key: bool
     ip_address: str | None
     user_agent: str | None
@@ -541,7 +544,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
 
             if auth_info and not auth_info.is_api_key:
                 # check the two cookies are in sync & that language preference cookie is correct
-                if headers.user_id != str(auth_info.user_id):
+                if headers.user_id_str != str(auth_info.user_id):
                     couchers_context.set_cookies(
                         create_session_cookies(auth_info.token, auth_info.user_id, auth_info.token_expiry)
                     )
@@ -602,11 +605,11 @@ def parse_headers(headers: Mapping[str, str | bytes]) -> CouchersHeaders:
     )
 
     ui_lang = parse_ui_lang_cookie(headers)
-    user_id = parse_user_id_cookie(headers)
+    user_id_str = parse_user_id_cookie(headers)
     sofa = parse_sofa_cookie(headers)
 
     return CouchersHeaders(
-        user_id=user_id,
+        user_id_str=user_id_str,
         token=token,
         sofa=sofa,
         is_api_key=is_api_key,

--- a/app/backend/src/couchers/perf.py
+++ b/app/backend/src/couchers/perf.py
@@ -7,7 +7,7 @@ from sqlalchemy import Engine, event
 # Per-request resource accounting. The gRPC server is thread-per-request with synchronous psycopg, so the SQLAlchemy
 # cursor-execute listeners fire on the same thread that runs the handler. We keep a thread-local accumulator that the
 # interceptor arms (start_perf) right before invoking the handler and reads back (read_perf) right after, so the
-# captured numbers cover the handler span only (not auth lookup or the _store_log insert that runs afterwards).
+# captured numbers cover the handler span only (not auth lookup or the _log_call insert that runs afterwards).
 
 _local = threading.local()
 
@@ -36,7 +36,7 @@ def start_perf() -> None:
 def read_perf() -> PerfResult | None:
     """Snapshot and clear the current thread's accumulator, or None if accounting wasn't armed.
 
-    Clearing means queries that run after this (e.g. the _store_log insert, or background work reusing the thread)
+    Clearing means queries that run after this (e.g. the _log_call insert, or background work reusing the thread)
     aren't attributed to the just-finished request.
     """
     acc: _PerfAccumulator | None = getattr(_local, "acc", None)

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -917,7 +917,7 @@ def test_parse_headers_with_all_optional_headers():
     assert result.ip_address == "192.168.1.1"
     assert result.user_agent == "TestAgent/1.0"
     assert result.ui_lang == "en"
-    assert result.user_id == "42"
+    assert result.user_id_str == "42"
 
 
 def test_parse_headers_with_bytes_ip_address():


### PR DESCRIPTION
The gRPC interceptor writes an `api_calls` row and a handful of Prometheus observations for every call, and does the auth and per-call setup that decides whether a call runs at all. Both grew in place: the logging was duplicated between the arm where the servicer returned and the arm where it raised, and setup signalled a turned-away call by raising a private exception for the interceptor to catch two frames up. Neither reads well, and both are awkward to extend.

Three things change, with no change in behaviour. `CouchersHeaders` moves up beside the other call-scoped types, its fields in a readable order. `_store_log` becomes `_log_call`, taking the headers and the call's start time rather than values picked out of them, and working out the duration, the traceback and the observations itself — so the two arms of the servicer call collapse into one call site. And `admit_call` returns either an admitted call or a rejected one instead of raising.

A follow-up will use this to record the calls that are rejected before a servicer runs, which are currently missing from `api_calls` entirely.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._