### PR TITLE
UpdateEvent(update_all_future) rewrites occurrences of other events

### DIFF
--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -779,6 +779,13 @@ class Events(events_pb2_grpc.EventsServicer):
         if end_datetime != occurrence.end_time:
             notify_updated.append(notification_data_pb2.EventUpdateItem.EVENT_UPDATE_ITEM_END_TIME)
 
+        if request.update_all_future and (
+            start_datetime != occurrence.start_time or end_datetime != occurrence.end_time
+        ):
+            # Not implemented: every future occurrence would need its own times, rechecked against the others.
+            # Writing this one range to all of them violates the exclusion constraint on (event_id, during).
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "event_cant_update_all_times")
+
         if start_datetime != occurrence.start_time or end_datetime != occurrence.end_time:
             _check_occurrence_time_validity(start_datetime, end_datetime, context)
 
@@ -808,6 +815,8 @@ class Events(events_pb2_grpc.EventsServicer):
         if request.update_all_future:
             session.execute(
                 update(EventOccurrence)
+                .where(EventOccurrence.event_id == event.id)
+                .where(~EventOccurrence.is_deleted)
                 .where(EventOccurrence.end_time >= cutoff_time)
                 .where(EventOccurrence.start_time >= occurrence.start_time)
                 .values(occurrence_update)

--- a/app/backend/src/tests/test_events.py
+++ b/app/backend/src/tests/test_events.py
@@ -850,6 +850,156 @@ def test_UpdateEvent_all(db, moderator: Moderator):
             assert time_before_update <= to_aware_datetime(res.last_edited) <= time_after_update
 
 
+def test_UpdateEvent_all_leaves_other_events_alone(db, moderator: Moderator):
+    """update_all_future must only touch the occurrences of the event being edited."""
+    # creator of the event that gets edited
+    user1, token1 = generate_user()
+    # creator of an unrelated event in the same time window
+    user2, token2 = generate_user()
+    # community moderator, so that neither creator has edit rights on the other's event
+    user3, token3 = generate_user()
+
+    with session_scope() as session:
+        create_community(session, 0, 2, "Community", [user3], [], None)
+
+    start_time = now() + timedelta(hours=1)
+
+    with events_session(token1) as api:
+        edited_id = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Edited Event",
+                content="0th occurrence",
+                location=events_pb2.EventLocation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=1)),
+            )
+        ).event_id
+
+        second_id = api.ScheduleEvent(
+            events_pb2.ScheduleEventReq(
+                event_id=edited_id,
+                content="1th occurrence",
+                location=events_pb2.EventLocation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=2)),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=3)),
+            )
+        ).event_id
+
+    # an occurrence of a different event, starting after the edited one and ending well after the cutoff
+    with events_session(token2) as api:
+        other_id = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Other Event",
+                content="Other content.",
+                location=events_pb2.EventLocation(
+                    address="Somewhere else entirely",
+                    lat=0.5,
+                    lng=0.5,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=4)),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=5)),
+            )
+        ).event_id
+
+    for occurrence_id in (edited_id, second_id, other_id):
+        moderator.approve_event_occurrence(occurrence_id)
+
+    with events_session(token2) as api:
+        other_before = api.GetEvent(events_pb2.GetEventReq(event_id=other_id))
+
+    with events_session(token1) as api:
+        api.UpdateEvent(
+            events_pb2.UpdateEventReq(
+                event_id=edited_id,
+                content=wrappers_pb2.StringValue(value="New content."),
+                location=events_pb2.EventLocation(
+                    address="Not so near Null Island",
+                    lat=0.2,
+                    lng=0.2,
+                ),
+                update_all_future=True,
+            )
+        )
+
+    with events_session(token3) as api:
+        for occurrence_id in (edited_id, second_id):
+            res = api.GetEvent(events_pb2.GetEventReq(event_id=occurrence_id))
+            assert res.content == "New content."
+            assert res.location.address == "Not so near Null Island"
+
+        res = api.GetEvent(events_pb2.GetEventReq(event_id=other_id))
+        assert res.content == "Other content."
+        assert res.location.address == "Somewhere else entirely"
+        assert res.location.lat == 0.5
+        assert res.location.lng == 0.5
+        assert res.timezone == other_before.timezone
+        assert res.last_edited == other_before.last_edited
+
+
+def test_UpdateEvent_all_cant_change_times(db, moderator: Moderator):
+    """Every future occurrence would get the same times, which the exclusion constraint forbids."""
+    user1, token1 = generate_user()
+    user2, token2 = generate_user()
+
+    with session_scope() as session:
+        create_community(session, 0, 2, "Community", [user2], [], None)
+
+    start_time = now() + timedelta(hours=1)
+
+    with events_session(token1) as api:
+        event_id = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Dummy Title",
+                content="0th occurrence",
+                location=events_pb2.EventLocation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=1)),
+            )
+        ).event_id
+
+        api.ScheduleEvent(
+            events_pb2.ScheduleEventReq(
+                event_id=event_id,
+                content="1th occurrence",
+                location=events_pb2.EventLocation(
+                    address="Near Null Island",
+                    lat=0.1,
+                    lng=0.2,
+                ),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=2)),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(start_time + timedelta(hours=3)),
+            )
+        )
+
+        with pytest.raises(grpc.RpcError) as e:
+            api.UpdateEvent(
+                events_pb2.UpdateEventReq(
+                    event_id=event_id,
+                    start_datetime_iso8601_local=wrappers_pb2.StringValue(
+                        value=datetime_to_iso8601_local(start_time + timedelta(minutes=30))
+                    ),
+                    end_datetime_iso8601_local=wrappers_pb2.StringValue(
+                        value=datetime_to_iso8601_local(start_time + timedelta(hours=1, minutes=30))
+                    ),
+                    update_all_future=True,
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "You cannot update all events if you're modifying start or end times."
+
+
 def test_GetEvent(db, moderator: Moderator):
     # event creator
     user1, token1 = generate_user()


### PR DESCRIPTION
The events service lets an organiser edit a whole series at once: `UpdateEvent` with `update_all_future` set applies the edit to every later occurrence. The bulk update it issued was not scoped to the event being edited, so it rewrote the content, photo, location, timezone and edit time of every occurrence in the database that starts at or after the edited one and has not yet ended, meaning edit rights on any one event were enough to overwrite anyone else's; it is now scoped to that event and skips deleted occurrences. Separately, when the same request also changed the start or end time, all of those occurrences were given identical times, which the exclusion constraint on `event_occurrences` rejects, so the call failed; that combination is already meant to be refused, but the check only covered a change of timezone and now covers an explicit time change too.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._