### PR TITLE
Vary fixture users and assert per-user data stays with its own user

### DIFF
--- a/app/backend/src/tests/fixtures/db.py
+++ b/app/backend/src/tests/fixtures/db.py
@@ -1,3 +1,4 @@
+import hashlib
 import subprocess
 from collections.abc import Sequence
 from contextlib import contextmanager
@@ -166,9 +167,50 @@ def autocommit_engine(url: str):
     engine.dispose()
 
 
-def make_user(moderation_state_id: int = 0, **kwargs: Any) -> User:
-    """Build an unsaved user. Pass a real moderation_state_id if you intend to save it."""
+_FIXTURE_GENDERS = ("Woman", "Man", "Non-binary", "Genderqueer", "Agender")
+# a fixed window so the derived birthdates don't drift with the wall clock: everyone is an adult, nobody is implausible
+_FIXTURE_BIRTHDATE_EARLIEST = date(1950, 1, 1)
+_FIXTURE_BIRTHDATE_SPAN_DAYS = 20000
+# the fake timezone_areas polygon for America/New_York comfortably contains this box around the old fixture location,
+# so users keep the timezone they always had
+_FIXTURE_LAT, _FIXTURE_LNG = 40.7108, -73.9740
+_FIXTURE_COORDINATE_JITTER_DEG = 0.5
+
+
+def _fixture_variation(seed: str) -> dict[str, Any]:
+    """
+    Attributes that would otherwise be identical for every fixture user, varied deterministically.
+
+    A population that shares a birthdate, a gender and a location hides bugs that treat those values as an identity
+    (the `lite_users` strong verification bug) and makes distance errors untestable. Tests that want a collision opt
+    into it: pass the field explicitly, or give two users the same `fixture_seed`.
+    """
+    digest = hashlib.blake2b(seed.encode(), digest_size=16).digest()
+
+    def _fraction(start: int) -> float:
+        """A number in [-1, 1) from four bytes of the digest"""
+        return int.from_bytes(digest[start : start + 4], "big") / 2**31 - 1
+
+    return {
+        "birthdate": _FIXTURE_BIRTHDATE_EARLIEST
+        + timedelta(days=int.from_bytes(digest[0:4], "big") % _FIXTURE_BIRTHDATE_SPAN_DAYS),
+        "gender": _FIXTURE_GENDERS[digest[4] % len(_FIXTURE_GENDERS)],
+        "geom": create_coordinate(
+            _FIXTURE_LAT + _FIXTURE_COORDINATE_JITTER_DEG * _fraction(5),
+            _FIXTURE_LNG + _FIXTURE_COORDINATE_JITTER_DEG * _fraction(9),
+        ),
+    }
+
+
+def make_user(moderation_state_id: int = 0, fixture_seed: str | None = None, **kwargs: Any) -> User:
+    """
+    Build an unsaved user. Pass a real moderation_state_id if you intend to save it.
+
+    Birthdate, gender and coordinates are derived from `fixture_seed` (the username by default), so users differ from
+    each other unless you deliberately collide them with a shared seed or explicit values.
+    """
     username = "test_user_" + random_hex(16)
+    variation = _fixture_variation(fixture_seed if fixture_seed is not None else kwargs.get("username", username))
 
     user = User(
         moderation_state_id=moderation_state_id,
@@ -180,8 +222,8 @@ def make_user(moderation_state_id: int = 0, **kwargs: Any) -> User:
         city="Testing city",
         hometown="Test hometown",
         community_standing=0.5,
-        birthdate=date(year=2000, month=1, day=1),
-        gender="Woman",
+        birthdate=variation["birthdate"],
+        gender=variation["gender"],
         pronouns="",
         occupation="Tester",
         education="UST(esting)",
@@ -190,7 +232,7 @@ def make_user(moderation_state_id: int = 0, **kwargs: Any) -> User:
         about_place="My place has a lot of testing paraphenelia",
         additional_information="I can be a bit testy",
         accepted_tos=TOS_VERSION,
-        geom=create_coordinate(40.7108, -73.9740),
+        geom=variation["geom"],
         geom_radius=100,
         last_onboarding_email_sent=now(),
         last_donated=now(),

--- a/app/backend/src/tests/test_confinement.py
+++ b/app/backend/src/tests/test_confinement.py
@@ -1,0 +1,200 @@
+"""
+Per-user data must reach its own user and nobody else.
+
+Tests usually assert that a user who has something gets it, and the bug that survives that is the one where somebody
+else gets it too: the `lite_users` strong verification bug matched attempts to users by birthdate and gender, which no
+"the verified user has the badge" assertion can tell apart from matching by identity. So these build a population that
+collides on everything that isn't an identity, give each user a different fact, and assert each fact reaches exactly
+one of them.
+"""
+
+import json
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from google.protobuf import empty_pb2
+from sqlalchemy import select
+from sqlalchemy_utils import refresh_materialized_view
+
+from couchers.db import session_scope
+from couchers.helpers.badges import user_add_badge
+from couchers.materialized_views import LiteUser, refresh_materialized_views_rapid
+from couchers.models import Message, MessageType
+from couchers.models.uploads import get_avatar_upload
+from couchers.proto import api_pb2, messages_pb2, requests_pb2
+from couchers.utils import now, today
+from tests.fixtures.db import backdate_conversations, generate_user
+from tests.fixtures.sessions import api_session, gis_session, requests_session
+from tests.test_requests import valid_request_text
+
+
+@pytest.fixture(autouse=True)
+def _(testconfig):
+    pass
+
+
+# everything a user could be confused by: the fixture seed collides birthdate, gender and location
+COLLIDING: dict[str, Any] = dict(fixture_seed="collision", name="Same Name", city="Same City", hometown="Same Hometown")
+
+
+@pytest.fixture
+def population(db):
+    """Users indistinguishable except by identity, each holding one per-user fact the others don't"""
+    verified, _ = generate_user(**COLLIDING, strong_verification=True)
+    badged, _ = generate_user(**COLLIDING)
+    incomplete, _ = generate_user(**COLLIDING, complete_profile=False)
+    _, token = generate_user()
+
+    with session_scope() as session:
+        user_add_badge(session, badged.id, "volunteer", do_notify=False)
+
+    with session_scope() as session:
+        avatar_urls = {
+            user.username: (upload.full_url if (upload := get_avatar_upload(session, user)) else "")
+            for user in (verified, badged, incomplete)
+        }
+
+    return SimpleNamespace(
+        verified=verified,
+        badged=badged,
+        incomplete=incomplete,
+        users=[verified, badged, incomplete],
+        avatar_urls=avatar_urls,
+        token=token,
+    )
+
+
+def test_GetUser_confines_per_user_facts(population):
+    with api_session(population.token) as api:
+        responses = {user.username: api.GetUser(api_pb2.GetUserReq(user=user.username)) for user in population.users}
+
+    assert [username for username, res in responses.items() if res.has_strong_verification] == [
+        population.verified.username
+    ]
+    assert [username for username, res in responses.items() if res.badges] == [population.badged.username]
+
+    for username, res in responses.items():
+        assert res.username == username
+        assert res.avatar_url == population.avatar_urls[username]
+
+
+def test_GetLiteUser_confines_per_user_facts(population):
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with api_session(population.token) as api:
+        responses = {
+            user.username: api.GetLiteUser(api_pb2.GetLiteUserReq(user=user.username)) for user in population.users
+        }
+
+    assert [username for username, res in responses.items() if res.has_strong_verification] == [
+        population.verified.username
+    ]
+
+    for user in population.users:
+        res = responses[user.username]
+        assert res.user_id == user.id
+        assert res.avatar_url == population.avatar_urls[user.username]
+
+
+def test_GetLiteUsers_confines_per_user_facts(population):
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    # mixing usernames and ids, since the batch is assembled from a lookup by each
+    queries = [population.verified.username, str(population.badged.id), population.incomplete.username]
+
+    with api_session(population.token) as api:
+        res = api.GetLiteUsers(api_pb2.GetLiteUsersReq(users=queries))
+
+    assert [response.query for response in res.responses] == queries
+    assert [response.user.user_id for response in res.responses] == [user.id for user in population.users]
+    assert [response.user.has_strong_verification for response in res.responses] == [True, False, False]
+
+
+def test_GetUsers_geojson_confines_per_user_facts(population):
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with gis_session(population.token) as gis:
+        data = json.loads(gis.GetUsers(empty_pb2.Empty()).data)
+
+    completeness = {
+        feature["properties"]["id"]: feature["properties"]["has_completed_profile"] for feature in data["features"]
+    }
+
+    assert completeness[population.verified.id]
+    assert completeness[population.badged.id]
+    assert not completeness[population.incomplete.id]
+
+
+def test_lite_users_confines_strong_verification(population):
+    refresh_materialized_views_rapid(empty_pb2.Empty())
+
+    with session_scope() as session:
+        verified_ids = session.execute(select(LiteUser.id).where(LiteUser.has_strong_verification)).scalars().all()
+
+    assert set(verified_ids) == {population.verified.id}
+
+
+# a host needs this many requests older than the response window before a rate is reported at all
+_REQUESTS_FOR_A_RATE = 3
+
+
+def _request_hosting(surfer_token: str, host_id: int, moderator) -> int:
+    """Send a host request and age it past the window the response rate is measured over"""
+    with requests_session(surfer_token) as api:
+        host_request_id: int = api.CreateHostRequest(
+            requests_pb2.CreateHostRequestReq(
+                host_user_id=host_id,
+                from_date=(today() + timedelta(days=2)).isoformat(),
+                to_date=(today() + timedelta(days=3)).isoformat(),
+                text=valid_request_text(),
+            )
+        ).host_request_id
+
+    moderator.approve_host_request(host_request_id)
+    backdate_conversations()
+
+    with session_scope() as session:
+        session.execute(
+            select(Message)
+            .where(Message.conversation_id == host_request_id)
+            .where(Message.message_type == MessageType.chat_created)
+        ).scalar_one().time = now() - timedelta(hours=34)
+
+    return host_request_id
+
+
+def test_GetResponseRate_confines_rates_to_their_own_host(db, moderator):
+    """The response rates view unions message subqueries across hosts, so each host must get their own"""
+    responsive, responsive_token = generate_user()
+    unresponsive, _ = generate_user()
+    quiet, _ = generate_user()
+    _, surfer_token = generate_user()
+
+    answered = [_request_hosting(surfer_token, responsive.id, moderator) for _ in range(_REQUESTS_FOR_A_RATE)]
+    for _ in range(_REQUESTS_FOR_A_RATE):
+        _request_hosting(surfer_token, unresponsive.id, moderator)
+
+    with requests_session(responsive_token) as api:
+        for host_request_id in answered:
+            api.RespondHostRequest(
+                requests_pb2.RespondHostRequestReq(
+                    host_request_id=host_request_id,
+                    status=messages_pb2.HOST_REQUEST_STATUS_ACCEPTED,
+                    text="Accepting host request",
+                )
+            )
+
+    with session_scope() as session:
+        refresh_materialized_view(session, "user_response_rates")
+
+    with requests_session(surfer_token) as api:
+        rates = {
+            host.username: api.GetResponseRate(requests_pb2.GetResponseRateReq(user_id=host.id))
+            for host in (responsive, unresponsive, quiet)
+        }
+
+    assert rates[quiet.username].HasField("insufficient_data")
+    assert rates[unresponsive.username].HasField("low")
+    assert rates[responsive.username].HasField("almost_all")

--- a/app/backend/src/tests/test_fixture_diversity.py
+++ b/app/backend/src/tests/test_fixture_diversity.py
@@ -1,0 +1,39 @@
+"""
+Guards the diversity of the user fixtures themselves: a population that shares a birthdate, a gender and a location
+hides bugs that mistake those values for an identity, and makes distance errors untestable.
+"""
+
+from datetime import date
+
+from tests.fixtures.db import make_user
+
+
+def test_users_differ_from_each_other():
+    users = [make_user(username=f"diverse_user_{i}") for i in range(8)]
+
+    assert len({user.birthdate for user in users}) == len(users)
+    assert len({user.coordinates for user in users}) == len(users)
+    assert len({user.gender for user in users}) > 1
+
+
+def test_users_are_adults_in_new_york():
+    for i in range(8):
+        user = make_user(username=f"diverse_user_{i}")
+        assert date(1950, 1, 1) <= user.birthdate <= date(2005, 1, 1)
+        lat, lng = user.coordinates
+        assert 40.2 < lat < 41.3 and -74.5 < lng < -73.4
+
+
+def test_a_shared_fixture_seed_collides_users():
+    user1 = make_user(fixture_seed="shared")
+    user2 = make_user(fixture_seed="shared")
+
+    assert (user1.birthdate, user1.gender, user1.coordinates) == (user2.birthdate, user2.gender, user2.coordinates)
+    assert user1.username != user2.username
+
+
+def test_explicit_values_win_over_derived_ones():
+    user = make_user(birthdate=date(1988, 1, 1), gender="Man")
+
+    assert user.birthdate == date(1988, 1, 1)
+    assert user.gender == "Man"

--- a/app/backend/src/tests/test_public.py
+++ b/app/backend/src/tests/test_public.py
@@ -25,7 +25,7 @@ from couchers.models import (
 )
 from couchers.proto import api_pb2, public_pb2
 from couchers.servicers.public import _get_donation_stats, _get_public_users, _get_signup_page_info, _get_volunteers
-from couchers.utils import now
+from couchers.utils import create_coordinate, now
 from tests.fixtures.db import generate_user, make_volunteer
 from tests.fixtures.misc import process_jobs
 from tests.fixtures.sessions import public_session
@@ -37,14 +37,10 @@ def _(testconfig):
 
 
 def test_GetPublicMapLayer(db):
-    user1, _ = generate_user()
-    user2, _ = generate_user(username="user2", public_visibility=ProfilePublicVisibility.nothing)
-    user3, _ = generate_user()
-    user4, _ = generate_user(username="user4", public_visibility=ProfilePublicVisibility.limited)
-    user5, _ = generate_user()
-
-    # these are hardcoded in test_fixtures
-    test_user_coordinates = [-73.9740, 40.7108]
+    # a degree apart each, so a randomized location (at most 0.1 degrees off) can only belong to one of them
+    map_only_users = [generate_user(geom=create_coordinate(40 + i, -74))[0] for i in range(3)]
+    generate_user(username="user2", public_visibility=ProfilePublicVisibility.nothing)
+    named_user, _ = generate_user(username="user4", public_visibility=ProfilePublicVisibility.limited)
 
     with session_scope() as session:
         queue_job(session, job=update_randomized_locations, payload=empty_pb2.Empty())
@@ -55,43 +51,32 @@ def test_GetPublicMapLayer(db):
         http_body = public.GetPublicUsers(empty_pb2.Empty())
         assert http_body.content_type == "application/json"
         data = json.loads(http_body.data)
-        # Sort to ensure a deterministic order
-        data["features"].sort(key=lambda f: f["geometry"]["coordinates"][0])
-        assert data == {
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [-74.042643848, 40.706241098]},
-                    "properties": {"username": None},
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [-73.974, 40.7108]},
-                    "properties": {"username": "user4"},
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [-73.955417734, 40.691831306]},
-                    "properties": {"username": None},
-                },
-                {
-                    "type": "Feature",
-                    "geometry": {"type": "Point", "coordinates": [-73.928380198, 40.729706144]},
-                    "properties": {"username": None},
-                },
-            ],
-        }
 
-        for user in data["features"]:
-            coords = user["geometry"]["coordinates"]
-            if user["properties"]["username"]:
-                assert coords == test_user_coordinates
-            else:
-                xdiff = coords[0] - test_user_coordinates[0]
-                ydiff = coords[1] - test_user_coordinates[1]
-                dist = sqrt(xdiff**2 + ydiff**2)
-                assert dist > 0.02 and dist < 0.1
+    assert data["type"] == "FeatureCollection"
+    named = [feature for feature in data["features"] if feature["properties"]["username"]]
+    anonymous = [feature for feature in data["features"] if not feature["properties"]["username"]]
+
+    lat, lng = named_user.coordinates
+    assert len(named) == 1
+    assert named[0]["type"] == "Feature"
+    assert named[0]["properties"] == {"username": "user4"}
+    assert named[0]["geometry"]["type"] == "Point"
+    # the response rounds coordinates to nine decimal places
+    assert named[0]["geometry"]["coordinates"] == pytest.approx([lng, lat])
+
+    # each map-only user appears exactly once, displaced from their real location by 0.02 to 0.1 degrees
+    assert len(anonymous) == len(map_only_users)
+    for user in map_only_users:
+        lat, lng = user.coordinates
+        distances = [
+            sqrt(
+                (feature["geometry"]["coordinates"][0] - lng) ** 2 + (feature["geometry"]["coordinates"][1] - lat) ** 2
+            )
+            for feature in anonymous
+        ]
+        nearest = min(range(len(anonymous)), key=distances.__getitem__)
+        assert 0.02 < distances[nearest] < 0.1
+        anonymous.pop(nearest)
 
 
 def test_GetPublicMapLayer_excludes_shadowed(db):

--- a/app/backend/src/tests/test_visible_users.py
+++ b/app/backend/src/tests/test_visible_users.py
@@ -33,7 +33,7 @@ def test_is_visible_property(db):
 
         visible_users = session.execute(select(User.id).where(User.is_visible)).scalars().all()
 
-        assert visible_users[0] == user1.id
+        assert set(visible_users) == {user1.id}
 
 
 def test_select_dot_where_users_visible(db):


### PR DESCRIPTION
The backend test fixtures build every user from one template, so a whole test database shares a single birthdate, gender and set of coordinates, and nothing checks that a fact belonging to one user doesn't reach another. That combination is what let the `lite_users` strong verification bug live for 21 months: the view matched verification attempts to users by birthdate and gender, every fixture user was born on the same day, and no test asserted that a second user *didn't* get the badge. Birthdate, gender and coordinates are now derived from the username so users differ from each other, with a shared `fixture_seed` or an explicit value as the opt-in for tests that want a collision. New confinement tests cover `GetUser`, `GetLiteUser`, `GetLiteUsers`, the GIS user GeoJSON, `lite_users` itself and `GetResponseRate`, asserting that each per-user fact reaches exactly one user in a population built to collide on everything that isn't an identity.

The public map layer test asserted coordinates copied from the fixtures, so it couldn't tell whether each randomised location belonged to the user it was served for. It now checks each user against their own location.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
