### PR TITLE
Collapse only the literals in a query log fingerprint, not the gaps between them

### DIFF
--- a/app/backend/src/tests/fixtures/query_log.py
+++ b/app/backend/src/tests/fixtures/query_log.py
@@ -83,8 +83,10 @@ def _fingerprint(statement: str) -> str:
     sql = re.sub(r"\(\?\)(?:\s*,\s*\(\?\))+", "(?)", sql)
     # Literals inlined into the statement text rather than bound. Bulk resource loads do this: the real
     # timezone_areas.sql is a few hundred INSERTs each carrying megabytes of WKB hex, so without collapsing them
-    # every row becomes its own multi-megabyte shape.
-    sql = re.sub(r"'[^']{64,}'", "'...'", sql)
+    # every row becomes its own multi-megabyte shape. Every literal is matched and the long ones are picked out
+    # afterwards, rather than matching only the long ones: a pattern for "quote, 64 characters, quote" also matches
+    # from one literal's closing quote to the next literal's opening quote, collapsing the statement in between.
+    sql = re.sub(r"'([^']*)'", lambda literal: "'...'" if len(literal.group(1)) >= 64 else literal.group(), sql)
     return _truncate(re.sub(r"\s+", " ", sql).strip())
 
 

--- a/app/backend/src/tests/test_query_log.py
+++ b/app/backend/src/tests/test_query_log.py
@@ -47,6 +47,19 @@ def test_fingerprint_collapses_bulk_inlined_literals():
     assert len(a) < 100
 
 
+def test_fingerprint_keeps_the_text_between_two_literals():
+    """The gap between two literals is not a literal, however long it is: collapsing it merges distinct shapes."""
+    touch_user = (
+        "WITH touch_user AS (UPDATE users SET last_active=now() WHERE users.id = %(id_1)s "
+        "AND users.last_active < now() - interval '5 minutes' RETURNING users.id) "
+        "INSERT INTO user_activity (user_id, period) SELECT id, interval '1 hour' FROM touch_user"
+    )
+    assert "'...'" not in query_log._fingerprint(touch_user)
+    assert query_log._fingerprint(touch_user) != query_log._fingerprint(
+        touch_user.replace("RETURNING users.id", "RETURNING users.id, users.last_active")
+    )
+
+
 def test_fingerprint_is_capped():
     """The cap is what bounds the artifact: uncapped, the timezone_areas load took one CI node's dump to 495 MB."""
     huge = query_log._fingerprint("SELECT " + "x" * 100_000)


### PR DESCRIPTION
The test suite's query log reduces every SQL statement the backend issues to a fingerprint, which is the key the CI report groups executions under and diffs against develop, so a PR can show which access patterns it changed. Literals inlined into the statement text are collapsed first, since bulk resource loads carry megabytes of data per row that would otherwise make every row its own shape. The pattern doing that matches a long run between two quotes, which describes the span from one literal's closing quote to the next one's opening quote just as well as it describes a literal, so any statement with 64 or more characters between two literals lost the text in between. Statements differing only inside such a span share a fingerprint, and the diff cannot show the change. This matches every literal instead and collapses the long ones afterwards, so the affected shapes get new fingerprints and appear once as removed and added against develop's baseline.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._