### PR TITLE
Check that a query's tables are linked by keys, not by values

### DIFF
--- a/app/backend/src/couchers/models/verification.py
+++ b/app/backend/src/couchers/models/verification.py
@@ -120,17 +120,25 @@ class StrongVerificationAttempt(Base, kw_only=True):
         return self.status != StrongVerificationAttemptStatus.deleted
 
     @hybrid_method
+    def _is_own_user(self, user: User | type[User]) -> Any:
+        """
+        An attempt only verifies the user it belongs to. As a SQL expression there's no control flow to carry that, so
+        every predicate taking a subject has to bind it, or a caller can pair any attempt with any user.
+        """
+        return self.user_id == user.id
+
+    @hybrid_method
     def _raw_birthdate_match(self, user: User | type[User]) -> Any:
-        """Does not check whether the SV attempt itself is not expired"""
+        """Checks neither that the attempt belongs to the user nor that it isn't expired"""
         return self.passport_date_of_birth == user.birthdate
 
     @hybrid_method
     def matches_birthdate(self, user: User | type[User]) -> Any:
-        return self.is_valid & self._raw_birthdate_match(user)
+        return self._is_own_user(user) & self.is_valid & self._raw_birthdate_match(user)
 
     @hybrid_method
     def _raw_gender_match(self, user: User | type[User]) -> Any:
-        """Does not check whether the SV attempt itself is not expired"""
+        """Checks neither that the attempt belongs to the user nor that it isn't expired"""
         return (
             ((user.gender == "Woman") & (self.passport_sex == PassportSex.female))  # type: ignore[operator]
             | ((user.gender == "Man") & (self.passport_sex == PassportSex.male))
@@ -140,15 +148,11 @@ class StrongVerificationAttempt(Base, kw_only=True):
 
     @hybrid_method
     def matches_gender(self, user: User | type[User]) -> Any:
-        return self.is_valid & self._raw_gender_match(user)
+        return self._is_own_user(user) & self.is_valid & self._raw_gender_match(user)
 
     @hybrid_method
     def has_strong_verification(self, user: User | type[User]) -> Any:
-        # an attempt only verifies its own user: as a SQL expression there's no control flow to carry that, so the
-        # identity check has to be part of the predicate or a caller can pair any attempt with any user
-        return (
-            (self.user_id == user.id) & self.is_valid & self._raw_birthdate_match(user) & self._raw_gender_match(user)
-        )
+        return self._is_own_user(user) & self.is_valid & self._raw_birthdate_match(user) & self._raw_gender_match(user)
 
     __table_args__ = (
         # used to look up verification status for a user

--- a/app/backend/src/tests/sql_linkage.py
+++ b/app/backend/src/tests/sql_linkage.py
@@ -1,0 +1,176 @@
+"""
+Finds tables in a query that are tied to the rest of the query by a value rather than by a key.
+
+The lite_users strong verification bug was a select over the attempts table and the users table whose only connection
+was `passport_date_of_birth = users.birthdate`. Every user sharing a birthdate with a verified user got the badge.
+
+SQLAlchemy's own FROM-linter cannot catch this for two independent reasons: the predicate does syntactically connect
+the two tables, so it sees no cartesian product, and a materialized view's select is compiled into DDL and never
+executed as a statement, so the lint path is never reached at all. This checks the stronger property the linter can't
+express: two tables count as connected only when an equality relates a foreign key to what it references, two foreign
+keys to the same target, or a column to itself through a subquery. A birthdate is not an identity.
+"""
+
+import itertools
+import warnings
+from typing import Any
+
+from sqlalchemy import Column, Table
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.elements import (
+    BinaryExpression,
+    BooleanClauseList,
+    ColumnClause,
+    ColumnElement,
+    _anonymous_label,
+)
+from sqlalchemy.sql.selectable import CompoundSelect, FromClause, Join, Select
+from sqlalchemy.sql.util import find_tables
+
+
+def _conjuncts(clause: ColumnElement[Any] | None) -> list[ColumnElement[Any]]:
+    """Splits a clause into the conditions that must all hold. Anything under an OR binds nothing, so it isn't split."""
+    if clause is None:
+        return []
+    if isinstance(clause, BooleanClauseList) and clause.operator is operators.and_:
+        return [conjunct for sub in clause.clauses for conjunct in _conjuncts(sub)]
+    return [clause]
+
+
+def _origins(expr: Any) -> set[Column[Any]]:
+    """The real table columns an expression stands for, seeing through subqueries: sub.c.id -> users.id"""
+    if not isinstance(expr, ColumnClause):
+        return set()
+    return {col for col in expr.proxy_set if isinstance(col, Column) and isinstance(col.table, Table)}
+
+
+def _fk_targets(col: Column[Any]) -> set[Column[Any]]:
+    return {fk.column for fk in col.foreign_keys}
+
+
+def _is_key_link(left: Any, right: Any) -> bool:
+    left_origins, right_origins = _origins(left), _origins(right)
+    # the same column reached through a subquery: an identity, not a coincidence
+    if left_origins & right_origins:
+        return True
+    for a, b in itertools.product(left_origins, right_origins):
+        if b in _fk_targets(a) or a in _fk_targets(b):
+            return True
+        # both sides point at the same row of a third table, e.g. two tables' user_id
+        if _fk_targets(a) & _fk_targets(b):
+            return True
+    return False
+
+
+def _leaves(from_clause: FromClause) -> list[FromClause]:
+    if isinstance(from_clause, Join):
+        return _leaves(from_clause.left) + _leaves(from_clause.right)
+    return [from_clause]
+
+
+def _join_conditions(from_clause: FromClause) -> list[ColumnElement[Any]]:
+    if isinstance(from_clause, Join):
+        return [
+            *_conjuncts(from_clause.onclause),
+            *_join_conditions(from_clause.left),
+            *_join_conditions(from_clause.right),
+        ]
+    return []
+
+
+def _key(from_clause: FromClause) -> str:
+    """
+    Identifies a FROM element by its name, which SQL requires to be unique within one FROM list.
+
+    Not by object identity: the ORM annotates its own copy of a table, so the entry in the FROM list and the table a
+    condition's column hangs off are equal but distinct objects.
+    """
+    name = getattr(from_clause, "name", None)
+    return str(name) if name is not None else str(id(from_clause))
+
+
+def _describe(from_clause: FromClause) -> str:
+    """Names a FROM element for the error message, falling back to what an unnamed subquery selects from."""
+    name = getattr(from_clause, "name", None)
+    if name is not None and not isinstance(name, _anonymous_label):
+        return str(name)
+    inner = getattr(from_clause, "element", None)
+    tables = sorted({table.name for table in find_tables(inner)}) if inner is not None else []
+    return f"unnamed subquery over {', '.join(tables)}" if tables else "unnamed subquery"
+
+
+class _Components:
+    """Union-find over the FROM elements, to check they end up in one connected component."""
+
+    def __init__(self, keys: list[str]) -> None:
+        self._parent = {key: key for key in keys}
+
+    def find(self, key: str) -> str:
+        while self._parent[key] != key:
+            self._parent[key] = self._parent[self._parent[key]]
+            key = self._parent[key]
+        return key
+
+    def union(self, left: str, right: str) -> None:
+        self._parent[self.find(left)] = self.find(right)
+
+    def count(self) -> int:
+        return len({self.find(key) for key in self._parent})
+
+
+def find_unkeyed_joins(statement: Select[Any] | CompoundSelect[Any], path: str = "query") -> list[str]:
+    """
+    Returns a problem description for every table not connected to the rest of its query by a key.
+
+    Recurses into subqueries, CTEs and the arms of a union, each of which is checked in its own right.
+    """
+    if isinstance(statement, CompoundSelect):
+        return [
+            problem
+            for index, arm in enumerate(statement.selects)
+            if isinstance(arm, (Select, CompoundSelect))
+            for problem in find_unkeyed_joins(arm, f"{path}/union[{index}]")
+        ]
+
+    with warnings.catch_warnings():
+        # resolving the FROM list builds a compiler for the default dialect, which warns that DISTINCT ON is
+        # PostgreSQL-only. We only ever run on PostgreSQL, and this reads structure rather than emitting any SQL.
+        warnings.filterwarnings("ignore", "DISTINCT ON is currently supported only by the PostgreSQL dialect")
+        froms = statement.get_final_froms()
+    leaves = [leaf for from_clause in froms for leaf in _leaves(from_clause)]
+    conditions = [
+        *(condition for from_clause in froms for condition in _join_conditions(from_clause)),
+        *_conjuncts(statement.whereclause),
+    ]
+
+    by_key = {_key(leaf): leaf for leaf in leaves}
+    components = _Components(list(by_key))
+    unkeyed: list[BinaryExpression[Any]] = []
+    for condition in conditions:
+        if not isinstance(condition, BinaryExpression) or condition.operator is not operators.eq:
+            continue
+        sides = [getattr(getattr(condition, side), "table", None) for side in ("left", "right")]
+        if any(side is None for side in sides):
+            continue
+        left, right = (_key(side) for side in sides)  # type: ignore[arg-type]
+        if left not in by_key or right not in by_key or left == right:
+            continue
+        if _is_key_link(condition.left, condition.right):
+            components.union(left, right)
+        else:
+            unkeyed.append(condition)
+
+    problems = []
+    if components.count() > 1:
+        # the unkeyed equalities are what the author probably mistook for a join
+        mistaken = "".join(f"\n    only linked by: {condition}" for condition in unkeyed)
+        problems.append(
+            f"{path}: {', '.join(sorted(_describe(leaf) for leaf in leaves))} are not all connected by keys, so rows "
+            f"are paired across every combination{mistaken}"
+        )
+
+    for leaf in leaves:
+        element = getattr(leaf, "element", None)
+        if isinstance(element, (Select, CompoundSelect)):
+            problems += find_unkeyed_joins(element, f"{path}/{_describe(leaf)}")
+    return problems

--- a/app/backend/src/tests/test_sql_linkage.py
+++ b/app/backend/src/tests/test_sql_linkage.py
@@ -20,6 +20,7 @@ import couchers.materialized_views  # noqa: F401 -- importing registers the view
 from couchers.models import Base, StrongVerificationAttempt, User
 from tests.sql_linkage import find_unkeyed_joins
 
+
 @pytest.fixture(autouse=True)
 def _(testconfig):
     pass

--- a/app/backend/src/tests/test_sql_linkage.py
+++ b/app/backend/src/tests/test_sql_linkage.py
@@ -1,0 +1,128 @@
+"""
+Mechanical checks that a query's tables are tied together by keys rather than by values.
+
+This is the bug class behind the lite_users strong verification bug: identity carried by convention instead of by a
+key. Nothing else we run can see it. mypy, ruff and the migrations-vs-models diff all check that two representations
+agree, which a self-consistently wrong query does; SQLAlchemy's FROM-linter sees the birthdate predicate as a
+connection and never runs against DDL anyway.
+"""
+
+import re
+from annotationlib import Format, get_annotations
+from typing import Any
+
+import pytest
+from sqlalchemy import CompoundSelect, Select, select
+from sqlalchemy.ext.hybrid import hybrid_method
+from sqlalchemy_utils.view import CreateView
+
+import couchers.materialized_views  # noqa: F401 -- importing registers the views on the metadata
+from couchers.models import Base, StrongVerificationAttempt, User
+from tests.sql_linkage import find_unkeyed_joins
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+_MAPPED_CLASSES = {mapper.class_.__name__: mapper.class_ for mapper in Base.registry.mappers}
+
+
+def _materialized_views() -> list[tuple[str, Select[Any] | CompoundSelect[Any]]]:
+    """
+    Every materialized view registered on the metadata, which is exactly the set that gets created in the database.
+
+    Read off the metadata rather than listed here, so a new view is covered without anyone remembering to add it.
+    """
+    return sorted(
+        (listener.name, listener.selectable)
+        for listener in Base.metadata.dispatch.after_create
+        if isinstance(listener, CreateView)
+    )
+
+
+def _subject_predicates() -> list[tuple[str, Any, Any]]:
+    """
+    Every public hybrid method on a model that takes another model as its subject, as (label, predicate, subject).
+
+    These are the expressions that have to bind their own subject: SQL has no control flow to carry the fact that the
+    row and the subject belong together, so a predicate that doesn't say so leaves it to each call site to remember.
+    The private helpers they compose are excluded, being documented as not binding.
+    """
+    found = []
+    for model in _MAPPED_CLASSES.values():
+        for name, attribute in vars(model).items():
+            if name.startswith("_") or not isinstance(attribute, hybrid_method):
+                continue
+            # read as strings: models annotate each other under TYPE_CHECKING, so the names don't resolve at runtime
+            annotations = get_annotations(attribute.func, format=Format.STRING)
+            for parameter, annotation in annotations.items():
+                if parameter == "return":
+                    continue
+                for subject_name in re.findall(r"\w+", annotation):
+                    if subject := _MAPPED_CLASSES.get(subject_name):
+                        found.append((f"{model.__name__}.{name}", getattr(model, name), subject))
+                        break
+    return found
+
+
+_MATERIALIZED_VIEWS = _materialized_views()
+_SUBJECT_PREDICATES = _subject_predicates()
+
+
+def test_the_checks_below_cover_something():
+    # a parametrised test over an empty list passes while protecting nothing, which is how we got here
+    assert _MATERIALIZED_VIEWS
+    assert _SUBJECT_PREDICATES
+
+
+@pytest.mark.parametrize(("name", "selectable"), _MATERIALIZED_VIEWS, ids=[name for name, _ in _MATERIALIZED_VIEWS])
+def test_materialized_view_tables_are_linked_by_keys(name, selectable):
+    assert not (problems := find_unkeyed_joins(selectable, name)), "\n".join(problems)
+
+
+@pytest.mark.parametrize(
+    ("label", "predicate", "subject"), _SUBJECT_PREDICATES, ids=[label for label, _, _ in _SUBJECT_PREDICATES]
+)
+def test_subject_predicates_bind_their_subject(label, predicate, subject):
+    """A predicate that binds its subject makes its own query correct, with no join for a caller to forget."""
+    # no explicit join: the FROM is inferred from the columns, so the predicate is the only thing that can link them
+    statement = select(subject.id).where(predicate(subject))
+
+    assert not (problems := find_unkeyed_joins(statement, label)), "\n".join(problems)
+
+
+def test_the_lite_users_bug_is_caught():
+    """The shape of the pre-0183 strong verification subquery: two tables related only by a birthdate."""
+    buggy = (
+        select(User.id)
+        .select_from(StrongVerificationAttempt)
+        .where(StrongVerificationAttempt.passport_date_of_birth == User.birthdate)
+    )
+
+    problems = find_unkeyed_joins(buggy, "sv_subquery")
+
+    assert len(problems) == 1
+    assert "strong_verification_attempts" in problems[0]
+    assert "users.birthdate" in problems[0]
+
+
+def test_a_keyed_join_is_accepted():
+    fine = (
+        select(User.id)
+        .select_from(StrongVerificationAttempt)
+        .join(User, User.id == StrongVerificationAttempt.user_id)
+        .where(StrongVerificationAttempt.passport_date_of_birth == User.birthdate)
+    )
+
+    assert find_unkeyed_joins(fine, "sv_subquery") == []
+
+
+def test_a_link_under_an_or_does_not_count():
+    """An equality that only holds down one branch of an OR binds nothing."""
+    either = select(User.id).where(
+        (StrongVerificationAttempt.user_id == User.id)
+        | (StrongVerificationAttempt.passport_date_of_birth == User.birthdate)
+    )
+
+    assert len(find_unkeyed_joins(either, "either")) == 1

--- a/app/backend/src/tests/test_strong_verification.py
+++ b/app/backend/src/tests/test_strong_verification.py
@@ -1043,3 +1043,23 @@ def test_attempt_only_verifies_its_own_user(db):
             .select_from(StrongVerificationAttempt)
             .where(StrongVerificationAttempt.has_strong_verification(User))
         ).scalars().all() == [verified_user.id]
+
+
+@pytest.mark.parametrize("predicate", ["matches_birthdate", "matches_gender"])
+def test_attempt_predicates_bind_their_own_user(db, predicate):
+    # the same gap as has_strong_verification: these take a subject, so they have to bind it themselves
+    verified_user, _ = generate_user(birthdate=date(1988, 1, 1), gender="Man", strong_verification=True)
+    other_user, _ = generate_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    with session_scope() as session:
+        attempt = session.execute(
+            select(StrongVerificationAttempt).where(StrongVerificationAttempt.user_id == verified_user.id)
+        ).scalar_one()
+        assert getattr(attempt, predicate)(verified_user)
+        assert not getattr(attempt, predicate)(other_user)
+
+        assert session.execute(
+            select(User.id)
+            .select_from(StrongVerificationAttempt)
+            .where(getattr(StrongVerificationAttempt, predicate)(User))
+        ).scalars().all() == [verified_user.id]


### PR DESCRIPTION
Strong Verification lets a user prove their identity with a passport, and the badge it grants is one of the stronger trust signals we show. #9584 fixed the `lite_users` view handing that badge to anyone born on the same day as a verified user: the view related the attempts table to the users table by birthdate and gender alone, so every pairing matched. Nothing we run could see it. Our guards check that two representations agree, which a self-consistently wrong query does, and SQLAlchemy's own FROM-linter both reads a birthdate predicate as a genuine connection and never runs against a view's DDL in the first place.

This adds a check for the property they miss, that every table in a query's FROM is reachable from the others through a foreign key rather than through a value, and applies it to the materialized views read off the metadata and to every public hybrid method taking a subject read off the mapper registry. Neither list is written down, so a new view or predicate is covered as soon as it exists. Reverting either half of the original fix fails these tests.

Two sibling predicates behind the per-field birthdate and gender verification statuses turned out to have the same gap, correct today only because their callers happen to look the attempt up by user id first, so they now bind their subject too. No behaviour change at the current call sites, and the SQL behind `lite_users` is untouched, so there is no migration.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._