### PR TITLE
Fix strong verification badge leaking to users with a shared birthdate

### DIFF
--- a/app/backend/src/couchers/materialized_views.py
+++ b/app/backend/src/couchers/materialized_views.py
@@ -153,6 +153,7 @@ def make_lite_users_selectable(create: bool = False) -> Select[Any]:
     strong_verification_subquery = (
         select(User.id, literal(True).label("true"))
         .select_from(StrongVerificationAttempt)
+        .join(User, User.id == StrongVerificationAttempt.user_id)
         .where(StrongVerificationAttempt.has_strong_verification(User))
         .distinct()
         .subquery(name="sv_subquery")

--- a/app/backend/src/couchers/migrations/versions/0183_fix_lite_users_strong_verification.py
+++ b/app/backend/src/couchers/migrations/versions/0183_fix_lite_users_strong_verification.py
@@ -17,8 +17,8 @@ depends_on = None
 
 # the strong verification subquery was missing the join back onto the attempt's own user, so it matched any user
 # sharing a birthdate (and compatible gender) with any strongly verified user; the rest of the definition is unchanged
-# from 0176, so it's shared between upgrade and downgrade with just that FROM clause swapped out
-def _create_lite_users(sv_from: str) -> None:
+# from 0176, so it's shared between upgrade and downgrade with just the attempt-to-user identity swapped out
+def _create_lite_users(sv_from: str, sv_identity: str) -> None:
     op.execute("DROP MATERIALIZED VIEW IF EXISTS lite_users")
     op.execute(f"""
         CREATE MATERIALIZED VIEW lite_users AS
@@ -61,7 +61,7 @@ def _create_lite_users(sv_from: str) -> None:
                 true AS "true"
             FROM {sv_from}
             WHERE
-                ((strong_verification_attempts.status = 'succeeded')
+                ({sv_identity}(strong_verification_attempts.status = 'succeeded')
                 AND COALESCE(timezone('Etc/UTC', strong_verification_attempts.passport_expiry_date::timestamp without time zone) >= now(), false)
                 AND strong_verification_attempts.passport_date_of_birth = users_1.birthdate
                 AND (
@@ -82,9 +82,10 @@ def _create_lite_users(sv_from: str) -> None:
 
 def upgrade() -> None:
     _create_lite_users(
-        "strong_verification_attempts JOIN users users_1 ON users_1.id = strong_verification_attempts.user_id"
+        "strong_verification_attempts JOIN users users_1 ON users_1.id = strong_verification_attempts.user_id",
+        "strong_verification_attempts.user_id = users_1.id AND ",
     )
 
 
 def downgrade() -> None:
-    _create_lite_users("strong_verification_attempts, users users_1")
+    _create_lite_users("strong_verification_attempts, users users_1", "")

--- a/app/backend/src/couchers/migrations/versions/0183_fix_lite_users_strong_verification.py
+++ b/app/backend/src/couchers/migrations/versions/0183_fix_lite_users_strong_verification.py
@@ -1,0 +1,90 @@
+"""Fix lite_users strong verification cross join
+
+Revision ID: 0183
+Revises: 0182
+Create Date: 2026-08-16 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0183"
+down_revision = "0182"
+branch_labels = None
+depends_on = None
+
+
+# the strong verification subquery was missing the join back onto the attempt's own user, so it matched any user
+# sharing a birthdate (and compatible gender) with any strongly verified user; the rest of the definition is unchanged
+# from 0176, so it's shared between upgrade and downgrade with just that FROM clause swapped out
+def _create_lite_users(sv_from: str) -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS lite_users")
+    op.execute(f"""
+        CREATE MATERIALIZED VIEW lite_users AS
+        SELECT
+            users.id,
+            users.username,
+            users.name,
+            users.city,
+            date_part('year', age(users.birthdate)) AS age,
+            users.geom,
+            users.geom_radius AS radius,
+            (users.banned_at IS NULL AND users.deleted_at IS NULL) AS is_visible,
+            users.shadowed_at,
+            uploads.filename AS avatar_filename,
+            ((users.profile_gallery_id IS NOT NULL)
+                AND EXISTS (SELECT 1 AS anon_1 FROM photo_gallery_items WHERE photo_gallery_items.gallery_id = users.profile_gallery_id)
+                AND users.about_me_length >= 150) AS has_completed_profile,
+            ((users.max_guests IS NOT NULL) AND (users.sleeping_arrangement IS NOT NULL) AND ((users.about_place IS NOT NULL) OR (users.other_host_info IS NOT NULL) OR (users.sleeping_details IS NOT NULL) OR (users.area IS NOT NULL) OR (users.house_rules IS NOT NULL))) AS has_completed_my_home,
+            COALESCE(sv_subquery."true", false) AS has_strong_verification,
+            CAST(json_build_object(
+                'type', 'Feature',
+                'geometry', CAST(ST_AsGeoJSON(users.geom, 5) AS json),
+                'properties', json_build_object('id', users.id, 'has_completed_profile',
+                    ((users.profile_gallery_id IS NOT NULL)
+                        AND EXISTS (SELECT 1 AS anon_2 FROM photo_gallery_items WHERE photo_gallery_items.gallery_id = users.profile_gallery_id)
+                        AND users.about_me_length >= 150))
+            ) AS text) AS geojson
+        FROM users
+        LEFT OUTER JOIN (
+            SELECT DISTINCT ON (photo_gallery_items.gallery_id)
+                photo_gallery_items.gallery_id,
+                photo_gallery_items.upload_key
+            FROM photo_gallery_items
+            ORDER BY photo_gallery_items.gallery_id, photo_gallery_items.position
+        ) avatar_photo ON avatar_photo.gallery_id = users.profile_gallery_id
+        LEFT OUTER JOIN uploads ON uploads.key = avatar_photo.upload_key
+        LEFT OUTER JOIN
+            (SELECT DISTINCT
+                users_1.id,
+                true AS "true"
+            FROM {sv_from}
+            WHERE
+                ((strong_verification_attempts.status = 'succeeded')
+                AND COALESCE(timezone('Etc/UTC', strong_verification_attempts.passport_expiry_date::timestamp without time zone) >= now(), false)
+                AND strong_verification_attempts.passport_date_of_birth = users_1.birthdate
+                AND (
+                    (users_1.gender = 'Woman' AND strong_verification_attempts.passport_sex = 'female')
+                    OR (users_1.gender = 'Man' AND strong_verification_attempts.passport_sex = 'male')
+                    OR strong_verification_attempts.passport_sex = 'unspecified'
+                    OR users_1.has_passport_sex_gender_exception = true
+                ))
+            ) sv_subquery
+        ON sv_subquery.id = users.id
+    """)
+    op.execute("CREATE UNIQUE INDEX uq_lite_users_id ON lite_users(id)")
+    op.execute("CREATE UNIQUE INDEX uq_lite_users_username ON lite_users(username)")
+    op.execute("CREATE INDEX ix_lite_users_id_visible ON lite_users USING hash (id) WHERE is_visible")
+    op.execute("CREATE INDEX ix_lite_users_username_visible ON lite_users USING hash (username) WHERE is_visible")
+    op.execute("CREATE INDEX idx_lite_users_geom ON lite_users USING gist (geom)")
+
+
+def upgrade() -> None:
+    _create_lite_users(
+        "strong_verification_attempts JOIN users users_1 ON users_1.id = strong_verification_attempts.user_id"
+    )
+
+
+def downgrade() -> None:
+    _create_lite_users("strong_verification_attempts, users users_1")

--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -144,7 +144,11 @@ class StrongVerificationAttempt(Base, kw_only=True):
 
     @hybrid_method
     def has_strong_verification(self, user: User | type[User]) -> Any:
-        return self.is_valid & self._raw_birthdate_match(user) & self._raw_gender_match(user)
+        # an attempt only verifies its own user: as a SQL expression there's no control flow to carry that, so the
+        # identity check has to be part of the predicate or a caller can pair any attempt with any user
+        return (
+            (self.user_id == user.id) & self.is_valid & self._raw_birthdate_match(user) & self._raw_gender_match(user)
+        )
 
     __table_args__ = (
         # used to look up verification status for a user

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -1024,3 +1024,22 @@ def test_lite_user_strong_verification_not_shared_between_users(db):
     with api_session(other_token) as api:
         assert api.GetLiteUser(api_pb2.GetLiteUserReq(user=verified_user.username)).has_strong_verification
         assert not api.GetLiteUser(api_pb2.GetLiteUserReq(user=other_user.username)).has_strong_verification
+
+
+def test_attempt_only_verifies_its_own_user(db):
+    verified_user, _ = generate_user(birthdate=date(1988, 1, 1), gender="Man", strong_verification=True)
+    other_user, _ = generate_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    with session_scope() as session:
+        attempt = session.execute(
+            select(StrongVerificationAttempt).where(StrongVerificationAttempt.user_id == verified_user.id)
+        ).scalar_one()
+        assert attempt.has_strong_verification(verified_user)
+        assert not attempt.has_strong_verification(other_user)
+
+        # as a SQL expression, without the join the two tables are still linked by the birthdate and gender predicates
+        assert session.execute(
+            select(User.id)
+            .select_from(StrongVerificationAttempt)
+            .where(StrongVerificationAttempt.has_strong_verification(User))
+        ).scalars().all() == [verified_user.id]

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -1011,3 +1011,16 @@ def test_strong_verification_non_passport(db, monkeypatch, push_collector: PushC
         push.content.body
         == "You used a document other than a passport. You can only use a passport for Strong Verification."
     )
+
+
+def test_lite_user_strong_verification_not_shared_between_users(db):
+    # regression: the lite_users view joined attempts to users only on birthdate/gender, so anyone born on the same
+    # day as a strongly verified user (with a compatible gender) got the badge too
+    verified_user, _ = generate_user(birthdate=date(1988, 1, 1), gender="Man", strong_verification=True)
+    other_user, other_token = generate_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with api_session(other_token) as api:
+        assert api.GetLiteUser(api_pb2.GetLiteUserReq(user=verified_user.username)).has_strong_verification
+        assert not api.GetLiteUser(api_pb2.GetLiteUserReq(user=other_user.username)).has_strong_verification


### PR DESCRIPTION
Strong verification badges on user lists and map search results come from the `lite_users` materialized view, which precomputes `has_strong_verification` for the lightweight user representation. That view matched a verification attempt to a user on birthdate and gender/sex correspondence alone, with nothing tying the attempt to the user it actually belongs to. The result was that any user who shares a birthday with a strongly verified user, and whose gender is compatible with that passport's sex, was shown the badge — which is how unverified accounts ended up with shields on the mod pages. This joins each attempt to its own user and recreates the view so deployed databases pick up the corrected definition.

The full profile RPCs and the `strong_verification` badge compute this separately and were always correct, so the bogus badge appeared only where the view is the source.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._