### PR TITLE
Only count public trip offers the owner can open

### DIFF
--- a/app/backend/src/couchers/servicers/public_trips.py
+++ b/app/backend/src/couchers/servicers/public_trips.py
@@ -77,12 +77,18 @@ def public_trip_to_pb(
         same_gender_only=public_trip.same_gender_only,
     )
     if public_trip.user_id == context.user_id:
-        pb.offers_count = session.execute(
+        # Filtered like the thread list the owner opens the offers from, since an offer they can't
+        # open shouldn't raise the count. The recipient of an offer on the trip is the owner, i.e.
+        # the viewer, so only the offering user's visibility needs checking.
+        offers = (
             select(func.count())
             .select_from(HostRequest)
             .where(HostRequest.public_trip_id == public_trip.id)
             .where(HostRequest.status != HostRequestStatus.cancelled)
-        ).scalar_one()
+        )
+        offers = where_users_column_visible(offers, context, HostRequest.initiator_user_id)
+        offers = where_moderated_content_visible(offers, context, HostRequest, is_list_operation=True)
+        pb.offers_count = session.execute(offers).scalar_one()
     else:
         # The viewer's own existing offer on this trip (if any), so the client can
         # show an "already offered" state and link to the thread.

--- a/app/backend/src/couchers/servicers/public_trips.py
+++ b/app/backend/src/couchers/servicers/public_trips.py
@@ -77,9 +77,6 @@ def public_trip_to_pb(
         same_gender_only=public_trip.same_gender_only,
     )
     if public_trip.user_id == context.user_id:
-        # Filtered like the thread list the owner opens the offers from, since an offer they can't
-        # open shouldn't raise the count. The recipient of an offer on the trip is the owner, i.e.
-        # the viewer, so only the offering user's visibility needs checking.
         offers = (
             select(func.count())
             .select_from(HostRequest)

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -169,13 +169,7 @@ class Moderator:
             )
 
     def hide_host_request(self, host_request_id: int, reason: str = "Test hide") -> None:
-        """
-        Hide a host request using the moderation API.
-
-        Args:
-            host_request_id: The conversation_id of the host request
-            reason: Optional reason for hiding
-        """
+        """Hide a host request using the moderation API. host_request_id is its conversation_id."""
         with real_moderation_session(self.token) as api:
             state_res = api.GetModerationState(
                 moderation_pb2.GetModerationStateReq(

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -168,6 +168,31 @@ class Moderator:
                 )
             )
 
+    def hide_host_request(self, host_request_id: int, reason: str = "Test hide") -> None:
+        """
+        Hide a host request using the moderation API.
+
+        Args:
+            host_request_id: The conversation_id of the host request
+            reason: Optional reason for hiding
+        """
+        with real_moderation_session(self.token) as api:
+            state_res = api.GetModerationState(
+                moderation_pb2.GetModerationStateReq(
+                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_HOST_REQUEST,
+                    object_id=host_request_id,
+                )
+            )
+            api.ModerateContent(
+                moderation_pb2.ModerateContentReq(
+                    moderation_state_id=state_res.moderation_state.moderation_state_id,
+                    action=moderation_pb2.MODERATION_ACTION_HIDE,
+                    visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+                    reason=reason,
+                    clear_flags=True,
+                )
+            )
+
     def approve_group_chat(self, group_chat_id: int, reason: str = "Test approval") -> None:
         """
         Approve a group chat using the moderation API.

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -46,7 +46,7 @@ from tests.fixtures.db import (
     generate_user,
     make_friends,
 )
-from tests.fixtures.misc import EmailCollector, PushCollector
+from tests.fixtures.misc import EmailCollector, Moderator, PushCollector
 from tests.fixtures.sessions import (
     account_session,
     auth_api_session,
@@ -289,7 +289,7 @@ def test_UnbanUser(db):
     assert res.admin_actions[0].level == admin_pb2.ADMIN_ACTION_LEVEL_HIGH
 
 
-def test_ShadowUser(db):
+def test_ShadowUser(db, moderator: Moderator):
     super_user, super_token = generate_user(is_superuser=True)
     surfer, surfer_token = generate_user()
     host, _ = generate_user()
@@ -307,13 +307,7 @@ def test_ShadowUser(db):
                 text=valid_request_text(),
             )
         ).host_request_id
-    with session_scope() as session:
-        state = session.execute(
-            select(ModerationState)
-            .where(ModerationState.object_type == ModerationObjectType.host_request)
-            .where(ModerationState.object_id == host_request_id)
-        ).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_host_request(host_request_id)
 
     with real_admin_session(super_token) as api:
         res = api.ShadowUser(admin_pb2.ShadowUserReq(user=surfer.username, admin_note=admin_note))
@@ -336,7 +330,7 @@ def test_ShadowUser(db):
         assert state.visibility == ModerationVisibility.shadowed
 
 
-def test_UnshadowUser(db):
+def test_UnshadowUser(db, moderator: Moderator):
     super_user, super_token = generate_user(is_superuser=True)
     surfer, surfer_token = generate_user()
     host, _ = generate_user()
@@ -362,18 +356,9 @@ def test_UnshadowUser(db):
             )
         ).host_request_id
 
+    moderator.hide_host_request(admin_hidden_request_id)
     with session_scope() as session:
         session.execute(select(User).where(User.id == surfer.id)).scalar_one().shadowed_at = now()
-        session.execute(
-            select(ModerationState)
-            .where(ModerationState.object_type == ModerationObjectType.host_request)
-            .where(ModerationState.object_id == shadow_cascade_request_id)
-        ).scalar_one().visibility = ModerationVisibility.shadowed
-        session.execute(
-            select(ModerationState)
-            .where(ModerationState.object_type == ModerationObjectType.host_request)
-            .where(ModerationState.object_id == admin_hidden_request_id)
-        ).scalar_one().visibility = ModerationVisibility.hidden
 
     with real_admin_session(super_token) as api:
         res = api.UnshadowUser(admin_pb2.UnshadowUserReq(user=surfer.username, admin_note="rehabilitated"))

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -989,7 +989,6 @@ def test_list_public_trips_by_user_offers_count_owner(db, moderator: Moderator):
             )
         ).host_request_id
 
-    # The offer is shadowed until a moderator approves it, so the owner can't open it yet
     with public_trips_session(traveler_token) as api:
         res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
         trip = next(t for t in res.public_trips if t.trip_id == trip_id)
@@ -1006,8 +1005,7 @@ def test_list_public_trips_by_user_offers_count_owner(db, moderator: Moderator):
 
 
 def test_list_public_trips_by_user_offers_count_excludes_invisible_offers(db, moderator: Moderator):
-    """The count only covers offers the owner can open: not hidden ones, and not ones from a user
-    they can't see."""
+    """The count only covers offers the owner can open."""
     traveler, traveler_token = generate_user()
     _hidden_host, hidden_host_token = generate_user()
     banned_host, banned_host_token = generate_user()

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -111,6 +111,12 @@ def _create_trip_directly(
         return trip.id
 
 
+def _set_offer_visibility(host_request_id: int, visibility: ModerationVisibility):
+    with session_scope() as session:
+        offer = session.execute(select(HostRequest).where(HostRequest.conversation_id == host_request_id)).scalar_one()
+        offer.moderation_state.visibility = visibility
+
+
 def test_create_public_trip(db):
     user, token = generate_user()
     node_id = _make_node()
@@ -978,7 +984,7 @@ def test_list_public_trips_by_user_offers_count_owner(db):
 
     # Host creates an offer via a host request linked to the trip
     with requests_session(host_token) as api:
-        api.CreateHostRequest(
+        host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=traveler.id,
                 from_date=(today() + timedelta(days=5)).isoformat(),
@@ -986,13 +992,64 @@ def test_list_public_trips_by_user_offers_count_owner(db):
                 text=_valid_request_text(),
                 public_trip_id=trip_id,
             )
-        )
+        ).host_request_id
+
+    # The offer is shadowed until a moderator approves it, so the owner can't open it yet
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        trip = next(t for t in res.public_trips if t.trip_id == trip_id)
+        assert trip.HasField("offers_count")
+        assert trip.offers_count == 0
+
+    _set_offer_visibility(host_request_id, ModerationVisibility.visible)
 
     with public_trips_session(traveler_token) as api:
         res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
         trip = next(t for t in res.public_trips if t.trip_id == trip_id)
         assert trip.HasField("offers_count")
         assert trip.offers_count == 1
+
+
+def test_list_public_trips_by_user_offers_count_excludes_invisible_offers(db):
+    """The count only covers offers the owner can open: not hidden ones, and not ones from a user
+    they can't see."""
+    traveler, traveler_token = generate_user()
+    _hidden_host, hidden_host_token = generate_user()
+    banned_host, banned_host_token = generate_user()
+    node_id = _make_node()
+
+    trip_id = _create_trip_directly(traveler.id, node_id, today() + timedelta(days=5), today() + timedelta(days=10))
+
+    offer_ids = []
+    for token in (hidden_host_token, banned_host_token):
+        with requests_session(token) as api:
+            offer_ids.append(
+                api.CreateHostRequest(
+                    requests_pb2.CreateHostRequestReq(
+                        host_user_id=traveler.id,
+                        from_date=(today() + timedelta(days=5)).isoformat(),
+                        to_date=(today() + timedelta(days=10)).isoformat(),
+                        text=_valid_request_text(),
+                        public_trip_id=trip_id,
+                    )
+                ).host_request_id
+            )
+    hidden_offer_id = offer_ids[0]
+
+    for offer_id in offer_ids:
+        _set_offer_visibility(offer_id, ModerationVisibility.visible)
+
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        assert next(t for t in res.public_trips if t.trip_id == trip_id).offers_count == 2
+
+    _set_offer_visibility(hidden_offer_id, ModerationVisibility.hidden)
+    with session_scope() as session:
+        session.execute(select(User).where(User.id == banned_host.id)).scalar_one().banned_at = now()
+
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        assert next(t for t in res.public_trips if t.trip_id == trip_id).offers_count == 0
 
 
 def test_list_public_trips_by_user_offers_count_not_set_for_others(db):
@@ -1036,6 +1093,8 @@ def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
             .scalars()
             .all()
         )
+        for offer in offers:
+            offer.moderation_state.visibility = ModerationVisibility.visible
         offers[0].status = HostRequestStatus.pending
         offers[1].status = HostRequestStatus.accepted
         offers[2].status = HostRequestStatus.confirmed

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -25,6 +25,7 @@ from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.proto import public_trips_pb2, requests_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_multi, today
 from tests.fixtures.db import generate_user
+from tests.fixtures.misc import Moderator
 from tests.fixtures.sessions import public_trips_session, requests_session
 
 
@@ -109,12 +110,6 @@ def _create_trip_directly(
         session.flush()
         moderation_state.object_id = trip.id
         return trip.id
-
-
-def _set_offer_visibility(host_request_id: int, visibility: ModerationVisibility):
-    with session_scope() as session:
-        offer = session.execute(select(HostRequest).where(HostRequest.conversation_id == host_request_id)).scalar_one()
-        offer.moderation_state.visibility = visibility
 
 
 def test_create_public_trip(db):
@@ -969,7 +964,7 @@ def test_list_public_trips_by_user_status_filter_ignored_for_others(db):
         assert [t.trip_id for t in res.public_trips] == [active]
 
 
-def test_list_public_trips_by_user_offers_count_owner(db):
+def test_list_public_trips_by_user_offers_count_owner(db, moderator: Moderator):
     traveler, traveler_token = generate_user()
     host, host_token = generate_user()
     node_id = _make_node()
@@ -1001,7 +996,7 @@ def test_list_public_trips_by_user_offers_count_owner(db):
         assert trip.HasField("offers_count")
         assert trip.offers_count == 0
 
-    _set_offer_visibility(host_request_id, ModerationVisibility.visible)
+    moderator.approve_host_request(host_request_id)
 
     with public_trips_session(traveler_token) as api:
         res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
@@ -1010,7 +1005,7 @@ def test_list_public_trips_by_user_offers_count_owner(db):
         assert trip.offers_count == 1
 
 
-def test_list_public_trips_by_user_offers_count_excludes_invisible_offers(db):
+def test_list_public_trips_by_user_offers_count_excludes_invisible_offers(db, moderator: Moderator):
     """The count only covers offers the owner can open: not hidden ones, and not ones from a user
     they can't see."""
     traveler, traveler_token = generate_user()
@@ -1037,13 +1032,13 @@ def test_list_public_trips_by_user_offers_count_excludes_invisible_offers(db):
     hidden_offer_id = offer_ids[0]
 
     for offer_id in offer_ids:
-        _set_offer_visibility(offer_id, ModerationVisibility.visible)
+        moderator.approve_host_request(offer_id)
 
     with public_trips_session(traveler_token) as api:
         res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
         assert next(t for t in res.public_trips if t.trip_id == trip_id).offers_count == 2
 
-    _set_offer_visibility(hidden_offer_id, ModerationVisibility.hidden)
+    moderator.hide_host_request(hidden_offer_id)
     with session_scope() as session:
         session.execute(select(User).where(User.id == banned_host.id)).scalar_one().banned_at = now()
 
@@ -1065,7 +1060,7 @@ def test_list_public_trips_by_user_offers_count_not_set_for_others(db):
         assert not res.public_trips[0].HasField("offers_count")
 
 
-def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
+def test_list_public_trips_by_user_offers_count_excludes_cancelled(db, moderator: Moderator):
     traveler, traveler_token = generate_user()
     hosts = [generate_user() for _ in range(5)]
     node_id = _make_node()
@@ -1074,7 +1069,7 @@ def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
 
     for _host, host_token in hosts:
         with requests_session(host_token) as api:
-            api.CreateHostRequest(
+            offer_id = api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
                     host_user_id=traveler.id,
                     from_date=(today() + timedelta(days=5)).isoformat(),
@@ -1082,7 +1077,8 @@ def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
                     text=_valid_request_text(),
                     public_trip_id=trip_id,
                 )
-            )
+            ).host_request_id
+        moderator.approve_host_request(offer_id)
 
     # Set one offer per status, so we cover every status the count has to consider.
     with session_scope() as session:
@@ -1093,8 +1089,6 @@ def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
             .scalars()
             .all()
         )
-        for offer in offers:
-            offer.moderation_state.visibility = ModerationVisibility.visible
         offers[0].status = HostRequestStatus.pending
         offers[1].status = HostRequestStatus.accepted
         offers[2].status = HostRequestStatus.confirmed

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -22,6 +22,7 @@ from couchers.proto import discussions_pb2, events_pb2, moderation_pb2, threads_
 from couchers.servicers.threads import pack_thread_id
 from couchers.utils import datetime_to_iso8601_local, now
 from tests.fixtures.db import generate_user
+from tests.fixtures.misc import Moderator
 from tests.fixtures.sessions import discussions_session, events_session, real_moderation_session, threads_session
 from tests.test_communities import create_community
 
@@ -238,20 +239,14 @@ def test_shadowed_comment_visible_to_author_only(db):
         assert len(ret.replies) == 0
 
 
-def test_shadowed_reply_visible_to_author_only(db):
+def test_shadowed_reply_visible_to_author_only(db, moderator: Moderator):
     """A shadowed reply is visible to its author but not to other users."""
     author, author_token = generate_user()
     other, other_token = generate_user()
 
     _, comment_thread_id = _make_thread_and_comment(author_token, content="hi")
     # Approve the comment so the parent comment is visible to others (otherwise they can't see the comment context anyway)
-    comment_db_id = comment_thread_id // 10
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        state = session.execute(
-            select(ModerationState).where(ModerationState.id == comment.moderation_state_id)
-        ).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_thread_post(comment_thread_id)
 
     with threads_session(author_token) as api:
         api.PostReply(threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="my reply"))
@@ -268,23 +263,13 @@ def test_shadowed_reply_visible_to_author_only(db):
         assert len(ret.replies) == 0
 
 
-def _approve(session, moderation_state_id):
-    session.execute(
-        select(ModerationState).where(ModerationState.id == moderation_state_id)
-    ).scalar_one().visibility = ModerationVisibility.visible
-
-
-def test_comment_by_invisible_user_hidden(db):
+def test_comment_by_invisible_user_hidden(db, moderator: Moderator):
     """A comment by a deleted/banned user is hidden from others even when its moderation state is visible."""
     author, author_token = generate_user()
     other, other_token = generate_user()
 
     parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="from invisible user")
-    comment_db_id = comment_thread_id // 10
-
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        _approve(session, comment.moderation_state_id)
+    moderator.approve_thread_post(comment_thread_id)
 
     # while the author is visible, the comment shows
     with threads_session(other_token) as api:
@@ -299,7 +284,7 @@ def test_comment_by_invisible_user_hidden(db):
         assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
 
 
-def test_reply_by_invisible_user_hidden(db):
+def test_reply_by_invisible_user_hidden(db, moderator: Moderator):
     """A reply by a deleted/banned user is hidden from others even when its moderation state is visible."""
     commenter, commenter_token = generate_user()
     replier, replier_token = generate_user()
@@ -307,19 +292,13 @@ def test_reply_by_invisible_user_hidden(db):
 
     # comment by a user who stays visible, so the parent comment can still be navigated to
     parent_thread_id, comment_thread_id = _make_thread_and_comment(commenter_token, content="hi")
-    comment_db_id = comment_thread_id // 10
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        _approve(session, comment.moderation_state_id)
+    moderator.approve_thread_post(comment_thread_id)
 
     with threads_session(replier_token) as api:
         reply_thread_id = api.PostReply(
             threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="my reply")
         ).thread_id
-    reply_db_id = reply_thread_id // 10
-    with session_scope() as session:
-        reply = session.execute(select(Reply).where(Reply.id == reply_db_id)).scalar_one()
-        _approve(session, reply.moderation_state_id)
+    moderator.approve_thread_post(reply_thread_id)
 
     # while the replier is visible, the reply shows and is counted on the parent comment
     with threads_session(viewer_token) as api:
@@ -373,28 +352,23 @@ def test_admin_can_approve_comment(db):
         assert ret.replies[0].content == "approved comment"
 
 
-def test_admin_can_hide_comment(db):
+def test_admin_can_hide_comment(db, moderator: Moderator):
     """A moderator can hide an approved comment, removing it from non-author views."""
     author, author_token = generate_user()
     other, other_token = generate_user()
-    _moderator, moderator_token = generate_user(is_superuser=True)
 
     parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="bad comment")
     comment_db_id = comment_thread_id // 10
-
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        state_id = comment.moderation_state_id
-        # Pretend the comment was previously approved
-        state = session.execute(select(ModerationState).where(ModerationState.id == state_id)).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_thread_post(comment_thread_id)
 
     # Other user sees it
     with threads_session(other_token) as api:
         assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 1
 
     # Moderator hides it
-    with real_moderation_session(moderator_token) as api:
+    with session_scope() as session:
+        state_id = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one().moderation_state_id
+    with real_moderation_session(moderator.token) as api:
         api.ModerateContent(
             moderation_pb2.ModerateContentReq(
                 moderation_state_id=state_id,
@@ -412,13 +386,13 @@ def test_admin_can_hide_comment(db):
         assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
 
 
-def test_total_num_responses_excludes_shadowed(db):
+def test_total_num_responses_excludes_shadowed(db, moderator: Moderator):
     from couchers.context import make_background_user_context  # noqa: PLC0415
     from couchers.servicers.threads import total_num_responses  # noqa: PLC0415
 
     author, author_token = generate_user()
     viewer, _ = generate_user()
-    parent_thread_id, _ = _make_thread_and_comment(author_token, content="one")
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="one")
     viewer_context = make_background_user_context(user_id=viewer.id)
 
     parent_db_id, _ = divmod(parent_thread_id, 10)
@@ -426,14 +400,7 @@ def test_total_num_responses_excludes_shadowed(db):
     with session_scope() as session:
         assert total_num_responses(session, viewer_context, parent_db_id) == 0
 
-    with session_scope() as session:
-        state = session.execute(
-            select(ModerationState).where(
-                ModerationState.object_type == ModerationObjectType.comment,
-                ModerationState.object_id == session.execute(select(Comment.id)).scalar_one(),
-            )
-        ).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_thread_post(comment_thread_id)
 
     with session_scope() as session:
         assert total_num_responses(session, viewer_context, parent_db_id) == 1


### PR DESCRIPTION
A public trip's `offers_count` counted every non-cancelled host request linked to the trip, applying neither moderation nor user visibility, while the thread list the owner opens those offers from filters on both. A host request is created shadowed, so this was the ordinary case rather than an edge case: the owner saw a count of offers awaiting initial review, and clicked through to a list that didn't have them. An offer from a banned, deleted or blocked user counted the same way. Filter the count exactly as the thread list is filtered — the offer's own moderation visibility, and the offering user's visibility. The recipient of an offer on a trip is the trip owner, i.e. the viewer, so only the offering side needs a visibility check.

## Testing

- `test_list_public_trips_by_user_offers_count_owner` now pins the whole lifecycle: a fresh offer is shadowed and doesn't count, and it counts once approved. The pre-approval assertion fails on `develop`.
- `test_list_public_trips_by_user_offers_count_excludes_invisible_offers` (new): two approved offers count as 2; hiding one and banning the other's author takes the count to 0. Fails on `develop`.
- `test_list_public_trips_by_user_offers_count_excludes_cancelled` now approves its offers, so it still exercises the status rule rather than passing for the wrong reason.
- `src/tests/test_public_trips.py`, `test_requests.py` and `test_message_threads.py` pass locally; `make format` and `make mypy` clean.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] ~~Added migrations if there are any database changes~~ (no database changes)

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
