### PR TITLE
Stop notifications about hidden content reaching its author

### DIFF
--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -235,18 +235,21 @@ def moderation_state_column_visible(
                 )
             )
 
+    conditions = [
+        aliased_mod_state.visibility == ModerationVisibility.visible,
+        aliased_mod_state.visibility == ModerationVisibility.unlisted,
+    ]
+    if shadowed_conditions:
+        conditions.append(
+            and_(
+                aliased_mod_state.visibility == ModerationVisibility.shadowed,
+                or_(*shadowed_conditions),
+            )
+        )
+
     return or_(
         column.is_(None),
-        exists(
-            select(aliased_mod_state.id).where(
-                aliased_mod_state.id == column,
-                or_(
-                    aliased_mod_state.visibility == ModerationVisibility.visible,
-                    aliased_mod_state.visibility == ModerationVisibility.unlisted,
-                    *shadowed_conditions,
-                ),
-            )
-        ),
+        exists(select(aliased_mod_state.id).where(aliased_mod_state.id == column, or_(*conditions))),
     )
 
 

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -193,6 +193,43 @@ class Moderator:
                 )
             )
 
+    def set_group_chat_visibility(
+        self,
+        group_chat_id: int,
+        visibility: moderation_pb2.ModerationVisibility.ValueType,
+        reason: str = "Test moderation",
+    ) -> None:
+        """
+        Set a group chat's visibility using the moderation API.
+
+        Args:
+            group_chat_id: The conversation_id of the group chat
+            visibility: The visibility to move the group chat to
+            reason: Optional reason for the moderation
+        """
+        raising = visibility in (
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            moderation_pb2.MODERATION_VISIBILITY_UNLISTED,
+        )
+        with real_moderation_session(self.token) as api:
+            state_res = api.GetModerationState(
+                moderation_pb2.GetModerationStateReq(
+                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_GROUP_CHAT,
+                    object_id=group_chat_id,
+                )
+            )
+            api.ModerateContent(
+                moderation_pb2.ModerateContentReq(
+                    moderation_state_id=state_res.moderation_state.moderation_state_id,
+                    action=(
+                        moderation_pb2.MODERATION_ACTION_APPROVE if raising else moderation_pb2.MODERATION_ACTION_HIDE
+                    ),
+                    visibility=visibility,
+                    reason=reason,
+                    clear_flags=True,
+                )
+            )
+
     def approve_friend_request(self, friend_request_id: int, reason: str = "Test approval") -> None:
         """
         Approve a friend request using the moderation API.

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -199,14 +199,6 @@ class Moderator:
         visibility: moderation_pb2.ModerationVisibility.ValueType,
         reason: str = "Test moderation",
     ) -> None:
-        """
-        Set a group chat's visibility using the moderation API.
-
-        Args:
-            group_chat_id: The conversation_id of the group chat
-            visibility: The visibility to move the group chat to
-            reason: Optional reason for the moderation
-        """
         raising = visibility in (
             moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
             moderation_pb2.MODERATION_VISIBILITY_UNLISTED,

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -19,11 +19,8 @@ from couchers.jobs.handlers import check_expo_push_receipts
 from couchers.jobs.worker import process_job
 from couchers.models import (
     DeviceType,
-    GroupChat,
     HostingStatus,
     MeetupStatus,
-    ModerationState,
-    ModerationVisibility,
     Notification,
     NotificationDelivery,
     NotificationDeliveryType,
@@ -44,6 +41,7 @@ from couchers.proto import (
     conversations_pb2,
     editor_pb2,
     events_pb2,
+    moderation_pb2,
     notification_data_pb2,
     notifications_pb2,
 )
@@ -489,10 +487,10 @@ def test_unseen_notification_count_excludes_ums_hidden(db, moderator):
 @pytest.mark.parametrize(
     "visibility,author_sees,other_sees",
     [
-        (ModerationVisibility.visible, 1, 1),
-        (ModerationVisibility.unlisted, 1, 1),
-        (ModerationVisibility.shadowed, 1, 0),
-        (ModerationVisibility.hidden, 0, 0),
+        (moderation_pb2.MODERATION_VISIBILITY_VISIBLE, 1, 1),
+        (moderation_pb2.MODERATION_VISIBILITY_UNLISTED, 1, 1),
+        (moderation_pb2.MODERATION_VISIBILITY_SHADOWED, 1, 0),
+        (moderation_pb2.MODERATION_VISIBILITY_HIDDEN, 0, 0),
     ],
 )
 def test_notifications_follow_the_visibility_of_their_content(db, moderator, visibility, author_sees, other_sees):
@@ -511,11 +509,7 @@ def test_notifications_follow_the_visibility_of_their_content(db, moderator, vis
 
     process_jobs()
 
-    with session_scope() as session:
-        state_id = session.execute(
-            select(GroupChat.moderation_state_id).where(GroupChat.conversation_id == group_chat_id)
-        ).scalar_one()
-        session.execute(update(ModerationState).where(ModerationState.id == state_id).values(visibility=visibility))
+    moderator.set_group_chat_visibility(group_chat_id, visibility)
 
     for token, expected in [(author_token, author_sees), (other_token, other_sees)]:
         with api_session(token) as api:

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -19,8 +19,11 @@ from couchers.jobs.handlers import check_expo_push_receipts
 from couchers.jobs.worker import process_job
 from couchers.models import (
     DeviceType,
+    GroupChat,
     HostingStatus,
     MeetupStatus,
+    ModerationState,
+    ModerationVisibility,
     Notification,
     NotificationDelivery,
     NotificationDeliveryType,
@@ -481,6 +484,45 @@ def test_unseen_notification_count_excludes_ums_hidden(db, moderator):
 
     with api_session(token1) as api:
         assert api.Ping(api_pb2.PingReq()).unseen_notification_count == 1
+
+
+@pytest.mark.parametrize(
+    "visibility,author_sees,other_sees",
+    [
+        (ModerationVisibility.visible, 1, 1),
+        (ModerationVisibility.unlisted, 1, 1),
+        (ModerationVisibility.shadowed, 1, 0),
+        (ModerationVisibility.hidden, 0, 0),
+    ],
+)
+def test_notifications_follow_the_visibility_of_their_content(db, moderator, visibility, author_sees, other_sees):
+    author, author_token = generate_user()
+    other, other_token = generate_user()
+    sender, sender_token = generate_user()
+
+    with conversations_session(author_token) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[other.id, sender.id])
+        ).group_chat_id
+    moderator.approve_group_chat(group_chat_id)
+
+    with conversations_session(sender_token) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message"))
+
+    process_jobs()
+
+    with session_scope() as session:
+        state_id = session.execute(
+            select(GroupChat.moderation_state_id).where(GroupChat.conversation_id == group_chat_id)
+        ).scalar_one()
+        session.execute(update(ModerationState).where(ModerationState.id == state_id).values(visibility=visibility))
+
+    for token, expected in [(author_token, author_sees), (other_token, other_sees)]:
+        with api_session(token) as api:
+            assert api.Ping(api_pb2.PingReq()).unseen_notification_count == expected
+        with notifications_session(token) as notifications:
+            res = notifications.ListNotifications(notifications_pb2.ListNotificationsReq())
+            assert len(res.notifications) == expected
 
 
 def test_GetVapidPublicKey(db):


### PR DESCRIPTION
Notifications carry the moderation state of the content they are about, so that a notification is only delivered and listed once that content is visible, with an exception that lets an author see notifications about their own content while it is still shadowed. That exception was applied without any test on the visibility itself, so it also let through content a moderator had hidden: when a group chat, host request, event or any other moderated object was hidden, its author kept receiving the push notifications, emails and unseen count for it, carrying the content, while every other user correctly stopped. The exception is now restricted to shadowed content, matching the rule the equivalent helper for the content itself already applies.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._