### PR TITLE
Add a data JSONB column to moderation queue items

### DIFF
--- a/app/backend/src/couchers/i18n/admin_locales/en.json
+++ b/app/backend/src/couchers/i18n/admin_locales/en.json
@@ -7,6 +7,8 @@
     "cannot_reinstate_and_set_stopped_date": "Cannot reinstate a volunteer and set a stopped date at the same time.",
     "cannot_set_visibility_on_state": "This object type cannot be approved or hidden, its visibility is not decided by the moderation system.",
     "content_report_not_found": "Content report not found.",
+    "data_must_be_valid_json": "The moderation data must be valid JSON.",
+    "data_only_allowed_on_flag": "Moderation data can only be set when flagging.",
     "deletereference_deprecated_use_ums": "DeleteReference is deprecated. Use the Unified Moderation System (UMS) to hide a reference.",
     "event_community_invite_already_decided": "That event community invite was already approved/denied.",
     "event_community_invite_not_found": "Couldn't find that event community invite.",

--- a/app/backend/src/couchers/migrations/versions/0184_add_moderation_queue_data.py
+++ b/app/backend/src/couchers/migrations/versions/0184_add_moderation_queue_data.py
@@ -1,0 +1,25 @@
+"""Add data column to moderation queue items
+
+Revision ID: 0184
+Revises: 0183
+Create Date: 2026-08-16 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "0184"
+down_revision = "0183"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("moderation_queue", sa.Column("data", postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("moderation_queue", "data")

--- a/app/backend/src/couchers/models/moderation.py
+++ b/app/backend/src/couchers/models/moderation.py
@@ -9,7 +9,7 @@ import enum
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cache
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from sqlalchemy import (
     BigInteger,
@@ -23,6 +23,7 @@ from sqlalchemy import (
     String,
     func,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from couchers.models.base import Base, moderation_seq
@@ -151,6 +152,8 @@ class ModerationQueueItem(Base, kw_only=True):
     reason: Mapped[str] = mapped_column(String)
 
     priority: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0", default=0)
+
+    data: Mapped[Any | None] = mapped_column(JSONB(none_as_null=True), default=None)
 
     # When resolved, this links to the log entry that resolved it
     resolved_by_log_id: Mapped[int | None] = mapped_column(ForeignKey("moderation_log.id"), index=True, default=None)

--- a/app/backend/src/couchers/moderation/utils.py
+++ b/app/backend/src/couchers/moderation/utils.py
@@ -3,6 +3,7 @@ Utility functions for the Unified Moderation System (UMS)
 """
 
 from collections.abc import Callable
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -25,6 +26,7 @@ def create_moderation(
     object_id: int | Callable[[int], int],
     # None for objects that are their own creator, whose id isn't known until the callback has run
     creator_user_id: int | None = None,
+    data: Any | None = None,
 ) -> ModerationState:
     has_own_visibility_mechanism = get_moderated_models()[object_type].has_own_visibility_mechanism
     visibility = None if has_own_visibility_mechanism else ModerationVisibility.shadowed
@@ -68,6 +70,7 @@ def create_moderation(
                 moderation_state_id=moderation_state.id,
                 trigger=ModerationTrigger.initial_review,
                 reason="Object created.",
+                data=data,
             )
         )
         observe_moderation_queue_item_created(ModerationTrigger.initial_review, object_type)

--- a/app/backend/src/couchers/servicers/moderation.py
+++ b/app/backend/src/couchers/servicers/moderation.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import grpc
@@ -419,6 +420,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 resolved_by_log_id=item.resolved_by_log_id or 0,
                 moderation_state=moderation_state_to_pb(mod_state, session),
                 priority=item.priority,
+                data=json.dumps(item.data) if item.data is not None else "",
             )
 
             queue_items_pb.append(queue_item_pb)
@@ -523,6 +525,15 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
         reason = request.reason or "Moderated by admin"
         object_type = moderation_state.object_type
 
+        data = None
+        if request.data.strip():
+            if action != ModerationAction.flag:
+                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:data_only_allowed_on_flag")
+            try:
+                data = json.loads(request.data)
+            except json.JSONDecodeError:
+                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:data_must_be_valid_json")
+
         if action in (ModerationAction.approve, ModerationAction.hide):
             if get_moderated_models()[object_type].has_own_visibility_mechanism:
                 context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:cannot_set_visibility_on_state")
@@ -575,6 +586,7 @@ class Moderation(moderation_pb2_grpc.ModerationServicer):
                 trigger=trigger,
                 reason=reason,
                 priority=request.priority,
+                data=data,
             )
             session.add(queue_item)
             session.flush()

--- a/app/backend/src/tests/test_moderation.py
+++ b/app/backend/src/tests/test_moderation.py
@@ -2,6 +2,7 @@
 Comprehensive tests for the Unified Moderation System (UMS)
 """
 
+import json
 from datetime import datetime, timedelta
 
 import grpc
@@ -173,6 +174,130 @@ def test_add_to_moderation_queue(db):
             .where(ModerationLog.action == ModerationAction.flag)
         ).scalar_one()
         assert flag_log.queue_item_id == flag.id
+
+
+def test_flag_with_data(db):
+    """A flag can carry a JSON payload"""
+    super_user, super_token = generate_user(is_superuser=True)
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    state_id = create_test_host_request_with_moderation(token1, user2.id)
+
+    with real_moderation_session(super_token) as api:
+        api.ModerateContent(
+            moderation_pb2.ModerateContentReq(
+                moderation_state_id=state_id,
+                action=moderation_pb2.MODERATION_ACTION_FLAG,
+                trigger=moderation_pb2.MODERATION_TRIGGER_MACHINE_FLAG,
+                reason="Automod",
+                data=json.dumps({"classifier": "spam", "score": 0.97, "matches": ["buy now"]}),
+            )
+        )
+
+        res = api.GetModerationQueue(
+            moderation_pb2.GetModerationQueueReq(triggers=[moderation_pb2.MODERATION_TRIGGER_MACHINE_FLAG])
+        )
+        assert len(res.queue_items) == 1
+        assert json.loads(res.queue_items[0].data) == {
+            "classifier": "spam",
+            "score": 0.97,
+            "matches": ["buy now"],
+        }
+
+    with session_scope() as session:
+        flag = session.execute(
+            select(ModerationQueueItem)
+            .where(ModerationQueueItem.moderation_state_id == state_id)
+            .where(ModerationQueueItem.trigger == ModerationTrigger.machine_flag)
+        ).scalar_one()
+        assert flag.data == {"classifier": "spam", "score": 0.97, "matches": ["buy now"]}
+
+
+def test_flag_without_data(db):
+    """A flag with no data serializes as an empty string"""
+    super_user, super_token = generate_user(is_superuser=True)
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    state_id = create_test_host_request_with_moderation(token1, user2.id)
+
+    with real_moderation_session(super_token) as api:
+        res = api.GetModerationQueue(moderation_pb2.GetModerationQueueReq())
+        assert len(res.queue_items) == 1
+        assert res.queue_items[0].data == ""
+
+    with session_scope() as session:
+        item = session.execute(
+            select(ModerationQueueItem).where(ModerationQueueItem.moderation_state_id == state_id)
+        ).scalar_one()
+        assert item.data is None
+
+
+def test_flag_with_invalid_data(db):
+    """Flag data must be valid JSON"""
+    super_user, super_token = generate_user(is_superuser=True)
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    state_id = create_test_host_request_with_moderation(token1, user2.id)
+
+    with real_moderation_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.ModerateContent(
+                moderation_pb2.ModerateContentReq(
+                    moderation_state_id=state_id,
+                    action=moderation_pb2.MODERATION_ACTION_FLAG,
+                    trigger=moderation_pb2.MODERATION_TRIGGER_MACHINE_FLAG,
+                    reason="Automod",
+                    data="not json",
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "The moderation data must be valid JSON."
+
+
+def test_data_rejected_on_non_flag_action(db):
+    """Data has nowhere to go on actions that don't create a queue item"""
+    super_user, super_token = generate_user(is_superuser=True)
+    user1, token1 = generate_user()
+    user2, _ = generate_user()
+
+    state_id = create_test_host_request_with_moderation(token1, user2.id)
+
+    with real_moderation_session(super_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.ModerateContent(
+                moderation_pb2.ModerateContentReq(
+                    moderation_state_id=state_id,
+                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+                    reason="Looks fine",
+                    data=json.dumps({"score": 0.1}),
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "Moderation data can only be set when flagging."
+
+
+def test_create_moderation_with_data(db):
+    """create_moderation can attach data to the initial review item"""
+    user, _ = generate_user()
+
+    with session_scope() as session:
+        moderation_state = create_moderation(
+            session=session,
+            object_type=ModerationObjectType.host_request,
+            object_id=123,
+            creator_user_id=user.id,
+            data={"classifier": "spam", "score": 0.42},
+        )
+
+        item = session.execute(
+            select(ModerationQueueItem).where(ModerationQueueItem.moderation_state_id == moderation_state.id)
+        ).scalar_one()
+        assert item.trigger == ModerationTrigger.initial_review
+        assert item.data == {"classifier": "spam", "score": 0.42}
 
 
 def test_moderate_content(db):

--- a/app/proto/moderation.proto
+++ b/app/proto/moderation.proto
@@ -92,6 +92,7 @@ message ModerationQueueItemInfo {
   int64 resolved_by_log_id = 7;
   ModerationStateInfo moderation_state = 8;
   int32 priority = 9;
+  string data = 10;  // optional JSON payload
 }
 
 message ModerationLogEntryInfo {
@@ -171,6 +172,8 @@ message ModerateContentReq {
   int64 supersede_queue_item_id = 8;
   // For APPROVE / HIDE: also resolve all open flags on the state
   bool clear_flags = 9;
+  // For FLAG: JSON object stored on the new flag
+  string data = 10;
 }
 
 message ModerateContentRes {


### PR DESCRIPTION
Moderation queue items — the flags moderators work through in the Unified Moderation System — store a trigger, a priority and a free-text reason. This adds a JSONB `data` column alongside them, mirroring the `data` field on admin actions. It can be set through `ModerateContent` when raising a flag, and by the content-creation path so it lands on the initial review item; the moderation queue listing returns it JSON-encoded.

Setting data on an action that doesn't create a queue item (approve, hide, unflag, priority changes) is rejected rather than silently dropped.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._