### PR TITLE
Stop the slowest backend tests doing work they don't need to

### DIFF
--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import re
 from collections.abc import Generator
+from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -24,6 +25,7 @@ from couchers import experimentation  # noqa: E402
 from couchers.config import config  # noqa: E402
 from couchers.db import _get_base_engine  # noqa: E402
 from couchers.models import Base  # noqa: E402
+from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS  # noqa: E402
 from tests.fixtures import query_log  # noqa: E402
 from tests.fixtures.db import (  # noqa: E402
     autocommit_engine,
@@ -411,6 +413,19 @@ def feature_flags(monkeypatch) -> FeatureFlags:
     # Switch to GrowthBook mode (empty override path).
     monkeypatch.setitem(config, "FEATURE_FLAGS_FILE_OVERRIDE_PATH", "")
     return FeatureFlags(features)
+
+
+@pytest.fixture
+def low_rate_limits(monkeypatch) -> None:
+    """
+    Shrinks every rate limit so a test can walk past it in a handful of calls.
+
+    The production limits run up to 150 actions, and a test that has to exceed one spends most of its
+    time creating the users to act on. The tests read the limits out of the definitions, so they pick
+    these up without knowing they've been lowered.
+    """
+    for action, definition in list(RATE_LIMIT_DEFINITIONS.items()):
+        monkeypatch.setitem(RATE_LIMIT_DEFINITIONS, action, replace(definition, warning_limit=3, hard_limit=6))
 
 
 @pytest.fixture

--- a/app/backend/src/tests/test_account.py
+++ b/app/backend/src/tests/test_account.py
@@ -469,7 +469,7 @@ def test_ChangeEmailV2_wrong_token(db, fast_passwords):
         assert user_updated.email == user.email
 
 
-def test_ChangeEmailV2_tokens_two_hour_window(db, timewarp: Timewarp):
+def test_ChangeEmailV2_tokens_two_hour_window(db, fast_passwords, timewarp: Timewarp):
     password = random_hex()
     new_email = f"{random_hex()}@couchers.org.invalid"
     user, token = generate_user(hashed_password=hash_password(password))

--- a/app/backend/src/tests/test_api.py
+++ b/app/backend/src/tests/test_api.py
@@ -1118,7 +1118,7 @@ def test_cant_friend_request_incomplete_profile(db):
         api.SendFriendRequest(api_pb2.SendFriendRequestReq(user_id=user1.id))
 
 
-def test_excessive_friend_requests_are_reported(db, email_collector: EmailCollector):
+def test_excessive_friend_requests_are_reported(db, low_rate_limits, email_collector: EmailCollector):
     """Test that excessive friend requests are first reported in a warning email and finally lead blocking of further requests."""
     user, token = generate_user()
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.friend_request]

--- a/app/backend/src/tests/test_communities.py
+++ b/app/backend/src/tests/test_communities.py
@@ -1264,7 +1264,7 @@ def test_LeaveCommunity_regression(db):
         assert not api.GetCommunity(communities_pb2.GetCommunityReq(community_id=c2_id)).member
 
 
-def test_enforce_community_memberships_for_user(testing_communities):
+def test_enforce_community_memberships_for_user(testing_communities, fast_passwords):
     """
     Make sure the user is added to the right communities on signup
     """

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -822,7 +822,7 @@ def test_send_direct_message(db, moderator: Moderator, push_collector: PushColle
         assert messages[0].author_user_id == user1.id
 
 
-def test_excessive_chat_initiations_are_reported(db, email_collector: EmailCollector):
+def test_excessive_chat_initiations_are_reported(db, low_rate_limits, email_collector: EmailCollector):
     """Test that excessive chat initiations are first reported in a warning email and finally lead blocking of further contacting other users."""
     user, token = generate_user()
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.chat_initiation]
@@ -865,7 +865,7 @@ def test_excessive_chat_initiations_are_reported(db, email_collector: EmailColle
         assert "The user has been blocked from sending further chat initiations for now." in email.plain
 
 
-def test_send_direct_message_rate_limit(db, moderator, email_collector: EmailCollector):
+def test_send_direct_message_rate_limit(db, low_rate_limits, moderator, email_collector: EmailCollector):
     """SendDirectMessage should enforce the chat_initiation rate limit when creating a new DM, but not when sending into an existing one."""
     user, token = generate_user(complete_profile=True)
     rate_limit_definition = RATE_LIMIT_DEFINITIONS[RateLimitAction.chat_initiation]

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -20,6 +20,7 @@ from couchers.models import (
 )
 from couchers.proto import api_pb2, conversations_pb2, notification_data_pb2, notifications_pb2
 from couchers.rate_limits.definitions import RATE_LIMIT_DEFINITIONS, RATE_LIMIT_HOURS
+from couchers.servicers import conversations
 from couchers.utils import Duration_from_timedelta, now, to_aware_datetime
 from tests.fixtures.db import generate_user, make_friends, make_user_block, make_user_invisible
 from tests.fixtures.misc import EmailCollector, Moderator, PushCollector, process_jobs
@@ -1899,7 +1900,7 @@ def test_rejoined_group_chat_archived_filter_reads_newest_subscription(db, moder
         assert not listed.is_archived
 
 
-def test_regression_ListGroupChats_pagination(db, moderator):
+def test_regression_ListGroupChats_pagination(db, moderator, monkeypatch):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     user3, token3 = generate_user()
@@ -1907,10 +1908,14 @@ def test_regression_ListGroupChats_pagination(db, moderator):
     make_friends(user1, user2)
     make_friends(user1, user3)
 
+    # two full pages and a partial one, which is the shape that lost chats, without paying for a
+    # chat per row of a production-sized page
+    monkeypatch.setattr(conversations, "DEFAULT_PAGINATION_LENGTH", 3)
+
     with conversations_session(token1) as c:
         # tuples of (group_chat_id, message_id)
         group_chat_and_message_ids = []
-        for i in range(50):
+        for i in range(7):
             res1 = c.CreateGroupChat(
                 conversations_pb2.CreateGroupChatReq(
                     recipient_user_ids=[user2.id, user3.id], title=wrappers_pb2.StringValue(value=f"Chat {i}")
@@ -1926,15 +1931,18 @@ def test_regression_ListGroupChats_pagination(db, moderator):
 
         seen_group_chat_ids = []
 
+        pages = 0
         last_message_id = 0
         more = True
         while more:
             res = c.ListGroupChats(conversations_pb2.ListGroupChatsReq(last_message_id=last_message_id))
             last_message_id = res.last_message_id
             more = not res.no_more
+            pages += 1
 
             seen_group_chat_ids.extend([chat.group_chat_id for chat in res.group_chats])
 
+        assert pages == 3, "The chats didn't come back over several pages, so nothing was paginated"
         assert set(seen_group_chat_ids) == {x[0] for x in group_chat_and_message_ids}, "Not all group chats returned"
 
 

--- a/app/backend/src/tests/test_dummy_data.py
+++ b/app/backend/src/tests/test_dummy_data.py
@@ -6,7 +6,7 @@ from couchers.resources import copy_resources_to_database
 from dummy_data import add_dummy_data
 
 
-def test_add_dummy_data(db, caplog, testconfig):
+def test_add_dummy_data(db, caplog, testconfig, fast_passwords):
     # copy the real resources to the database: this way if the testing resources go out of date with the real ones
     # causing dummy data to fail, we'll catch it easily
     with session_scope() as session:

--- a/app/backend/src/tests/test_requests.py
+++ b/app/backend/src/tests/test_requests.py
@@ -453,7 +453,7 @@ def test_create_request_incomplete_profile(db):
     assert e.value.details() == "You have to complete your profile before you can send a request."
 
 
-def test_excessive_requests_are_reported(db, email_collector: EmailCollector):
+def test_excessive_requests_are_reported(db, low_rate_limits, email_collector: EmailCollector):
     """Test that excessive host requests are first reported in a warning email and finally lead blocking of further requests."""
     user, token = generate_user()
     today_plus_2 = today() + timedelta(days=2)

--- a/app/backend/src/tests/test_search.py
+++ b/app/backend/src/tests/test_search.py
@@ -24,46 +24,58 @@ def _(testconfig):
     pass
 
 
-def test_Search(testing_communities):
-    user, token = generate_user()
-    with search_session(token) as api:
-        res = api.Search(
-            search_pb2.SearchReq(
-                query="Country 1, Region 1",
-                include_users=True,
-                include_communities=True,
-                include_groups=True,
-                include_places=True,
-                include_guides=True,
+class TestSearchInCommunities:
+    """The tests that search the whole community tree, grouped so they share one copy of it."""
+
+    @staticmethod
+    def test_Search(testing_communities):
+        user, token = generate_user()
+        with search_session(token) as api:
+            res = api.Search(
+                search_pb2.SearchReq(
+                    query="Country 1, Region 1",
+                    include_users=True,
+                    include_communities=True,
+                    include_groups=True,
+                    include_places=True,
+                    include_guides=True,
+                )
             )
-        )
-        res = api.Search(
-            search_pb2.SearchReq(
-                query="Country 1, Region 1, Attraction",
-                title_only=True,
-                include_users=True,
-                include_communities=True,
-                include_groups=True,
-                include_places=True,
-                include_guides=True,
+            res = api.Search(
+                search_pb2.SearchReq(
+                    query="Country 1, Region 1, Attraction",
+                    title_only=True,
+                    include_users=True,
+                    include_communities=True,
+                    include_groups=True,
+                    include_places=True,
+                    include_guides=True,
+                )
             )
-        )
 
+    @staticmethod
+    def test_UserSearch(testing_communities):
+        """Test that UserSearch returns all users if no filter is set."""
+        user, token = generate_user()
 
-def test_UserSearch(testing_communities):
-    """Test that UserSearch returns all users if no filter is set."""
-    user, token = generate_user()
+        refresh_materialized_views_rapid(empty_pb2.Empty())
+        refresh_materialized_views(empty_pb2.Empty())
 
-    refresh_materialized_views_rapid(empty_pb2.Empty())
-    refresh_materialized_views(empty_pb2.Empty())
+        with search_session(token) as api:
+            res = api.UserSearch(search_pb2.UserSearchReq())
+            assert len(res.results) > 0
+            assert res.total_items == len(res.results)
+            res = api.UserSearchV2(search_pb2.UserSearchReq())
+            assert len(res.results) > 0
+            assert res.total_items == len(res.results)
 
-    with search_session(token) as api:
-        res = api.UserSearch(search_pb2.UserSearchReq())
-        assert len(res.results) > 0
-        assert res.total_items == len(res.results)
-        res = api.UserSearchV2(search_pb2.UserSearchReq())
-        assert len(res.results) > 0
-        assert res.total_items == len(res.results)
+    @staticmethod
+    def test_EventSearch_no_filters(testing_communities):
+        """Test that EventSearch returns all events if no filter is set."""
+        user, token = generate_user()
+        with search_session(token) as api:
+            res = api.EventSearch(search_pb2.EventSearchReq())
+            assert len(res.events) > 0
 
 
 def test_regression_search_in_area(db):
@@ -436,14 +448,6 @@ def sample_community(db) -> int:
     user, _ = generate_user()
     with session_scope() as session:
         return create_community(session, -50, 50, "Community", [user], [], None).id
-
-
-def test_EventSearch_no_filters(testing_communities):
-    """Test that EventSearch returns all events if no filter is set."""
-    user, token = generate_user()
-    with search_session(token) as api:
-        res = api.EventSearch(search_pb2.EventSearchReq())
-        assert len(res.events) > 0
 
 
 def test_event_search_by_query(sample_community, create_event):


### PR DESCRIPTION
A handful of backend tests are slow because of how they are set up rather than what they cover. The four rate limit tests reach the warning and hard thresholds by really performing that many actions — the chat initiation limits are 15 and 150, so two of them create around 150 users apiece just to have someone to message; three more sign up or change a password without the `fast_passwords` fixture and pay for real argon2 hashing at roughly 310ms a call; the three search tests that want a whole community tree each build their own copy of it; and the `ListGroupChats` pagination regression test creates 50 chats to get past a page size of 20. This lowers the limits and the page size for the tests that have to exceed them, applies `fast_passwords` where it was missing, and shares one community tree between the search tests, taking those tests from about 21 seconds to under 3.

This is independent of #9577, which speeds the same suite up elsewhere and also touches the tests conftest.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._