### PR TITLE
Freeze the clock in the tests that bound a timestamp

### DIFF
--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -51,7 +51,7 @@ def test_create_discussion_errors(db):
         assert e.value.details() == "Missing discussion content."
 
 
-def test_create_and_get_discussion(db, push_collector: PushCollector, moderator: Moderator):
+def test_create_and_get_discussion(db, frozen_timewarp, push_collector: PushCollector, moderator: Moderator):
     generate_user()
     user, token = generate_user()
     user2, token2 = generate_user()
@@ -459,7 +459,7 @@ def test_admin_delete_discussion(db):
         assert res.deleted
 
 
-def test_discussion_notifications_regression(db, push_collector: PushCollector, moderator: Moderator):
+def test_discussion_notifications_regression(db, frozen_timewarp, push_collector: PushCollector, moderator: Moderator):
     generate_user()
     user, token = generate_user()
     user2, token2 = generate_user()

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -31,6 +31,7 @@ from couchers.utils import datetime_to_iso8601_local, now, to_aware_datetime
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import EmailCollector, Moderator, PushCollector, process_jobs
 from tests.fixtures.sessions import events_session, real_editor_session, threads_session
+from tests.fixtures.timewarp import FrozenTimewarp
 from tests.test_communities import create_community, create_group
 
 
@@ -50,7 +51,7 @@ def is_utc_or_gmt(timezone: str) -> bool:
     return timezone in ("Etc/UTC", "Etc/GMT")
 
 
-def test_CreateEvent(db, push_collector: PushCollector, moderator: Moderator):
+def test_CreateEvent(db, frozen_timewarp, push_collector: PushCollector, moderator: Moderator):
     # test cases:
     # can create event
     # cannot create event with missing details
@@ -381,7 +382,7 @@ def test_CreateEvent_incomplete_profile(db):
         assert e.value.details() == "You have to complete your profile before you can create an event."
 
 
-def test_ScheduleEvent(db):
+def test_ScheduleEvent(db, frozen_timewarp):
     # test cases:
     # can schedule a new event occurrence
 
@@ -567,7 +568,7 @@ def test_cannot_overlap_occurrences_update(db):
         assert e.value.details() == "An event cannot have overlapping occurrences."
 
 
-def test_UpdateEvent_single(db, moderator: Moderator):
+def test_UpdateEvent_single(db, frozen_timewarp: FrozenTimewarp, moderator: Moderator):
     # test cases:
     # owner can update
     # community owner can update
@@ -621,6 +622,8 @@ def test_UpdateEvent_single(db, moderator: Moderator):
     with events_session(token6) as api:
         api.SetEventSubscription(events_pb2.SetEventSubscriptionReq(event_id=event_id, subscribe=True))
 
+    # the clock is stopped, so the edit below needs the test to move it on for last_edited to change
+    frozen_timewarp.advance(timedelta(minutes=1))
     time_before_update = now()
 
     with events_session(token1) as api:
@@ -744,7 +747,7 @@ def test_UpdateEvent_single(db, moderator: Moderator):
         assert res.location.lng == 0.02
 
 
-def test_UpdateEvent_all(db, moderator: Moderator):
+def test_UpdateEvent_all(db, frozen_timewarp: FrozenTimewarp, moderator: Moderator):
     # event creator
     user1, token1 = generate_user()
     # community moderator
@@ -819,6 +822,8 @@ def test_UpdateEvent_all(db, moderator: Moderator):
 
     updated_event_id = event_ids[3]
 
+    # the clock is stopped, so the edit below needs the test to move it on for last_edited to change
+    frozen_timewarp.advance(timedelta(minutes=1))
     time_before_update = now()
 
     with events_session(token1) as api:
@@ -1000,7 +1005,7 @@ def test_UpdateEvent_all_cant_change_times(db, moderator: Moderator):
         assert e.value.details() == "You cannot update all events if you're modifying start or end times."
 
 
-def test_GetEvent(db, moderator: Moderator):
+def test_GetEvent(db, frozen_timewarp, moderator: Moderator):
     # event creator
     user1, token1 = generate_user()
     # community moderator

--- a/app/backend/src/tests/test_pages.py
+++ b/app/backend/src/tests/test_pages.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import grpc
 import pytest
 from google.protobuf import wrappers_pb2
@@ -20,6 +22,7 @@ from couchers.proto import pages_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_aware_datetime, to_multi
 from tests.fixtures.db import generate_user
 from tests.fixtures.sessions import pages_session
+from tests.fixtures.timewarp import FrozenTimewarp
 from tests.test_communities import create_community
 
 
@@ -176,7 +179,7 @@ def test_create_guide_errors(db):
         assert e.value.details() == "You need to either supply an address and location or neither for a guide."
 
 
-def test_create_page_place(db):
+def test_create_page_place(db, frozen_timewarp):
     user, token = generate_user()
     with session_scope() as session:
         c_id = create_community(session, 0, 2, "Root node", [user], [], None).id
@@ -214,7 +217,7 @@ def test_create_page_place(db):
         assert res.can_moderate
 
 
-def test_create_page_guide(db):
+def test_create_page_guide(db, frozen_timewarp):
     user, token = generate_user()
     with session_scope() as session:
         c_id = create_community(session, 0, 2, "Root node", [user], [], None).id
@@ -280,7 +283,7 @@ def test_create_page_guide(db):
         assert res.can_moderate
 
 
-def test_get_page(db):
+def test_get_page(db, frozen_timewarp):
     user1, token1 = generate_user()
     user2, token2 = generate_user()
     with session_scope() as session:
@@ -323,7 +326,7 @@ def test_get_page(db):
         assert res.thread.num_responses == 0
 
 
-def test_update_page(db):
+def test_update_page(db, frozen_timewarp: FrozenTimewarp):
     user, token = generate_user()
     with session_scope() as session:
         c_id = create_community(session, 0, 2, "Root node", [user], [], None).id
@@ -342,6 +345,8 @@ def test_update_page(db):
             )
         ).page_id
 
+        # the clock is stopped, so each edit needs the test to move it on for last_edited to change
+        frozen_timewarp.advance(timedelta(minutes=1))
         time_before_update = now()
         api.UpdatePage(
             pages_pb2.UpdatePageReq(
@@ -370,6 +375,7 @@ def test_update_page(db):
         assert res.can_edit
         assert res.can_moderate
 
+        frozen_timewarp.advance(timedelta(minutes=1))
         time_before_second_update = now()
         api.UpdatePage(
             pages_pb2.UpdatePageReq(
@@ -400,6 +406,7 @@ def test_update_page(db):
         assert res.thread.thread_id > 0
         assert res.thread.num_responses == 0
 
+        frozen_timewarp.advance(timedelta(minutes=1))
         time_before_third_update = now()
         api.UpdatePage(
             pages_pb2.UpdatePageReq(
@@ -430,6 +437,7 @@ def test_update_page(db):
         assert res.thread.thread_id > 0
         assert res.thread.num_responses == 0
 
+        frozen_timewarp.advance(timedelta(minutes=1))
         time_before_fourth_update = now()
         api.UpdatePage(
             pages_pb2.UpdatePageReq(


### PR DESCRIPTION
Several tests across pages, discussions and events check that a `created` or `last_edited` timestamp is sane by taking `now()` in python either side of the RPC and asserting the value the database wrote falls between the two. Python reads the host clock and postgres reads the clock in its container, and those drift apart by a millisecond or two, so the assertions fail at random — most recently four in `test_pages` and one in `test_discussions` in the same run. They now run on the `frozen_timewarp` fixture, which stops a clock that both python and postgres read, so the comparison is against the same instant on both sides.

Where a test is checking that an edit moves `last_edited` on from `created`, it advances the frozen clock itself between the two, which makes that assertion exact rather than dependent on how long the RPC happened to take.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._