### PR TITLE
Stop every login re-selecting the whole user row

### DIFF
--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -130,14 +130,20 @@ def create_session(
         user_session.expiry = func.now() + duration
 
     session.add(user_session)
+
+    # read off the user before the commit expires it: every attribute touched after the commit re-selects the
+    # whole row, and this is on the path of every single login
+    user_id = user.id
+    user_gender = user.gender
+
     session.commit()
 
-    logger.debug(f"Handing out {token=} to {user=}")
+    logger.debug("Handing out %s to user %s", token, user_id)
 
     if set_cookie:
-        context.set_cookies(create_session_cookies(token, user.id, user_session.expiry))
+        context.set_cookies(create_session_cookies(token, user_id, user_session.expiry))
 
-    logins_counter.labels(user.gender).inc()
+    logins_counter.labels(user_gender).inc()
 
     return token, user_session.expiry
 

--- a/app/backend/src/tests/fixtures/sessions.py
+++ b/app/backend/src/tests/fixtures/sessions.py
@@ -90,6 +90,9 @@ class _MockCouchersContext:
     def get_header(self, name):
         return None
 
+    def set_cookies(self, cookies):
+        pass
+
 
 class CookieMetadataPlugin(grpc.AuthMetadataPlugin):
     """

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -5,12 +5,13 @@ from unittest.mock import DEFAULT, patch
 import grpc
 import pytest
 from google.protobuf import empty_pb2, wrappers_pb2
-from sqlalchemy import select, update
+from sqlalchemy import event, select, update
 from sqlalchemy.sql import delete, func
 
 from couchers import urls
+from couchers.context import CouchersContext
 from couchers.crypto import hash_password, random_hex
-from couchers.db import session_scope
+from couchers.db import _get_base_engine, session_scope
 from couchers.models import (
     ContributeOption,
     ContributorForm,
@@ -26,11 +27,13 @@ from couchers.models import (
     UserSession,
 )
 from couchers.proto import account_pb2, api_pb2, auth_pb2
+from couchers.servicers.auth import create_session
 from couchers.utils import now
 from tests.fixtures.db import generate_user
 from tests.fixtures.misc import EmailCollector, PushCollector
 from tests.fixtures.sessions import (
     MetadataKeeperInterceptor,
+    _MockCouchersContext,
     account_session,
     api_session,
     auth_api_session,
@@ -1623,3 +1626,29 @@ def test_signup_motivations_empty_motivations_list(db):
         flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
         assert flow.heard_about_couchers == "former_cs_member"
         assert flow.signup_motivations == []
+
+
+def test_create_session_does_not_reselect_the_user(db):
+    """
+    The commit in create_session expires the user, so anything read off it afterwards re-selects the whole row.
+
+    This is on the path of every login, so it was the most executed statement in the query log.
+    """
+    user, _ = generate_user()
+
+    statements = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    engine = _get_base_engine()
+    with session_scope() as session:
+        db_user = session.execute(select(User).where(User.id == user.id)).scalar_one()
+        context = cast(CouchersContext, _MockCouchersContext())
+        event.listen(engine, "before_cursor_execute", record)
+        try:
+            create_session(context, session, db_user, False)
+        finally:
+            event.remove(engine, "before_cursor_execute", record)
+
+    assert not [statement for statement in statements if "FROM users" in statement]


### PR DESCRIPTION
Session creation is on the path of every login, API key issue and test fixture: it writes the session row, commits, and then reads a few things back off the user to set the session cookie and count the login. SQLAlchemy expires the user on commit, so each of those reads re-selected the entire user row from the database, and the debug log line interpolated the user into an f-string that was built whatever the log level, forcing the same select even when debug logging is off. That select was the most executed statement in the backend query log. The values needed after the commit are now read off the user before it, and the log line no longer renders the user.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._