### PR TITLE
Tighten the PR skill's description guidance

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -69,7 +69,11 @@ Read the PR template from `.github/pull_request_template.md` and fill it in.
 
 The description has one job: give a reviewer who context-switches in enough to understand what the change is about and why it exists, without reading the code. Nothing else.
 
-**Shape.** One paragraph. Open with high-level context — which subsystem this touches, what it is for, why it matters — so a reviewer who may be familiar with this area but did not drive the session is oriented. Then what is wrong, missing, or needed, and what the change does about it. Add a second short paragraph only for a behaviour change reviewers need to know about, a stacking or follow-up relationship to another PR, or a human-directed decision (see below). Most descriptions should be well under 150 words.
+**Shape. ONE paragraph.** Not two. Not "one short one and then a brief note". One. Open with high-level context — which subsystem this touches, what it is for, why it matters — so a reviewer who may be familiar with this area but did not drive the session is oriented. Then what is wrong, missing, or needed, and what the change does about it. Stop there. Well under 150 words.
+
+A second paragraph is allowed in exactly one case: the user explicitly directed a consequential decision that needs recording (see **The one exception** below). That case is rare — most PRs will never hit it. Everything else you were tempted to put in a second paragraph — a behaviour change, a stacking or follow-up relationship to another PR, a caveat — either fits as a clause in the one paragraph or does not belong in the description at all. If you have written two paragraphs and the second is not a user-directed decision, delete it; do not merge it in.
+
+**Never fabricate. This is absolute.** Write only what you actually know from the session, the diff, the repo, or the user. You do not get to invent *why* a change is being made. If the user did not tell you the motivation, and it is not plainly evident from the code or the issue being fixed, then you do not know it — say what the change does and leave the motivation out. Never write a plausible-sounding backstory: no invented user complaints, no invented incidents or bug reports, no invented performance or scale pressures, no invented product goals, no invented prior discussion, no invented future plans, no guessed issue or PR numbers, no attributing a decision to the user that they did not make. A description that is short and says less is always better than one that reads well and contains something you made up. If you are unsure whether you know a rationale or are reconstructing it, you are reconstructing it — leave it out.
 
 **Stay above the code.** Write in terms a reviewer can follow without opening a file — the authentication system, the notification emails, the search page — rather than the private helpers, local variables and internal functions that implement them. Nobody remembers what those do, including whoever wrote them. Identifiers are fine where a reviewer would recognise them from outside: RPC and service names, database tables, proto messages, settings and env vars, feature flags, URLs.
 
@@ -84,6 +88,7 @@ The description has one job: give a reviewer who context-switches in enough to u
 - Annotations on checklist items. Tick or leave unticked.
 - Headings, tables, or bold sub-headings beyond the template's own.
 - A first sentence that restates the title.
+- Any rationale, history, or context you cannot point to a source for.
 
 **The one exception.** If the user explicitly directed a design or implementation decision during the session, and it is consequential and looks wrong on its face — or was picked after real work on an alternative — record it in a sentence or two as their decision. Nothing you decided on your own ever qualifies.
 
@@ -100,6 +105,11 @@ Append the following note as the very last line of the PR body, after the "For m
 ### 7. Prune the description
 
 Read the draft description once more as if you had no context on the change and were a busy person with other PRs to get through. Ask what could be dropped and what needs clarifying: a sentence they would skip, a phrase they would have to re-read, a term they would have to look up.
+
+Then check the two hard rules explicitly:
+
+- **Count the paragraphs.** If there is more than one, and the extra is not a user-directed decision under the exception, delete it.
+- **Point at a source for every claim of *why*.** Go sentence by sentence over anything that explains motivation, history, or impact. For each, name where it came from — the user said it, the diff shows it, the issue states it. Anything left over is fabricated: delete it.
 
 Then make one more editing pass for simplification and clarification. You may only prune and reword — the description must not get longer.
 


### PR DESCRIPTION
The `pr` skill under `.claude/skills/` writes the branch, commit and PR body when a pull request is opened from Claude Code, and its description guidance is what keeps those bodies short enough to be worth reading. The shape rule previously permitted a second paragraph for a behaviour change, a stacking relationship to another PR, or a human-directed decision, and said nothing explicit about rationale the author cannot actually source. It now allows a single paragraph, with a user-directed consequential decision as the only exception, and adds a rule against writing motivation, history, or context that cannot be traced back to the session, the diff, the repo, or the user. Both rules are re-checked explicitly in the pruning pass before the PR is created.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._