### PR TITLE
Write session and activity accounting in one statement

### DIFF
--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -172,10 +172,9 @@ def _try_get_and_update_user_details(
             client_platform=client_platform,
             api_calls=1,
         )
-        # all three writes go out as one statement: every concurrent call from a session contends for the same
-        # sessions row (and the same user_activity row), and splitting them held that lock across two more round
-        # trips plus the commit. add_cte fixes the order, so everyone locks the same way round and the users
-        # lookup, which contends with nothing, happens before we take the sessions row
+        # one statement, so the sessions and user_activity row locks that every concurrent call from the same
+        # session queues on are held for a single round trip. add_cte fixes the order: everyone locks the same
+        # way round, and the uncontended users lookup happens before we take the sessions row
         session.execute(
             insert_stmt.on_conflict_do_update(
                 index_elements=[

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -173,8 +173,8 @@ def _try_get_and_update_user_details(
             api_calls=1,
         )
         # one statement, so the sessions and user_activity row locks that every concurrent call from the same
-        # session queues on are held for a single round trip. add_cte fixes the order: everyone locks the same
-        # way round, and the uncontended users lookup happens before we take the sessions row
+        # session queues on are held for a single round trip. postgres leaves the order it applies the CTEs in
+        # undefined, but every caller runs this same statement, so they all take those locks the same way round
         session.execute(
             insert_stmt.on_conflict_do_update(
                 index_elements=[

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -144,14 +144,6 @@ def _try_get_and_update_user_details(
 
         user, user_session, is_jailed = result._tuple()
 
-        # let's update the token
-        touch_session = (
-            update(UserSession)
-            .where(UserSession.token == token)
-            .values(last_seen=func.now(), api_calls=UserSession.api_calls + 1)
-            .cte("touch_session")
-        )
-
         # update user last active time if it's been a while; a non-matching UPDATE takes no row lock, so this
         # costs nothing on the calls that don't move it
         touch_user = (
@@ -160,6 +152,14 @@ def _try_get_and_update_user_details(
             .where(User.last_active < func.now() - literal_column("interval '5 minutes'"))
             .values(last_active=func.now())
             .cte("touch_user")
+        )
+
+        # let's update the token
+        touch_session = (
+            update(UserSession)
+            .where(UserSession.token == token)
+            .values(last_seen=func.now(), api_calls=UserSession.api_calls + 1)
+            .cte("touch_session")
         )
 
         # upsert so concurrent requests for the same activity tuple don't race to insert and violate the index
@@ -174,7 +174,8 @@ def _try_get_and_update_user_details(
         )
         # all three writes go out as one statement: every concurrent call from a session contends for the same
         # sessions row (and the same user_activity row), and splitting them held that lock across two more round
-        # trips plus the commit. add_cte keeps them in a fixed order, so the lock order is the same for everyone
+        # trips plus the commit. add_cte fixes the order, so everyone locks the same way round and the users
+        # lookup, which contends with nothing, happens before we take the sessions row
         session.execute(
             insert_stmt.on_conflict_do_update(
                 index_elements=[
@@ -190,7 +191,7 @@ def _try_get_and_update_user_details(
                         insert_stmt.excluded.client_platform, UserActivity.client_platform
                     ),
                 },
-            ).add_cte(touch_session, touch_user)
+            ).add_cte(touch_user, touch_session)
         )
 
         # build before committing to avoid expire_on_commit reloading these attributes

--- a/app/backend/src/couchers/interceptors.py
+++ b/app/backend/src/couchers/interceptors.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import cache
 from os import getpid
 from threading import get_ident
@@ -17,7 +17,7 @@ from google.protobuf.descriptor import Descriptor
 from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 from opentelemetry import trace
-from sqlalchemy import Function, literal_column, select
+from sqlalchemy import Function, literal_column, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import undefer
 from sqlalchemy.sql import func
@@ -56,7 +56,6 @@ from couchers.utils import (
     create_lang_cookie,
     create_session_cookies,
     generate_sofa_cookie,
-    now,
     parse_api_key,
     parse_session_cookie,
     parse_sofa_cookie,
@@ -145,13 +144,23 @@ def _try_get_and_update_user_details(
 
         user, user_session, is_jailed = result._tuple()
 
-        # update user last active time if it's been a while
-        if now() - user.last_active > timedelta(minutes=5):
-            user.last_active = func.now()
-
         # let's update the token
-        user_session.last_seen = func.now()
-        user_session.api_calls += 1
+        touch_session = (
+            update(UserSession)
+            .where(UserSession.token == token)
+            .values(last_seen=func.now(), api_calls=UserSession.api_calls + 1)
+            .cte("touch_session")
+        )
+
+        # update user last active time if it's been a while; a non-matching UPDATE takes no row lock, so this
+        # costs nothing on the calls that don't move it
+        touch_user = (
+            update(User)
+            .where(User.id == user.id)
+            .where(User.last_active < func.now() - literal_column("interval '5 minutes'"))
+            .values(last_active=func.now())
+            .cte("touch_user")
+        )
 
         # upsert so concurrent requests for the same activity tuple don't race to insert and violate the index
         insert_stmt = pg_insert(UserActivity).values(
@@ -163,6 +172,9 @@ def _try_get_and_update_user_details(
             client_platform=client_platform,
             api_calls=1,
         )
+        # all three writes go out as one statement: every concurrent call from a session contends for the same
+        # sessions row (and the same user_activity row), and splitting them held that lock across two more round
+        # trips plus the commit. add_cte keeps them in a fixed order, so the lock order is the same for everyone
         session.execute(
             insert_stmt.on_conflict_do_update(
                 index_elements=[
@@ -178,7 +190,7 @@ def _try_get_and_update_user_details(
                         insert_stmt.excluded.client_platform, UserActivity.client_platform
                     ),
                 },
-            )
+            ).add_cte(touch_session, touch_user)
         )
 
         # build before committing to avoid expire_on_commit reloading these attributes


### PR DESCRIPTION
Every authenticated API call updates some bookkeeping as part of authentication: it stamps the session's last-seen time and call count, moves the user's last-active time along if it has gone stale, and rolls up an entry in `user_activity`. Those three writes each went to Postgres separately, holding locks on rows that every concurrent call from the same session wants, across the round trips in between and the commit that follows. They now go out as one statement, using data-modifying CTEs in a fixed order.

The check for whether a user's last-active time is stale enough to move moves into SQL along with it, so it is no longer read into Python and decided there.

## Testing

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._