### PR TITLE
Only count a reply when the comment it hangs off is visible

### DIFF
--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -66,20 +66,19 @@ def total_num_responses(session: Session, context: CouchersContext, database_id:
         Comment,
         is_list_operation=True,
     )
-    replies = where_moderated_content_visible(
-        where_users_column_visible(
-            select(func.count())
-            .select_from(Reply)
-            .join(Comment, Comment.id == Reply.comment_id)
-            .where(Comment.thread_id == database_id)
-            .where(Reply.deleted == None),
-            context,
-            Reply.author_user_id,
-        ),
-        context,
-        Reply,
-        is_list_operation=True,
+    # The comment a reply hangs off is filtered too, since GetThread only reaches a reply through a
+    # comment it lists, and it lists a deleted comment as a stub when it still has replies.
+    replies = (
+        select(func.count())
+        .select_from(Reply)
+        .join(Comment, Comment.id == Reply.comment_id)
+        .where(Comment.thread_id == database_id)
+        .where(Reply.deleted == None)
     )
+    replies = where_users_column_visible(replies, context, Reply.author_user_id)
+    replies = where_users_column_visible(replies, context, Comment.author_user_id)
+    replies = where_moderated_content_visible(replies, context, Reply, is_list_operation=True)
+    replies = where_moderated_content_visible(replies, context, Comment, is_list_operation=True)
     return session.execute(comments).scalar_one() + session.execute(replies).scalar_one()
 
 

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -175,6 +175,17 @@ def _make_thread_and_comment(token, content="hello"):
     return parent_thread_id, comment_thread_id
 
 
+def _set_content_visibility(object_type, object_id, visibility):
+    with session_scope() as session:
+        state = session.execute(
+            select(ModerationState).where(
+                ModerationState.object_type == object_type,
+                ModerationState.object_id == object_id,
+            )
+        ).scalar_one()
+        state.visibility = visibility
+
+
 def test_comment_creates_moderation_state(db):
     """Posting a comment creates a ModerationState (shadowed) and an initial-review queue item."""
     user, token = generate_user()
@@ -453,6 +464,67 @@ def test_total_num_responses_includes_own_shadowed(db):
 
     with session_scope() as session:
         assert total_num_responses(session, author_context, parent_db_id) == 1
+
+
+def test_total_num_responses_excludes_replies_under_hidden_comment(db):
+    """A reply only counts while the comment it hangs off is visible, since that comment is the only
+    way GetThread reaches it."""
+    from couchers.context import make_background_user_context  # noqa: PLC0415
+    from couchers.servicers.threads import total_num_responses  # noqa: PLC0415
+
+    author, author_token = generate_user()
+    viewer, viewer_token = generate_user()
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="comment")
+    comment_db_id = comment_thread_id // 10
+    viewer_context = make_background_user_context(user_id=viewer.id)
+    parent_db_id, _ = divmod(parent_thread_id, 10)
+
+    with threads_session(author_token) as api:
+        reply_thread_id = api.PostReply(
+            threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="reply")
+        ).thread_id
+    reply_db_id = reply_thread_id // 10
+
+    _set_content_visibility(ModerationObjectType.comment, comment_db_id, ModerationVisibility.visible)
+    _set_content_visibility(ModerationObjectType.reply, reply_db_id, ModerationVisibility.visible)
+
+    with session_scope() as session:
+        assert total_num_responses(session, viewer_context, parent_db_id) == 2
+
+    _set_content_visibility(ModerationObjectType.comment, comment_db_id, ModerationVisibility.hidden)
+
+    with threads_session(viewer_token) as api:
+        assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
+    with session_scope() as session:
+        assert total_num_responses(session, viewer_context, parent_db_id) == 0
+
+
+def test_total_num_responses_excludes_replies_under_someone_elses_shadowed_comment(db):
+    """The reply's own author doesn't get to count it while the comment above it is still shadowed to
+    them: GetThread doesn't list that comment, so the reply isn't reachable."""
+    from couchers.context import make_background_user_context  # noqa: PLC0415
+    from couchers.servicers.threads import total_num_responses  # noqa: PLC0415
+
+    author, author_token = generate_user()
+    replier, replier_token = generate_user()
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="comment")
+    replier_context = make_background_user_context(user_id=replier.id)
+    parent_db_id, _ = divmod(parent_thread_id, 10)
+
+    with threads_session(replier_token) as api:
+        reply_thread_id = api.PostReply(
+            threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="reply")
+        ).thread_id
+
+    _set_content_visibility(ModerationObjectType.reply, reply_thread_id // 10, ModerationVisibility.visible)
+
+    with session_scope() as session:
+        assert total_num_responses(session, replier_context, parent_db_id) == 0
+
+    _set_content_visibility(ModerationObjectType.comment, comment_thread_id // 10, ModerationVisibility.visible)
+
+    with session_scope() as session:
+        assert total_num_responses(session, replier_context, parent_db_id) == 2
 
 
 def test_edit_comment_creates_version_record(db):


### PR DESCRIPTION
A thread's `num_responses` counted replies under comments the thread itself hides. `total_num_responses` joined `Comment` only to reach the thread, applying moderation and author visibility to the `Reply` but nothing to the `Comment`, while `GetThread` filters the comments it lists on both. So once a moderator hid a comment that already had approved replies, those replies kept counting, and the count sat next to a listing that showed nothing. The same held before any moderator acted: a reply approved under a still-shadowed comment counted for its author, who cannot see the comment it hangs off. Filter the joined comment the same way the listing does, keeping deleted comments in scope since `GetThread` renders those as stubs with their replies.

## Testing

- `test_total_num_responses_excludes_replies_under_hidden_comment`: a comment and its reply are both approved and the count is 2; hiding the comment drops both `GetThread`'s listing and the count to 0. Fails on `develop` (count stays 2 while the listing is empty).
- `test_total_num_responses_excludes_replies_under_someone_elses_shadowed_comment`: the replier's own approved reply doesn't count while the comment above it is shadowed to them, and counts once that comment is approved. Fails on `develop`.
- `src/tests/test_threads.py`, `test_discussions.py`, `test_pages.py` and `test_communities.py` pass locally; `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] ~~Added migrations if there are any database changes~~ (no database changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
