### PR TITLE
Add frontend codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Only the last matching line's owners are added to the PR
 * @aapeliv
 /app/**/locales/*.json @tristanlabelle # Watch Weblate integrations
-/app/web/ @nabramow
+/app/web/ @nabramow @darrenvong @papeldeorigami
 /docs/ @aapeliv @nabramow


### PR DESCRIPTION
Adding @darrenvong and @papeldeorigami as frontend codeowners so they have the ability to block risky PRs when they see them.