### PR TITLE
Log API calls rejected before the handler runs

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -303,8 +303,8 @@ def _log_call(
     nonexistent_method: bool = False,
 ) -> None:
     """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
-    metric_method = NONEXISTENT_METHOD_LABEL if nonexistent_method else method
     duration = (perf_counter_ns() - start) / 1e6  # ms
+    metric_method = NONEXISTENT_METHOD_LABEL if nonexistent_method else method
 
     req_bytes = _sanitized_bytes(request)
     res_bytes = _sanitized_bytes(response)

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -541,12 +541,12 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             call = admit_call(self._pool, handler_call_details)
 
             if isinstance(call, RejectedCall):
+                # anything unexpected goes to Sentry before the row below: if the DB is what's broken, that fails too
                 if call.exception:
                     observe_in_servicer_setup_errors_counter(method, type(call.exception).__name__)
                     sentry_sdk.set_tag("context", "servicer_setup")
                     sentry_sdk.set_tag("method", method)
                     sentry_sdk.capture_exception(call.exception)
-                # anything unexpected is reported to Sentry first: if the DB is what's broken, logging fails too
                 _log_rejected_call(
                     method=method,
                     code=call.code,

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -63,6 +63,9 @@ from couchers.utils import (
 
 logger = logging.getLogger(__name__)
 
+# the prometheus label shared by all calls to methods that don't exist
+NONEXISTENT_METHOD_LABEL = "<nonexistent>"
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class UserAuthInfo:
@@ -291,14 +294,16 @@ def _log_call(
     user_id: int | None,
     is_api_key: bool,
     sofa: str | None,
-    headers: CouchersHeaders,
+    headers: CouchersHeaders | None,
     start: int,
     perf: PerfResult | None,
-    request: Message,
-    response: Message | None,
-    exception: Exception | None,
+    request: Message | None = None,
+    response: Message | None = None,
+    exception: Exception | None = None,
+    nonexistent_method: bool = False,
 ) -> None:
     """Record a finished call: one api_calls row, plus the per-call Prometheus observations."""
+    metric_method = NONEXISTENT_METHOD_LABEL if nonexistent_method else method
     duration = (perf_counter_ns() - start) / 1e6  # ms
 
     req_bytes = _sanitized_bytes(request)
@@ -327,18 +332,74 @@ def _log_call(
                 db_write_query_count=perf.db_write_query_count if perf else None,
                 db_time_ms=perf.db_time_ms if perf else None,
                 cpu_ms=perf.cpu_ms if perf else None,
-                client_platform=headers.client_platform,
-                ip_address=headers.ip_address,
-                user_agent=headers.user_agent,
+                client_platform=headers.client_platform if headers else None,
+                ip_address=headers.ip_address if headers else None,
+                user_agent=headers.user_agent if headers else None,
                 sofa=sofa,
             )
         )
 
     observe_in_servicer_duration_histogram(
-        method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
+        metric_method, user_id, status_code or "", type(exception).__name__ if exception else "", duration / 1000
     )
-    observe_api_call(method, headers.client_platform)
+    observe_api_call(metric_method, headers.client_platform if headers else None)
     logger.debug(f"{user_id=}, {method=}, {duration=} ms")
+
+
+def _log_rejected_call(
+    *,
+    method: str,
+    code: grpc.StatusCode,
+    start: int,
+    handler_call_details: grpc.HandlerCallDetails,
+    user_id: int | None = None,
+    exception: Exception | None = None,
+    nonexistent_method: bool = False,
+) -> None:
+    """Log a call rejected during auth/setup."""
+    try:
+        headers: CouchersHeaders | None = parse_headers(dict(handler_call_details.invocation_metadata))
+    except BadHeaders:
+        headers = None
+
+    perf = read_perf()
+    _log_call(
+        method=method,
+        status_code=code.name,
+        user_id=user_id,
+        is_api_key=headers.is_api_key if headers else False,
+        sofa=headers.sofa if headers else None,
+        headers=headers,
+        start=start,
+        perf=perf,
+        exception=exception,
+        nonexistent_method=nonexistent_method,
+    )
+    observe_in_servicer_setup_histogram(NONEXISTENT_METHOD_LABEL if nonexistent_method else method, perf)
+
+
+def _rejected_call_handler[T, R](
+    *,
+    method: str,
+    message: str,
+    code: grpc.StatusCode,
+    start: int,
+    handler_call_details: grpc.HandlerCallDetails,
+) -> grpc.RpcMethodHandler[T, R]:
+    """Terminate a call that has no handler to run, logging it from the pool thread rather than the serving one."""
+
+    def f(request: Any, context: grpc.ServicerContext) -> NoReturn:
+        start_perf()
+        _log_rejected_call(
+            method=method,
+            code=code,
+            start=start,
+            handler_call_details=handler_call_details,
+            nonexistent_method=True,
+        )
+        context.abort(code, message)
+
+    return grpc.unary_unary_rpc_method_handler(f)
 
 
 type Cont[T, R] = Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[T, R] | None]
@@ -357,10 +418,11 @@ class AdmittedCall:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class RejectedCall:
-    """What a call that didn't clear setup gets terminated with."""
+    """What a call that didn't clear setup gets terminated and logged with."""
 
     code: grpc.StatusCode
     message: str
+    user_id: int | None
     # set when setup broke rather than turned the call away, so the caller can report it
     exception: Exception | None
 
@@ -369,8 +431,10 @@ def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetai
     """
     Pre-RPC setup handling.
 
-    Never raises: a call that doesn't make it through comes back as a RejectedCall for the caller to terminate.
+    Never raises: a call that doesn't make it through comes back as a RejectedCall carrying whatever setup had
+    resolved before it stopped, so the caller can log the call it never ran.
     """
+    auth_info = None
     try:
         headers = parse_headers(dict(handler_call_details.invocation_metadata))
 
@@ -402,12 +466,22 @@ def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetai
         )
     except BadHeaders:
         return RejectedCall(
-            code=grpc.StatusCode.UNAUTHENTICATED, message=COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE, exception=None
+            code=grpc.StatusCode.UNAUTHENTICATED,
+            message=COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
+            user_id=None,
+            exception=None,
         )
     except CallRejectedError as e:
-        return RejectedCall(code=e.code, message=e.msg, exception=None)
+        return RejectedCall(
+            code=e.code, message=e.msg, user_id=auth_info.user_id if auth_info else None, exception=None
+        )
     except Exception as e:
-        return RejectedCall(code=grpc.StatusCode.INTERNAL, message=UNKNOWN_ERROR_MESSAGE, exception=e)
+        return RejectedCall(
+            code=grpc.StatusCode.INTERNAL,
+            message=UNKNOWN_ERROR_MESSAGE,
+            user_id=auth_info.user_id if auth_info else None,
+            exception=e,
+        )
 
     return AdmittedCall(
         headers=headers,
@@ -452,7 +526,13 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
         # only the handler lookup happens here, the rest waits for the handler thread; see the class docstring
         handler = continuation(handler_call_details)
         if not handler or not (prev_function := handler.unary_unary):
-            return abort_handler(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED)
+            return _rejected_call_handler(
+                method=method,
+                message=NONEXISTENT_API_CALL_ERROR_MESSAGE,
+                code=grpc.StatusCode.UNIMPLEMENTED,
+                start=start,
+                handler_call_details=handler_call_details,
+            )
 
         def function_without_couchers_stuff(req: Message, grpc_context: grpc.ServicerContext) -> Message | None:
             # accounting for the auth/setup phase; the handler re-arms its own below
@@ -466,6 +546,16 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     sentry_sdk.set_tag("context", "servicer_setup")
                     sentry_sdk.set_tag("method", method)
                     sentry_sdk.capture_exception(call.exception)
+                # anything unexpected is reported to Sentry first: if the DB is what's broken, logging fails too
+                _log_rejected_call(
+                    method=method,
+                    code=call.code,
+                    start=start,
+                    handler_call_details=handler_call_details,
+                    user_id=call.user_id,
+                    exception=call.exception,
+                    nonexistent_method=call.code == grpc.StatusCode.UNIMPLEMENTED,
+                )
                 grpc_context.abort(call.code, call.message)
 
             observe_in_servicer_setup_histogram(method, read_perf())

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -63,7 +63,7 @@ from couchers.utils import (
 
 logger = logging.getLogger(__name__)
 
-# the prometheus label shared by all calls to methods that don't exist
+# the prometheus label shared by calls to methods with no servicer registered, whose name is whatever the caller sent
 NONEXISTENT_METHOD_LABEL = "<nonexistent>"
 
 
@@ -554,7 +554,6 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
                     handler_call_details=handler_call_details,
                     user_id=call.user_id,
                     exception=call.exception,
-                    nonexistent_method=call.code == grpc.StatusCode.UNIMPLEMENTED,
                 )
                 grpc_context.abort(call.code, call.message)
 

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -957,9 +957,15 @@ def test_rejected_call_logged_permission_denied(db):
     assert _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED") == hist_before + 1
 
 
-def test_rejected_call_logged_nonexistent_rpc(db):
-    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
-    api_calls_before = _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown")
+def test_rejected_call_logged_service_missing_from_pool(db):
+    """A servicer registered for a service missing from the descriptor pool is our bug, so it keeps its name."""
+    method = "/org.couchers.nonexistent.NA/GetNothing"
+    hist_before = _get_histogram_labels_value(method, "False", "", "UNIMPLEMENTED")
+    api_calls_before = _get_api_call_count(method, "unknown")
+    bucketed_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+    setup_db_before = _get_histogram_count(
+        servicer_setup_db_time_histogram, "couchers_servicer_setup_db_time_seconds_count", method=method
+    )
 
     def TestRpc(request, context, session):
         return empty_pb2.Empty()
@@ -977,26 +983,23 @@ def test_rejected_call_logged_nonexistent_rpc(db):
 
     with session_scope() as session:
         trace = session.execute(select(APICall)).scalar_one()
-        assert trace.method == "/org.couchers.nonexistent.NA/GetNothing"
+        assert trace.method == method
         assert trace.status_code == "UNIMPLEMENTED"
         assert trace.user_id is None
-        # headers are parsed before the method is looked up, so we know who called a method that doesn't exist
+        # headers are parsed before the auth level is looked up, so we know who made the call
         assert trace.ip_address == "1.1.1.1"
         assert trace.user_agent is not None
 
-    # the caller picks the method, so it's bucketed in prometheus instead of becoming a label of its own
-    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
-    assert _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown") == api_calls_before + 1
-    assert _get_histogram_labels_value("/org.couchers.nonexistent.NA/GetNothing", "False", "", "UNIMPLEMENTED") == 0
-    assert _get_api_call_count("/org.couchers.nonexistent.NA/GetNothing", "unknown") == 0
+    # the method is one this server registered, so it's a label of its own rather than bucketed
+    assert _get_histogram_labels_value(method, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_api_call_count(method, "unknown") == api_calls_before + 1
     assert (
         _get_histogram_count(
-            servicer_setup_db_time_histogram,
-            "couchers_servicer_setup_db_time_seconds_count",
-            method="/org.couchers.nonexistent.NA/GetNothing",
+            servicer_setup_db_time_histogram, "couchers_servicer_setup_db_time_seconds_count", method=method
         )
-        == 0
+        == setup_db_before + 1
     )
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == bucketed_before
 
 
 def test_rejected_call_logged_unregistered_method(db):

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -14,6 +14,7 @@ from google.protobuf.descriptor_pool import DescriptorPool
 from sqlalchemy import select, text, update
 
 from couchers.constants import (
+    COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE,
     MISSING_AUTH_LEVEL_ERROR_MESSAGE,
     NONEXISTENT_API_CALL_ERROR_MESSAGE,
     UNKNOWN_ERROR_MESSAGE,
@@ -22,6 +23,7 @@ from couchers.crypto import b64encode, random_hex, simple_encrypt
 from couchers.db import session_scope
 from couchers.descriptor_pool import get_descriptor_pool
 from couchers.interceptors import (
+    NONEXISTENT_METHOD_LABEL,
     BadHeaders,
     CallRejectedError,
     CouchersMiddlewareInterceptor,
@@ -66,6 +68,7 @@ def interceptor_dummy_api(
     request_type=empty_pb2.Empty,
     response_type=empty_pb2.Empty,
     creds=None,
+    call_method_name=None,
 ) -> Generator[Callable[..., Any]]:
     with futures.ThreadPoolExecutor(1) as executor:
         server = grpc.server(executor, interceptors=interceptors)
@@ -86,7 +89,7 @@ def interceptor_dummy_api(
         try:
             with grpc.secure_channel(f"localhost:{port}", creds or grpc.local_channel_credentials()) as channel:
                 yield channel.unary_unary(
-                    f"/{service_name}/{method_name}",
+                    f"/{service_name}/{call_method_name or method_name}",
                     request_serializer=request_type.SerializeToString,
                     response_deserializer=response_type.FromString,
                 )
@@ -494,6 +497,13 @@ def test_setup_phase_exception_observed(db):
 
     assert _get_setup_errors_value(method, "ValueError") == val + 1
 
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "INTERNAL"
+        assert trace.traceback
+        assert "expected only letters" in trace.traceback
+
 
 def test_tracing_interceptor_abort(db):
     val = _get_histogram_labels_value("/org.couchers.auth.Auth/SignupFlow", "False", "Exception", "FAILED_PRECONDITION")
@@ -877,6 +887,189 @@ def test_auth_levels(db):
             call_rpc(empty_pb2.Empty())
         assert err.value.code() == grpc.StatusCode.INTERNAL
         assert err.value.details() == "Internal authentication error."
+
+
+def test_rejected_call_logged_unauthenticated(db):
+    method = "/org.couchers.api.account.Account/GetAccountInfo"
+    hist_before = _get_histogram_labels_value(method, "False", "", "UNAUTHENTICATED")
+    api_calls_before = _get_api_call_count(method, "unknown")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.api.account.Account",
+        method_name="GetAccountInfo",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "UNAUTHENTICATED"
+        assert trace.user_id is None
+        assert not trace.is_api_key
+        # the request is never deserialized on a reject path
+        assert trace.request is None
+        assert trace.response is None
+        assert not trace.traceback
+        assert trace.duration > 0
+
+    assert _get_histogram_labels_value(method, "False", "", "UNAUTHENTICATED") == hist_before + 1
+    assert _get_api_call_count(method, "unknown") == api_calls_before + 1
+
+
+def test_rejected_call_logged_permission_denied(db):
+    """A rejected call from a valid session is attributed to that user."""
+    user, token = generate_user()
+    method = "/org.couchers.admin.Admin/GetUserDetails"
+    hist_before = _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.admin.Admin",
+        method_name="GetUserDetails",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(cookie_auth(token), ("x-couchers-client-platform", "web_mobile")))
+        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == method
+        assert trace.status_code == "PERMISSION_DENIED"
+        assert trace.user_id == user.id
+        assert trace.client_platform == ClientPlatform.web_mobile
+        assert not trace.traceback
+
+        # the same call is also counted in the per-user activity table, so the two agree
+        api_calls = session.execute(select(UserActivity.api_calls).where(UserActivity.user_id == user.id)).scalar_one()
+        assert api_calls == 1
+
+    assert _get_histogram_labels_value(method, "True", "", "PERMISSION_DENIED") == hist_before + 1
+
+
+def test_rejected_call_logged_nonexistent_rpc(db):
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+    api_calls_before = _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.nonexistent.NA",
+        method_name="GetNothing",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.nonexistent.NA/GetNothing"
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert trace.user_id is None
+        # headers are parsed before the method is looked up, so we know who called a method that doesn't exist
+        assert trace.ip_address == "1.1.1.1"
+        assert trace.user_agent is not None
+
+    # the caller picks the method, so it's bucketed in prometheus instead of becoming a label of its own
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_api_call_count(NONEXISTENT_METHOD_LABEL, "unknown") == api_calls_before + 1
+    assert _get_histogram_labels_value("/org.couchers.nonexistent.NA/GetNothing", "False", "", "UNIMPLEMENTED") == 0
+    assert _get_api_call_count("/org.couchers.nonexistent.NA/GetNothing", "unknown") == 0
+    assert (
+        _get_histogram_count(
+            servicer_setup_db_time_histogram,
+            "couchers_servicer_setup_db_time_seconds_count",
+            method="/org.couchers.nonexistent.NA/GetNothing",
+        )
+        == 0
+    )
+
+
+def test_rejected_call_logged_unregistered_method(db):
+    """A method with no servicer registered is terminated by the interceptor itself, and still logged."""
+    hist_before = _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED")
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        call_method_name="NotRegistered",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(("x-couchers-real-ip", "1.1.1.1"),))
+        assert e.value.code() == grpc.StatusCode.UNIMPLEMENTED
+        assert e.value.details() == NONEXISTENT_API_CALL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.auth.Auth/NotRegistered"
+        assert trace.status_code == "UNIMPLEMENTED"
+        assert trace.user_id is None
+        assert trace.ip_address == "1.1.1.1"
+        # no servicer was found, so the request was never deserialized
+        assert trace.request is None
+
+    assert _get_histogram_labels_value(NONEXISTENT_METHOD_LABEL, "False", "", "UNIMPLEMENTED") == hist_before + 1
+    assert _get_histogram_labels_value("/org.couchers.auth.Auth/NotRegistered", "False", "", "UNIMPLEMENTED") == 0
+
+
+def test_rejected_call_logged_missing_auth_level(db):
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(
+        TestRpc,
+        interceptors=[CouchersMiddlewareInterceptor()],
+        service_name="org.couchers.media.Media",
+        method_name="UploadConfirmation",
+    ) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty())
+        assert e.value.code() == grpc.StatusCode.INTERNAL
+        assert e.value.details() == MISSING_AUTH_LEVEL_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.media.Media/UploadConfirmation"
+        assert trace.status_code == "INTERNAL"
+
+
+def test_rejected_call_logged_bad_headers(db):
+    _, token = generate_user()
+
+    def TestRpc(request, context, session):
+        return empty_pb2.Empty()
+
+    with interceptor_dummy_api(TestRpc, interceptors=[CouchersMiddlewareInterceptor()]) as call_rpc:
+        with pytest.raises(grpc.RpcError) as e:
+            call_rpc(empty_pb2.Empty(), metadata=(cookie_auth(token), api_auth(token)))
+        assert e.value.code() == grpc.StatusCode.UNAUTHENTICATED
+        assert e.value.details() == COOKIES_AND_AUTH_HEADER_ERROR_MESSAGE
+
+    with session_scope() as session:
+        trace = session.execute(select(APICall)).scalar_one()
+        assert trace.method == "/org.couchers.auth.Auth/SignupFlow"
+        assert trace.status_code == "UNAUTHENTICATED"
+        assert trace.user_id is None
+        # the headers couldn't be parsed, so nothing is known about the client
+        assert trace.ip_address is None
+        assert trace.user_agent is None
 
 
 def test_parse_headers_with_session_cookie():


### PR DESCRIPTION
Stacked on #9573, which it needs to merge first.

Every call that reaches a servicer gets an `api_calls` row and a set of Prometheus observations. A call turned away before that — bad headers, no such method, no session, insufficient permissions — got neither, so only the client ever knew it happened. That makes a user reporting errors impossible to corroborate from the server side, and hides a probing or misconfigured client completely.

Rejected calls are now recorded like any other, carrying the status code they were rejected with and no request or response body. Calls naming a method that has no servicer registered are terminated by the interceptor itself and logged the same way, from a worker thread rather than the one dispatching calls. Those are counted under a single Prometheus label rather than the method name they carry, which is whatever the caller chose to send; the `api_calls` row still records it verbatim.

The duration on these rows is measured from the same point as a normal call, so for a rejected one it includes the wait for a worker thread.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._