### PR TITLE
Hold the descriptor pool in a ProtoAnnotations object

### DIFF
--- a/app/backend/src/couchers/middleware/descriptor_pool.py
+++ b/app/backend/src/couchers/middleware/descriptor_pool.py
@@ -10,11 +10,12 @@ def get_descriptors_pb() -> bytes:
         return descriptor_set_f.read()
 
 
-@functools.cache
-def get_descriptor_pool() -> descriptor_pool.DescriptorPool:
+def build_descriptor_pool() -> descriptor_pool.DescriptorPool:
     """
-    Generates a protocol buffer object descriptor pool which allows looking up info about our proto API, such as options
+    Builds a protocol buffer object descriptor pool which allows looking up info about our proto API, such as options
     for each servicer, method, or message.
+
+    Not cached: ProtoAnnotations holds the process-wide pool, see couchers.middleware.proto_annotations.
     """
     # this needs to be imported so the annotations are available in the generated pool...
     from couchers.proto import annotations_pb2  # noqa

--- a/app/backend/src/couchers/middleware/interceptors.py
+++ b/app/backend/src/couchers/middleware/interceptors.py
@@ -11,7 +11,6 @@ from zoneinfo import ZoneInfo
 
 import grpc
 import sentry_sdk
-from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 from opentelemetry import trace
 from sqlalchemy import Function, literal_column, select, update
@@ -41,10 +40,9 @@ from couchers.metrics import (
     observe_in_servicer_setup_errors_counter,
     observe_in_servicer_setup_histogram,
 )
-from couchers.middleware.descriptor_pool import get_descriptor_pool
 from couchers.middleware.errors import CallRejectedError
 from couchers.middleware.perf import PerfResult, read_perf, start_perf
-from couchers.middleware.proto_annotations import find_auth_level
+from couchers.middleware.proto_annotations import get_proto_annotations
 from couchers.middleware.ratelimit import should_rate_limit
 from couchers.middleware.sanitize import sanitized_bytes
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
@@ -366,7 +364,7 @@ class RejectedCall:
     exception: Exception | None
 
 
-def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall | RejectedCall:
+def admit_call(handler_call_details: grpc.HandlerCallDetails) -> AdmittedCall | RejectedCall:
     """
     Pre-RPC setup handling.
 
@@ -380,7 +378,7 @@ def admit_call(pool: DescriptorPool, handler_call_details: grpc.HandlerCallDetai
         # if this is not present in prod, it's a Big Bug in config
         assert config.DEV or headers.ip_address is not None
 
-        auth_level = find_auth_level(pool, handler_call_details.method)
+        auth_level = get_proto_annotations().auth_level(handler_call_details.method)
 
         auth_info = _try_get_and_update_user_details(
             headers.token,
@@ -454,7 +452,8 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
     """
 
     def __init__(self) -> None:
-        self._pool = get_descriptor_pool()
+        # builds the descriptor pool at startup rather than on the first call
+        get_proto_annotations()
 
     def intercept_service[T = Message, R = Message](
         self,
@@ -480,7 +479,7 @@ class CouchersMiddlewareInterceptor(grpc.ServerInterceptor):
             # accounting for the auth/setup phase; the handler re-arms its own below
             start_perf()
 
-            call = admit_call(self._pool, handler_call_details)
+            call = admit_call(handler_call_details)
 
             if isinstance(call, RejectedCall):
                 # anything unexpected goes to Sentry before the row below: if the DB is what's broken, that fails too

--- a/app/backend/src/couchers/middleware/proto_annotations.py
+++ b/app/backend/src/couchers/middleware/proto_annotations.py
@@ -4,9 +4,10 @@ Reading our custom proto annotations (see proto/annotations.proto) off the descr
 Everything that knows how descriptors, service/method options and extensions fit together lives here, so
 callers work in terms of "the auth level for this method" rather than in terms of protobuf machinery.
 
-Lookups are cached on (pool, method), which is bounded because the pool is a process-wide singleton and the
-descriptors fix the set of methods. functools.cache doesn't store exceptions, so a request naming a method
-that doesn't exist raises every time rather than accumulating cache entries.
+The pool is an invariant of ProtoAnnotations rather than an argument threaded through every lookup, and
+get_proto_annotations() is the process-wide instance. Lookups memoize on the instance, which is bounded
+because the descriptors fix the set of methods; failures aren't memoized, so a request naming a method that
+doesn't exist raises every time rather than accumulating entries.
 """
 
 from functools import cache
@@ -21,6 +22,7 @@ from couchers.constants import (
     MISSING_AUTH_LEVEL_ERROR_MESSAGE,
     NONEXISTENT_API_CALL_ERROR_MESSAGE,
 )
+from couchers.middleware.descriptor_pool import build_descriptor_pool
 from couchers.middleware.errors import CallRejectedError
 from couchers.proto import annotations_pb2
 from couchers.proto.annotations_pb2 import AuthLevel
@@ -32,39 +34,9 @@ def split_method(method: str) -> tuple[str, str]:
     return service_name, method_name
 
 
-def find_service(pool: DescriptorPool, service_name: str) -> ServiceDescriptor:
-    try:
-        return cast(ServiceDescriptor, pool.FindServiceByName(service_name))  # type: ignore[no-untyped-call]
-    except KeyError:
-        raise CallRejectedError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None
-
-
-def find_method(pool: DescriptorPool, method: str) -> MethodDescriptor:
-    service_name, method_name = split_method(method)
-    return cast(MethodDescriptor, find_service(pool, service_name).FindMethodByName(method_name))  # type: ignore[no-untyped-call]
-
-
-def service_extension(pool: DescriptorPool, service_name: str, extension: Any) -> Message:
-    """The value of a service-level extension; protobuf returns the default instance when it isn't set."""
-    return cast(Message, find_service(pool, service_name).GetOptions().Extensions[extension])
-
-
-def method_extension(pool: DescriptorPool, method: str, extension: Any) -> Message:
-    """The value of a method-level extension; protobuf returns the default instance when it isn't set."""
-    return cast(Message, find_method(pool, method).GetOptions().Extensions[extension])
-
-
 def optional_field(message: Message, field: str) -> int | None:
     """Read an optional scalar field, honouring proto field presence, so an explicit 0 differs from unset."""
     return getattr(message, field) if message.HasField(field) else None
-
-
-@cache
-def find_auth_level(pool: DescriptorPool, method: str) -> AuthLevel.ValueType:
-    service_name, _ = split_method(method)
-    level = find_service(pool, service_name).GetOptions().Extensions[annotations_pb2.auth_level]
-    validate_auth_level(level)
-    return level
 
 
 def validate_auth_level(auth_level: AuthLevel.ValueType) -> None:
@@ -80,3 +52,43 @@ def validate_auth_level(auth_level: AuthLevel.ValueType) -> None:
         annotations_pb2.AUTH_LEVEL_ADMIN,
     }:
         raise CallRejectedError(MISSING_AUTH_LEVEL_ERROR_MESSAGE, grpc.StatusCode.INTERNAL)
+
+
+class ProtoAnnotations:
+    """The annotations on our API, read off one descriptor pool."""
+
+    def __init__(self, pool: DescriptorPool) -> None:
+        self._pool = pool
+        self._auth_levels: dict[str, AuthLevel.ValueType] = {}
+
+    def _find_service(self, service_name: str) -> ServiceDescriptor:
+        try:
+            return cast(ServiceDescriptor, self._pool.FindServiceByName(service_name))  # type: ignore[no-untyped-call]
+        except KeyError:
+            raise CallRejectedError(NONEXISTENT_API_CALL_ERROR_MESSAGE, grpc.StatusCode.UNIMPLEMENTED) from None
+
+    def _find_method(self, method: str) -> MethodDescriptor:
+        service_name, method_name = split_method(method)
+        return cast(MethodDescriptor, self._find_service(service_name).FindMethodByName(method_name))  # type: ignore[no-untyped-call]
+
+    def service_extension(self, service_name: str, extension: Any) -> Message:
+        """The value of a service-level extension; protobuf returns the default instance when it isn't set."""
+        return cast(Message, self._find_service(service_name).GetOptions().Extensions[extension])
+
+    def method_extension(self, method: str, extension: Any) -> Message:
+        """The value of a method-level extension; protobuf returns the default instance when it isn't set."""
+        return cast(Message, self._find_method(method).GetOptions().Extensions[extension])
+
+    def auth_level(self, method: str) -> AuthLevel.ValueType:
+        if method not in self._auth_levels:
+            service_name, _ = split_method(method)
+            level = self._find_service(service_name).GetOptions().Extensions[annotations_pb2.auth_level]
+            validate_auth_level(level)
+            self._auth_levels[method] = level
+        return self._auth_levels[method]
+
+
+@cache
+def get_proto_annotations() -> ProtoAnnotations:
+    """The process-wide annotations, built off the descriptor set shipped with the backend."""
+    return ProtoAnnotations(build_descriptor_pool())

--- a/app/backend/src/couchers/middleware/ratelimit.py
+++ b/app/backend/src/couchers/middleware/ratelimit.py
@@ -27,8 +27,7 @@ from couchers.metrics import (
     observe_rate_limit_store_error,
     observe_rate_limit_trip,
 )
-from couchers.middleware.descriptor_pool import get_descriptor_pool
-from couchers.middleware.proto_annotations import method_extension, optional_field, service_extension, split_method
+from couchers.middleware.proto_annotations import get_proto_annotations, optional_field, split_method
 from couchers.proto import annotations_pb2
 
 if TYPE_CHECKING:
@@ -67,11 +66,11 @@ def resolve_method_rate_limits(method: str) -> ResolvedLimits:
         # the last value is always a global default, so there is always one to find
         return next(value for value in values if value is not None)
 
-    pool = get_descriptor_pool()
+    annotations = get_proto_annotations()
     service_name, _ = split_method(method)
-    method_rl = method_extension(pool, method, annotations_pb2.rate_limit)
-    service_default = service_extension(pool, service_name, annotations_pb2.rate_limit_default)
-    service_aggregate = service_extension(pool, service_name, annotations_pb2.rate_limit_aggregate)
+    method_rl = annotations.method_extension(method, annotations_pb2.rate_limit)
+    service_default = annotations.service_extension(service_name, annotations_pb2.rate_limit_default)
+    service_aggregate = annotations.service_extension(service_name, annotations_pb2.rate_limit_aggregate)
 
     return ResolvedLimits(
         service_name=service_name,

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -11,13 +11,12 @@ from couchers.context import make_interactive_context
 from couchers.db import session_scope
 from couchers.i18n import LocalizationContext
 from couchers.i18n.locales import DEFAULT_LOCALE
-from couchers.middleware.descriptor_pool import get_descriptor_pool
 from couchers.middleware.interceptors import (
     CouchersMiddlewareInterceptor,
     _try_get_and_update_user_details,
     check_permissions,
 )
-from couchers.middleware.proto_annotations import find_auth_level
+from couchers.middleware.proto_annotations import get_proto_annotations
 from couchers.proto import (
     account_pb2_grpc,
     admin_pb2_grpc,
@@ -187,7 +186,6 @@ class FakeChannel:
         self.handlers: dict[str, Any] = {}
         self._token = token
         self._locale = locale or DEFAULT_LOCALE
-        self._pool = get_descriptor_pool()
 
     def add_generic_rpc_handlers(self, generic_rpc_handlers: Any):
         _validate_generic_rpc_handlers(generic_rpc_handlers)
@@ -206,7 +204,7 @@ class FakeChannel:
                     sofa=None,
                     client_platform=None,
                 )
-            auth_level = find_auth_level(self._pool, method)
+            auth_level = get_proto_annotations().auth_level(method)
             check_permissions(auth_info, auth_level)
 
             # Do a full serialization cycle on the request and the

--- a/app/backend/src/tests/test_interceptors.py
+++ b/app/backend/src/tests/test_interceptors.py
@@ -31,7 +31,6 @@ from couchers.metrics import (
     servicer_setup_db_time_histogram,
     servicer_setup_errors_counter,
 )
-from couchers.middleware.descriptor_pool import get_descriptor_pool
 from couchers.middleware.errors import CallRejectedError
 from couchers.middleware.interceptors import (
     NONEXISTENT_METHOD_LABEL,
@@ -43,7 +42,7 @@ from couchers.middleware.interceptors import (
     check_permissions,
     parse_headers,
 )
-from couchers.middleware.proto_annotations import find_auth_level, validate_auth_level
+from couchers.middleware.proto_annotations import ProtoAnnotations, get_proto_annotations, validate_auth_level
 from couchers.models import APICall, ClientPlatform, User, UserActivity, UserSession
 from couchers.proto import account_pb2, admin_pb2, annotations_pb2, api_pb2, auth_pb2
 from couchers.servicers.account import Account
@@ -1140,23 +1139,19 @@ def test_parse_headers_malformed_authorization():
     assert result.is_api_key is True
 
 
-def test_find_auth_level_with_valid_service():
-    pool = get_descriptor_pool()
-
-    result = find_auth_level(pool, "/org.couchers.api.core.API/GetUser")
+def test_auth_level_with_valid_service():
+    result = get_proto_annotations().auth_level("/org.couchers.api.core.API/GetUser")
     assert result == annotations_pb2.AUTH_LEVEL_SECURE
 
 
-def test_find_auth_level_with_nonexistent_service():
-    pool = get_descriptor_pool()
-
+def test_auth_level_with_nonexistent_service():
     with pytest.raises(CallRejectedError) as exc:
-        find_auth_level(pool, "/org.couchers.nonexistent.Service/Method")
+        get_proto_annotations().auth_level("/org.couchers.nonexistent.Service/Method")
     assert exc.value.msg == NONEXISTENT_API_CALL_ERROR_MESSAGE
     assert exc.value.code == grpc.StatusCode.UNIMPLEMENTED
 
 
-def test_find_auth_level_with_unknown_auth_level():
+def test_auth_level_with_unknown_auth_level():
     pool = Mock(spec=DescriptorPool)
     service_desc = Mock(spec=ServiceDescriptor)
     service_options = Mock()
@@ -1165,7 +1160,7 @@ def test_find_auth_level_with_unknown_auth_level():
     pool.FindServiceByName.return_value = service_desc
 
     with pytest.raises(CallRejectedError) as exc:
-        find_auth_level(pool, "/org.couchers.api.core.API/GetUser")
+        ProtoAnnotations(pool).auth_level("/org.couchers.api.core.API/GetUser")
     assert exc.value.msg == MISSING_AUTH_LEVEL_ERROR_MESSAGE
     assert exc.value.code == grpc.StatusCode.INTERNAL
 


### PR DESCRIPTION
Serving a gRPC call means reading our custom proto annotations — the auth level a servicer requires, the rate limits on an RPC — off a protobuf descriptor pool built from the descriptor set shipped with the backend. Every lookup took that pool as an argument, so a caller that only wanted the auth level for a method first had to get hold of a pool and thread it through, and the interceptor carried one around for no other purpose. The pool now lives inside a `ProtoAnnotations` object, one per process, that callers ask for the annotation they want. No behaviour changes.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
