### PR TITLE
Add a SQL query audit over the published query log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pyrightconfig.json
 !/.claude/tools/**
 !/.claude/skills/
 !/.claude/skills/**
+
+# scratch working directory
+/tmp/

--- a/app/scripts/query_audit.py
+++ b/app/scripts/query_audit.py
@@ -1,0 +1,1934 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["sqlglot>=27"]
+# ///
+"""Audits every SQL query shape the backend test suite issues, against the schema those queries run on.
+
+The input is the query log published by the last develop pipeline (app/scripts/query_log_report.py's merged
+data.json.gz) plus the schema dump published alongside it. Run it with uv, which resolves sqlglot from the header
+above:
+
+  uv run app/scripts/query_audit.py --data data.json.gz --schema schema.sql
+
+Both arguments accept a URL as well as a path, so the published artifacts can be audited directly:
+
+  --data https://develop--test-artifacts.preview.couchershq.org/queries/data.json.gz
+  --schema https://develop--schema.preview.couchershq.org/schema.sql
+
+Every shape is judged on each dimension below, and a shape is only retired once every dimension has cleared it.
+A dimension clears a shape either because it cannot exhibit that class of bug at all (a statement with one table
+and no subquery has no join predicate to get wrong) or because it demonstrably satisfies the invariant. Anything
+else stays open and is listed for review. Nothing is dropped for being uninteresting: the point is that the shapes
+still open at the end are the complete set of queries a human has to read.
+
+A clear is only worth as much as the check behind it, so app/scripts/query_audit_selftest.py runs each dimension
+against statements built to fail it and re-derives every clear from the raw statement text by unrelated means.
+"""
+
+import argparse
+import gzip
+import json
+import re
+import sys
+import urllib.request
+from collections import Counter, defaultdict
+from collections.abc import Callable, Iterable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import sqlglot
+from sqlglot import exp
+
+# The recorder caps both the fingerprint and the concrete example at 4096 chars and marks what it cut. A cut
+# statement is not valid SQL, so it cannot be parsed and cannot be cleared by anything here.
+TRUNCATION_MARKER = "truncated by the query log"
+
+DIALECT = "postgres"
+
+
+# ---------------------------------------------------------------------------- schema
+
+
+@dataclass
+class Schema:
+    """Primary keys, unique constraints and foreign keys, read out of the published pg_dump."""
+
+    primary_keys: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    uniques: dict[str, list[tuple[str, ...]]] = field(default_factory=lambda: defaultdict(list))
+    # (table, column) -> (referenced table, referenced column), one entry per column of the constraint
+    foreign_keys: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
+    tables: set[str] = field(default_factory=set)
+    # (view, column) -> the base table column it is a plain copy of. Views carry no constraints of their own, so
+    # without this every join to lite_users looks like it relates two unrelated columns.
+    view_columns: dict[tuple[str, str], tuple[str, str]] = field(default_factory=dict)
+    # (table, column) -> whether the column is declared NOT NULL. Base tables only.
+    not_null: set[tuple[str, str]] = field(default_factory=set)
+    columns: set[tuple[str, str]] = field(default_factory=set)
+
+    def resolve(self, column: tuple[str, str]) -> tuple[str, str]:
+        return self.view_columns.get(column, column)
+
+    def nullable(self, column: tuple[str, str]) -> bool | None:
+        """Whether this column can hold NULL, or None when the schema does not say.
+
+        A view column is always None even when it copies a NOT NULL column: every view in this schema is built
+        over an outer join or a union, either of which manufactures NULLs the base table never holds.
+        """
+        if column in self.not_null:
+            return False
+        if column in self.columns:
+            return True
+        return None
+
+    def root(self, column: tuple[str, str]) -> tuple[str, str]:
+        """Follow foreign keys to the column this one ultimately identifies a row of.
+
+        Conversations are subtyped: host_requests.id and group_chats.id are both the primary key of their table
+        and a foreign key to conversations.id, so a join of messages.conversation_id to host_requests.id relates a
+        message to its own conversation even though neither column references the other.
+        """
+        current = self.resolve(column)
+        seen = {current}
+        while (parent := self.foreign_keys.get(current)) is not None and parent not in seen:
+            current = parent
+            seen.add(current)
+        return current
+
+    def is_key(self, table: str, column: str) -> bool:
+        """Whether this column on its own identifies at most one row of the table."""
+        return self.primary_keys.get(table) == (column,) or (column,) in self.uniques.get(table, [])
+
+    def key_columns(self, table: str) -> list[tuple[str, ...]]:
+        """Every column set that identifies at most one row: the primary key and each unique constraint."""
+        keys = list(self.uniques.get(table, []))
+        pk = self.primary_keys.get(table)
+        if pk:
+            keys.append(pk)
+        return keys
+
+
+def _split_columns(raw: str) -> tuple[str, ...]:
+    return tuple(part.strip().strip('"') for part in raw.split(","))
+
+
+def parse_schema(sql: str) -> Schema:
+    """Reads constraints out of a pg_dump. Regex rather than a SQL parse: the input is machine-generated with a
+    fixed shape, while the dump as a whole contains function bodies and extension DDL a parser trips over."""
+    # Identifiers that collide with a SQL keyword come out quoted, "references" among them.
+    name = r'"?(\w+)"?'
+    qualifier = r'(?:"?\w+"?\.)?'
+    schema = Schema()
+    for match in re.finditer(rf"^CREATE (?:UNLOGGED )?TABLE {qualifier}{name} \(", sql, re.M):
+        schema.tables.add(match.group(1))
+    for match in re.finditer(rf"^CREATE (?:MATERIALIZED )?VIEW {qualifier}{name}", sql, re.M):
+        schema.tables.add(match.group(1))
+
+    constraint = re.compile(
+        rf"ALTER TABLE (?:ONLY )?{qualifier}{name}\s+ADD CONSTRAINT \w+ (PRIMARY KEY|UNIQUE|FOREIGN KEY) \(([^)]*)\)"
+        rf"(?:\s+REFERENCES {qualifier}{name}\(([^)]*)\))?",
+        re.M,
+    )
+    for match in constraint.finditer(sql):
+        table, kind, columns, ref_table, ref_columns = match.groups()
+        cols = _split_columns(columns)
+        if kind == "PRIMARY KEY":
+            schema.primary_keys[table] = cols
+        elif kind == "UNIQUE":
+            schema.uniques[table].append(cols)
+        elif ref_table:
+            for column, ref_column in zip(cols, _split_columns(ref_columns)):
+                schema.foreign_keys[(table, column)] = (ref_table, ref_column)
+
+    # Unique indexes carry the same guarantee as unique constraints and SQLAlchemy emits plenty of them.
+    for match in re.finditer(rf"^CREATE UNIQUE INDEX \w+ ON {qualifier}{name} USING \w+ \(([^)]*)\)(.*)$", sql, re.M):
+        table, columns, tail = match.groups()
+        # A partial index only identifies a row within the subset it covers, which is not a guarantee we can use
+        # without reading the predicate, so leave those out.
+        if "WHERE" in tail.upper():
+            continue
+        if all(re.fullmatch(r'"?\w+"?', part.strip()) for part in columns.split(",")):
+            schema.uniques[table].append(_split_columns(columns))
+
+    for match in re.finditer(rf"^CREATE (?:MATERIALIZED )?VIEW {qualifier}{name} AS\b(.*?);\n", sql, re.M | re.S):
+        schema.view_columns.update(view_column_origins(match.group(1), match.group(2)))
+
+    for match in re.finditer(rf"^CREATE (?:UNLOGGED )?TABLE {qualifier}{name} \((.*?)^\);", sql, re.M | re.S):
+        table, body = match.groups()
+        for line in body.splitlines():
+            line = line.strip().rstrip(",")
+            column = re.match(rf"{name}\s+(.*)$", line)
+            if not column or line.upper().startswith(("CONSTRAINT", "PRIMARY KEY", "UNIQUE", "FOREIGN KEY", "CHECK")):
+                continue
+            schema.columns.add((table, column.group(1)))
+            if "NOT NULL" in column.group(2).upper():
+                schema.not_null.add((table, column.group(1)))
+    return schema
+
+
+def view_column_origins(view: str, body: str) -> dict[tuple[str, str], tuple[str, str]]:
+    """Maps a view's output columns to the base table columns they are a plain copy of.
+
+    A view is a named query, so its columns resolve exactly the way a derived table's do.
+    """
+    try:
+        select = sqlglot.parse_one(body.replace("WITH NO DATA", ""), dialect=DIALECT)
+    except Exception:  # noqa: BLE001 - a view we cannot read simply contributes nothing
+        return {}
+    return {(view, name): origin for name, origin in projection_origins(select, []).items()}
+
+
+# ---------------------------------------------------------------------------- shapes
+
+
+@dataclass
+class Shape:
+    id: str
+    sql: str
+    example: str
+    write: bool
+    ast: exp.Expression | None
+    parse_error: str | None
+    # Call sites and spans this shape was seen under, most frequent first.
+    sites: list[str] = field(default_factory=list)
+    spans: list[str] = field(default_factory=list)
+    executions: int = 0
+
+    @property
+    def app_sites(self) -> list[str]:
+        return [site for site in self.sites if "couchers/" in site]
+
+
+def _parse(sql: str) -> exp.Expression | None:
+    parsed = sqlglot.parse_one(sql, dialect=DIALECT, error_level=sqlglot.ErrorLevel.RAISE)
+    return parsed if isinstance(parsed, exp.Expression) else None
+
+
+def parse_statement(shape: dict[str, Any]) -> tuple[exp.Expression | None, str | None]:
+    """The concrete example first: it is the statement as the driver sent it, so it parses without help. The
+    fingerprint is the fallback for the handful whose example was truncated but whose binds collapsed enough to
+    fit; its ? placeholders are rewritten to $1, which the postgres dialect understands."""
+    failure = "statement truncated by the recorder's 4096 char cap"
+    for candidate in (shape["example"], shape["sql"].replace("?", "$1")):
+        if TRUNCATION_MARKER in candidate:
+            continue
+        try:
+            parsed = _parse(candidate)
+        except Exception as error:  # noqa: BLE001 - the message is the finding
+            failure = str(error).split("\n")[0]
+            continue
+        if parsed is not None:
+            return parsed, None
+        failure = "parsed to nothing"
+    return None, failure
+
+
+def load_shapes(data: dict[str, Any]) -> dict[str, Shape]:
+    sites: dict[str, str] = data["sites"]
+    site_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    span_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    executions: Counter[str] = Counter()
+    for spans in data["tests"].values():
+        for span in spans:
+            label = f"{span['kind']}:{span['name']}" if span["name"] else span["kind"]
+            for shape_id, site_id in zip(span["queries"], span["sites"]):
+                site_counts[shape_id][sites.get(site_id, site_id)] += 1
+                span_counts[shape_id][label] += 1
+                executions[shape_id] += 1
+
+    shapes: dict[str, Shape] = {}
+    for shape_id, raw in data["shapes"].items():
+        ast, error = parse_statement(raw)
+        shapes[shape_id] = Shape(
+            id=shape_id,
+            sql=raw["sql"],
+            example=raw["example"],
+            write=raw["write"],
+            ast=ast,
+            parse_error=error,
+            sites=[site for site, _ in site_counts[shape_id].most_common()],
+            spans=[span for span, _ in span_counts[shape_id].most_common()],
+            executions=executions[shape_id],
+        )
+    return shapes
+
+
+# ---------------------------------------------------------------------------- ast helpers
+
+
+def statement_tables(ast: exp.Expression) -> set[str]:
+    """Every relation the statement reads or writes, by name. Aliases collapse onto the underlying table, which is
+    what matters for deciding whether more than one relation is in play."""
+    return {table.name for table in ast.find_all(exp.Table) if table.name}
+
+
+def has_subquery(ast: exp.Expression) -> bool:
+    """Any nested query at all: a derived table, a scalar or IN subquery, a CTE or a set operation."""
+    if any(ast.find_all(exp.Subquery, exp.With, exp.SetOperation)):
+        return True
+    # A bare Select nested under the root, as scalar subqueries and EXISTS produce.
+    return any(node is not ast for node in ast.find_all(exp.Select))
+
+
+def conjuncts(predicate: exp.Expression | None) -> list[exp.Expression]:
+    """The top level AND terms of a predicate. Only terms that must all hold, so an OR stays whole: a key equality
+    inside one arm of an OR does not bound the statement to one row."""
+    if predicate is None:
+        return []
+    if isinstance(predicate, exp.And):
+        return conjuncts(predicate.left) + conjuncts(predicate.right)
+    if isinstance(predicate, exp.Paren):
+        return conjuncts(predicate.this)
+    return [predicate]
+
+
+def _bound_value(node: exp.Expression) -> bool:
+    """A parameter or a constant, i.e. something fixed per execution rather than another column."""
+    # A cast, a sign or a parenthesis around a constant is still a constant, and the log has all three: psycopg
+    # renders a bound -1 as `-1::BIGINT`, which is a negation of a cast of a literal.
+    while isinstance(node, (exp.Cast, exp.Paren, exp.Neg)):
+        node = node.this
+    return isinstance(node, (exp.Placeholder, exp.Parameter, exp.Literal, exp.Boolean, exp.Null))
+
+
+def bound_columns(predicate: exp.Expression | None) -> set[tuple[str, str]]:
+    """Columns pinned to a fixed value by a top level equality, as (qualifier, column).
+
+    Only the top level conjunction: an equality inside one arm of an OR does not pin anything, because the other
+    arm can still match.
+    """
+    bound: set[tuple[str, str]] = set()
+    for term in conjuncts(predicate):
+        if not isinstance(term, exp.EQ):
+            continue
+        for side, other in ((term.left, term.right), (term.right, term.left)):
+            if isinstance(side, exp.Column) and _bound_value(other):
+                bound.add((side.table, side.name))
+    return bound
+
+
+def equality_bound_columns(predicate: exp.Expression | None) -> set[str]:
+    return {column for _, column in bound_columns(predicate)}
+
+
+def from_clause(node: exp.Expression) -> exp.From | None:
+    # sqlglot spells the key "from_" since v30 and "from" before it.
+    origin = node.args.get("from_") or node.args.get("from")
+    return origin if isinstance(origin, exp.From) else None
+
+
+# A base table column, as (table, column).
+Origin = tuple[str, str]
+
+
+@dataclass
+class Frame:
+    """What one query level can refer to.
+
+    `sources` maps the name a column is qualified with to the real table behind it, or None when it is a derived
+    table. `origins` covers those derived tables, mapping their output columns back to the base table columns they
+    forward, so a join onto a subquery can still be judged against real keys.
+    """
+
+    sources: dict[str, str | None] = field(default_factory=dict)
+    origins: dict[tuple[str, str], Origin] = field(default_factory=dict)
+
+
+def projection_origins(select: exp.Expression, frames: list[Frame]) -> dict[str, Origin]:
+    """For each output column of a query level, the base table column it is a plain copy of.
+
+    Only straight column references are followed: a computed column is not a column of any table, and nothing here
+    should claim it identifies rows the way its inputs do. For a set operation only the columns both sides agree
+    on are kept, since either side can supply the row.
+    """
+    if isinstance(select, exp.SetOperation):
+        left = projection_origins(select.this, frames)
+        right = projection_origins(select.expression, frames)
+        return {name: origin for name, origin in left.items() if right.get(name) == origin}
+    if isinstance(select, exp.Subquery):
+        return projection_origins(select.this, frames)
+    if not isinstance(select, exp.Select):
+        return {}
+    inner = frames + [scope_frame(select, frames)]
+    origins: dict[str, Origin] = {}
+    for projection in select.expressions:
+        column = projection.this if isinstance(projection, exp.Alias) else projection
+        # max(messages.id) is still a value of messages.id, so a derived table that picks the latest row per group
+        # still forwards a real column and can be judged against its keys.
+        if isinstance(column, (exp.Min, exp.Max)):
+            column = column.this
+        if isinstance(column, exp.Column):
+            resolved = resolve_column(column, inner)
+            if resolved:
+                origins[projection.alias_or_name] = resolved
+    return origins
+
+
+def scope_frame(node: exp.Expression, frames: list[Frame] | None = None) -> Frame:
+    """The relations a SELECT, UPDATE or DELETE puts in scope, keyed by the name its columns are qualified with."""
+    frame = Frame()
+    outer = frames or []
+
+    def add(relation: exp.Expression | None) -> None:
+        if relation is None:
+            return
+        alias = relation.alias_or_name
+        # A parenthesised join tree, which is how pg_dump writes the FROM of a view, parses as an unaliased
+        # subquery around the join. Its relations are in scope just as if the parentheses were not there.
+        if isinstance(relation, exp.Subquery) and not alias:
+            add(relation.this)
+            for nested in relation.args.get("joins") or []:
+                add(nested.this)
+            return
+        if isinstance(relation, exp.Table):
+            # A CTE is referenced exactly like a table, including from inside its own body when it recurses, so a
+            # name an enclosing level already defined as a query resolves to that query rather than to a table.
+            for enclosing in reversed(outer):
+                if enclosing.sources.get(relation.name, "") is None:
+                    frame.sources[alias] = None
+                    for (source, column), origin in enclosing.origins.items():
+                        if source == relation.name:
+                            frame.origins[(alias, column)] = origin
+                    return
+            frame.sources[alias] = relation.name
+            # SQLAlchemy qualifies columns of an unaliased table by its own name, and of an aliased one by the
+            # alias; a schema qualified table can be referred to either way.
+            frame.sources.setdefault(relation.name, relation.name)
+        elif alias:
+            frame.sources[alias] = None
+            # The frame being built is in scope for its own FROM clause: a derived table can select from a CTE
+            # this same statement declares.
+            for name, origin in projection_origins(relation, outer + [frame]).items():
+                frame.origins[(alias, name)] = origin
+
+    # A CTE is referenced by name like a table, so it has to be in scope before the FROM that uses it is read.
+    with_clause = node.args.get("with_") or node.args.get("with")
+    for cte in with_clause.expressions if with_clause else []:
+        name = cte.alias_or_name
+        frame.sources[name] = None
+        origins = projection_origins(cte.this, outer + [frame])
+        # `WITH parents(id, parent_node_id, level) AS (...)` renames the body's columns positionally.
+        declared = [column.name for column in (cte.args.get("alias").columns if cte.args.get("alias") else [])]
+        if declared:
+            inner_names = [projection.alias_or_name for projection in cte.this.selects]
+            origins = {
+                outer_name: origins[inner_name]
+                for outer_name, inner_name in zip(declared, inner_names)
+                if inner_name in origins
+            }
+        for column, origin in origins.items():
+            frame.origins[(name, column)] = origin
+
+    origin_clause = from_clause(node)
+    if origin_clause is not None:
+        add(origin_clause.this)
+    if isinstance(node, (exp.Update, exp.Delete)):
+        add(node.this)
+    for join in node.args.get("joins") or []:
+        add(join.this)
+    return frame
+
+
+def resolve_column(column: exp.Column, frames: list[Frame]) -> Origin | None:
+    """The base table column this reference ultimately names, looking outwards for correlated references."""
+    qualifier = column.table
+    if not qualifier:
+        # An unqualified column, as pg_dump writes view bodies. Attributable only when the level it sits in has a
+        # single relation, in which case there is nothing else it could have come from.
+        for frame in reversed(frames):
+            # A table is registered under both its name and its alias, so count relations, not keys.
+            distinct = {table if table else alias for alias, table in frame.sources.items()}
+            if len(distinct) != 1:
+                continue
+            only = distinct.pop()
+            if only in frame.sources and frame.sources[only] is None:
+                return frame.origins.get((only, column.name))
+            return (only, column.name)
+        return None
+    for frame in reversed(frames):
+        if qualifier not in frame.sources:
+            continue
+        table = frame.sources[qualifier]
+        if table is not None:
+            return (table, column.name)
+        return frame.origins.get((qualifier, column.name))
+    return None
+
+
+def own_nodes[T: exp.Expression](node: exp.Expression, *types: type[T]) -> Iterator[T]:
+    """Nodes of the given types that belong to this query level rather than to one nested inside it.
+
+    A nested query has its own relations in scope, so its columns say nothing about the level above: counting them
+    as the outer level's would make an ordinary subquery look like it reads relations that are not there.
+    """
+    for child in node.args.values():
+        for item in child if isinstance(child, list) else [child]:
+            if not isinstance(item, exp.Expression) or isinstance(item, (exp.Select, exp.Subquery, exp.SetOperation)):
+                continue
+            if isinstance(item, types):
+                yield item
+            yield from own_nodes(item, *types)
+
+
+def column_equalities(predicate: exp.Expression | None) -> list[tuple[exp.Column, exp.Column]]:
+    """Every column to column equality in a predicate, including inside ORs and NOTs.
+
+    Deliberately not limited to the top level conjunction: a join predicate that only correlates inside one arm of
+    an OR still correlates, and this reads the predicate for what relates the two sides, not for what it filters.
+    Equalities inside a nested query belong to that query's own level and are left to it.
+    """
+    if predicate is None:
+        return []
+    candidates = [predicate, *own_nodes(predicate, exp.EQ)]
+    return [
+        (node.left, node.right)
+        for node in candidates
+        if isinstance(node, exp.EQ) and isinstance(node.left, exp.Column) and isinstance(node.right, exp.Column)
+    ]
+
+
+def is_literal_row_source(source: exp.Expression) -> bool:
+    """Whether an INSERT's source is just the rows it was handed.
+
+    SQLAlchemy's insertmanyvalues wraps a plain multi row insert in `SELECT p0, p1 FROM (VALUES (...)) AS
+    imp_sen(p0, p1, sen_counter) ORDER BY sen_counter` so it can use RETURNING and still match results back to
+    input rows. It reads no table, so it carries no more risk than a VALUES insert, but only if the projection
+    really is the columns of that VALUES list and nothing else.
+    """
+    if isinstance(source, exp.Values):
+        return True
+    if not isinstance(source, exp.Select):
+        return False
+    if source.args.get("joins") or source.args.get("where") or source.args.get("group"):
+        return False
+    # sqlglot spells the key "from_" since v30 and "from" before it.
+    origin = source.args.get("from_") or source.args.get("from")
+    if not isinstance(origin, exp.From):
+        return False
+    relation = origin.this
+    if isinstance(relation, exp.Subquery):
+        relation = relation.this
+    if not isinstance(relation, exp.Values):
+        return False
+    # Every projected value must come from that VALUES list, so no lookup can hide in the select list. Casts are
+    # the one call allowed: the wrapper types every column it forwards.
+    for projection in source.expressions:
+        for node in projection.find_all(exp.Select, exp.Subquery, exp.Func):
+            if not isinstance(node, exp.Cast):
+                return False
+    return True
+
+
+def key_anchored(ast: exp.Expression, table: str, schema: Schema) -> tuple[str, ...] | None:
+    """The key that pins this statement to at most one row of `table`, or None if nothing does."""
+    where = ast.args.get("where")
+    bound = equality_bound_columns(where.this if isinstance(where, exp.Where) else None)
+    for key in schema.key_columns(table):
+        if set(key) <= bound:
+            return key
+    return None
+
+
+# ---------------------------------------------------------------------------- checks
+
+CLEAR = "clear"
+OPEN = "open"
+# Read by a person and found correct, or read and found wrong. Both are recorded per shape id in the ledger beside
+# this script; the id is a hash of the statement, so editing the query invalidates its review and it comes back.
+REVIEWED = "reviewed"
+BUG = "bug"
+
+# How a join relates its two sides, best first. A join is only as good as its strongest equality.
+KEY = "key"
+PINNED = "pinned"
+SHARED_PARENT = "shared parent"
+EXPRESSION = "expression"
+NON_KEY = "non key"
+UNRESOLVED = "unresolved"
+NO_EQUALITY = "no equality"
+JOIN_RANK = [KEY, PINNED, SHARED_PARENT, EXPRESSION, NON_KEY, UNRESOLVED, NO_EQUALITY]
+# The two that need no reading: the join either follows a key, or brings in a single row named by its key.
+JOIN_SAFE = {KEY, PINNED}
+
+
+def classify_pair(left: tuple[str, str], right: tuple[str, str], schema: Schema) -> str:
+    """How strongly one column equality ties two rows together.
+
+    KEY means one side is a foreign key to the other's primary key, so the equality picks out the one parent row
+    the child names. SHARED_PARENT means both sides point at the same third table, which relates rows that happen
+    to share a parent rather than rows that reference each other. NON_KEY means the equality carries no key at
+    all: matching on a birthdate is the shape that let a verification attempt attach to a stranger's account.
+    """
+    left, right = schema.resolve(left), schema.resolve(right)
+    root = schema.root(left)
+    if root != schema.root(right):
+        return NON_KEY
+    # Both sides identify a row of the same thing. If either side is a key of its own table the equality picks out
+    # at most one row there, which is a real parent-child relation.
+    if schema.is_key(*left) or schema.is_key(*right):
+        return KEY
+    # Otherwise it is only a relation at all if both sides are references to that shared row, which relates every
+    # pair that hangs off it. Two copies of a plain attribute reach a shared root trivially and relate nothing:
+    # that is what matching users on their birthdate was.
+    if left != root and right != root:
+        return SHARED_PARENT
+    return NON_KEY
+
+
+def _render(resolved: Origin | None, column: exp.Column) -> str:
+    return f"{resolved[0]}.{resolved[1]}" if resolved else f"?.{column.name}"
+
+
+def join_condition(join: exp.Join, host: exp.Expression) -> exp.Expression | None:
+    """What relates this join's relation to the rest of the query.
+
+    For an inner join the WHERE is part of it: `A JOIN B ON X WHERE Y` and `A, B WHERE X AND Y` are the same
+    query, and the strong verification leak was written the second way, so reading only the ON clause would have
+    missed the very bug this check exists for. An outer join is judged on its ON alone, because there a WHERE
+    filters the joined result instead of deciding what joins to what.
+    """
+    on = join.args.get("on")
+    if join.args.get("side"):
+        return on
+    where = host.args.get("where")
+    filtering = where.this if isinstance(where, exp.Where) else None
+    if on is None or filtering is None:
+        return on or filtering
+    return exp.and_(on, filtering)
+
+
+def classify_join(join: exp.Join, host: exp.Expression, frames: list[Frame], schema: Schema) -> tuple[str, str]:
+    """The kind of the join and a description of what related the two sides."""
+    if join.args.get("using"):
+        return KEY, "USING(...)"
+    condition = join_condition(join, host)
+    if condition is None:
+        return NO_EQUALITY, "no join condition"
+    introduced = join.this.alias_or_name if isinstance(join.this, exp.Expression) else None
+
+    best, detail = NO_EQUALITY, "nothing relates the two sides"
+    for left_column, right_column in column_equalities(condition):
+        left = resolve_column(left_column, frames)
+        right = resolve_column(right_column, frames)
+        # For a comma join the condition is the whole WHERE, most of which is ordinary filtering; only the
+        # equalities that reach the relation this join introduces say anything about the join itself.
+        if introduced and introduced not in (left_column.table, right_column.table):
+            continue
+        rendered = f"{_render(left, left_column)} = {_render(right, right_column)}"
+        if left is None or right is None:
+            kind = UNRESOLVED
+        else:
+            kind = classify_pair(left, right, schema)
+        if JOIN_RANK.index(kind) < JOIN_RANK.index(best):
+            best, detail = kind, rendered
+    # A relation whose own key is equated to a bound value contributes exactly one row, so it cannot mis-relate or
+    # multiply anything regardless of what else the join says. SQLAlchemy's join_from(a, b, b.id == some_id) does
+    # this to pull one known user into a query so a visibility clause can reference it.
+    if introduced and JOIN_RANK.index(best) > JOIN_RANK.index(PINNED):
+        table = frames[-1].sources.get(introduced)
+        pinned = {column for qualifier, column in bound_columns(condition) if qualifier == introduced}
+        if table and any(set(key) <= pinned for key in schema.key_columns(table)):
+            return PINNED, f"{introduced} pinned to one row by its key"
+    if best != NO_EQUALITY:
+        return best, detail
+    # No equality, but a predicate that mentions both sides still relates them, as a spatial containment join
+    # does. Not something that can be checked against keys, so it is reported rather than cleared.
+    qualifiers = {column.table for column in condition.find_all(exp.Column) if column.table}
+    if introduced in qualifiers and qualifiers - {introduced}:
+        return EXPRESSION, f"related by a predicate, not an equality: {condition.sql(dialect=DIALECT)[:80]}"
+    return best, detail
+
+
+UNCORRELATED = "uncorrelated"
+CORRELATION_RANK = [KEY, UNCORRELATED, SHARED_PARENT, EXPRESSION, NON_KEY, UNRESOLVED, NO_EQUALITY]
+CORRELATION_SAFE = {KEY, UNCORRELATED}
+
+
+def level_predicates(node: exp.Expression) -> list[exp.Expression]:
+    """Everything at this query level that can relate its rows to anything: its WHERE and its join conditions."""
+    predicates = []
+    where = node.args.get("where")
+    if isinstance(where, exp.Where):
+        predicates.append(where.this)
+    for join in node.args.get("joins") or []:
+        on = join.args.get("on")
+        if on is not None:
+            predicates.append(on)
+    having = node.args.get("having")
+    if isinstance(having, exp.Having):
+        predicates.append(having.this)
+    return predicates
+
+
+def classify_correlation(node: exp.Expression, frames: list[Frame], schema: Schema) -> tuple[str, str]:
+    """How a nested query level ties itself to the query around it.
+
+    A subquery that reads no outer column stands on its own: it is a complete query whose own joins are checked
+    like any other, and there is no correlation to get wrong. One that does read an outer column relates its rows
+    to the outer row through a predicate, exactly as a join does, and is judged the same way.
+    """
+    local, outer = frames[-1], frames[:-1]
+
+    def is_outer(column: exp.Column) -> bool:
+        qualifier = column.table
+        return bool(qualifier) and qualifier not in local.sources and any(qualifier in f.sources for f in outer)
+
+    # A qualifier that belongs to no level we resolved is a relation this walk does not understand, and treating
+    # it as local would silently turn a correlated subquery into a standalone one.
+    own = list(own_nodes(node, exp.Column))
+    unknown = {
+        column.table
+        for column in own
+        if column.table and column.table not in local.sources and not any(column.table in f.sources for f in outer)
+    }
+    if unknown:
+        return UNRESOLVED, f"reads {', '.join(sorted(unknown))}, which resolves to no known relation"
+
+    correlated = [column for column in own if is_outer(column)]
+    if not correlated:
+        return UNCORRELATED, "reads nothing from the enclosing query"
+
+    best, detail = NO_EQUALITY, f"reads {correlated[0].sql(dialect=DIALECT)} but no equality ties the two levels"
+    for predicate in level_predicates(node):
+        for left_column, right_column in column_equalities(predicate):
+            # Only equalities that cross the boundary say anything about the correlation.
+            if is_outer(left_column) == is_outer(right_column):
+                continue
+            left = resolve_column(left_column, frames)
+            right = resolve_column(right_column, frames)
+            rendered = f"{_render(left, left_column)} = {_render(right, right_column)}"
+            kind = UNRESOLVED if left is None or right is None else classify_pair(left, right, schema)
+            if CORRELATION_RANK.index(kind) < CORRELATION_RANK.index(best):
+                best, detail = kind, rendered
+    return best, detail
+
+
+def walk_correlations(ast: exp.Expression, schema: Schema) -> list[tuple[str, str]]:
+    """Every nested query level in the statement, classified by how it ties itself to the level above."""
+    found: list[tuple[str, str]] = []
+
+    def visit(node: exp.Expression, frames: list[Frame]) -> None:
+        hosts_relations = isinstance(node, (exp.Select, exp.Update, exp.Delete))
+        inner = frames + [scope_frame(node, frames)] if hosts_relations else frames
+        # Every query level below the statement itself, which includes ones with no enclosing relations of their
+        # own: a CTE body and a set operation's branches are nested text even though nothing can correlate them.
+        if hosts_relations and node is not ast:
+            found.append(classify_correlation(node, inner, schema))
+        for child in node.args.values():
+            for item in child if isinstance(child, list) else [child]:
+                if isinstance(item, exp.Expression):
+                    visit(item, inner)
+
+    visit(ast, [])
+    return found
+
+
+def walk_joins(ast: exp.Expression, schema: Schema) -> list[tuple[str, str]]:
+    """Every join in the statement, at every level of nesting, classified."""
+    found: list[tuple[str, str]] = []
+
+    def visit(node: exp.Expression, frames: list[Frame]) -> None:
+        hosts_relations = isinstance(node, (exp.Select, exp.Update, exp.Delete))
+        inner = frames + [scope_frame(node, frames)] if hosts_relations else frames
+        if hosts_relations:
+            for join in node.args.get("joins") or []:
+                found.append(classify_join(join, node, inner, schema))
+        for child in node.args.values():
+            for item in child if isinstance(child, list) else [child]:
+                if isinstance(item, exp.Expression):
+                    visit(item, inner)
+
+    visit(ast, [])
+    return found
+
+
+@dataclass
+class Verdict:
+    state: str
+    reason: str
+
+
+Check = Callable[[Shape, Schema], Verdict]
+CHECKS: dict[str, Check] = {}
+
+
+def check(dimension: str) -> Callable[[Check], Check]:
+    def register(function: Check) -> Check:
+        CHECKS[dimension] = function
+        return function
+
+    return register
+
+
+@check("nesting")
+def check_nesting(shape: Shape, schema: Schema) -> Verdict:
+    """Does a nested query relate itself to the query around it correctly?
+
+    A correlated subquery ties its rows to the outer row through a predicate the same way a join does, and can get
+    that tie wrong the same way. Statements with nothing nested inside them clear here; the rest are the material
+    for the correlation pass.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    if isinstance(shape.ast, exp.Command):
+        # SET, SHOW, REFRESH MATERIALIZED VIEW: no relational content of their own.
+        return Verdict(CLEAR, "not a relational statement")
+    tables = statement_tables(shape.ast)
+    has_cte = bool(shape.ast.args.get("with_") or shape.ast.args.get("with"))
+    if (
+        isinstance(shape.ast, exp.Insert)
+        and len(tables) == 1
+        and not has_cte
+        and is_literal_row_source(shape.ast.expression)
+    ):
+        return Verdict(CLEAR, f"insert of literal rows into {next(iter(tables))}, reads no relation")
+    levels = walk_correlations(shape.ast, schema)
+    if not levels:
+        return Verdict(CLEAR, "nothing nested")
+    worst = max(levels, key=lambda item: CORRELATION_RANK.index(item[0]))
+    if worst[0] in CORRELATION_SAFE:
+        return Verdict(CLEAR, f"{len(levels)} nested level(s), each standalone or correlated on a key")
+    return Verdict(OPEN, f"{worst[0]}: {worst[1]}")
+
+
+@check("joins")
+def check_joins(shape: Shape, schema: Schema) -> Verdict:
+    """Does every join relate the two sides by a key?
+
+    This is the dimension the strong verification leak lived in: the lite_users view joined an attempt to a user
+    on birthdate and sex, columns that are equal for plenty of pairs of rows that have nothing to do with each
+    other. A join carrying a foreign key cannot do that, so those clear here and the rest are listed.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    joins = walk_joins(shape.ast, schema)
+    if not joins:
+        return Verdict(CLEAR, "no joins")
+    worst = max(joins, key=lambda item: JOIN_RANK.index(item[0]))
+    if worst[0] in JOIN_SAFE:
+        return Verdict(CLEAR, f"{len(joins)} join(s), each on a key or pinned to one row")
+    return Verdict(OPEN, f"{worst[0]}: {worst[1]}")
+
+
+# ---------------------------------------------------------------------------- visibility
+
+# The relations that carry a user's identity. lite_users is the materialized view of the same rows, and folds the
+# banned and deleted test into a single is_visible column.
+USER_RELATIONS = {"users", "lite_users"}
+
+# The three things couchers.sql.users_visible hides, each detected by the predicate it emits.
+BANNED = "banned"
+DELETED = "deleted"
+SHADOW = "shadow"
+BLOCKS = "blocks"
+IS_VISIBLE = "is_visible"
+
+# How thoroughly one user relation is filtered, best first.
+FULL = "filtered"
+MUTUAL = "mutually filtered"
+UNSHADOWED = "visible and unshadowed"
+VISIBLE_ONLY = "visible only"
+UNFILTERED = "unfiltered"
+VISIBILITY_RANK = [FULL, MUTUAL, UNSHADOWED, VISIBLE_ONLY, UNFILTERED]
+# users_visible for a logged in caller, and the viewer side of users_visible_to_each_other. Both are what the
+# helpers emit; anything weaker is either an anonymous caller, a deliberate exemption, or a leak.
+VISIBILITY_SAFE = {FULL, MUTUAL}
+
+
+def _is_null(term: exp.Expression, alias: str, column: str) -> bool:
+    return (
+        isinstance(term, exp.Is)
+        and isinstance(term.this, exp.Column)
+        and term.this.table == alias
+        and term.this.name == column
+        and isinstance(term.expression, exp.Null)
+    )
+
+
+def _mentions(term: exp.Expression, alias: str, column: str) -> bool:
+    return any(node.table == alias and node.name == column for node in term.find_all(exp.Column))
+
+
+def clause_marks(term: exp.Expression, alias: str, table: str) -> set[str]:
+    """Which parts of the visibility filter this one conjunct applies to the given user relation."""
+    if isinstance(term, exp.Paren):
+        return clause_marks(term.this, alias, table)
+    if isinstance(term, exp.Column) and term.table == alias and term.name == IS_VISIBLE:
+        return {IS_VISIBLE}
+    if _is_null(term, alias, "banned_at"):
+        return {BANNED}
+    if _is_null(term, alias, "deleted_at"):
+        return {DELETED}
+    if _is_null(term, alias, "shadowed_at"):
+        return {SHADOW}
+    # `shadowed_at IS NULL OR id = <the caller>`: a shadowbanned user still sees themselves.
+    if isinstance(term, exp.Or):
+        arms = [arm.this if isinstance(arm, exp.Paren) else arm for arm in term.flatten()]
+        shadow = [arm for arm in arms if _is_null(arm, alias, "shadowed_at")]
+        self_id = [
+            arm
+            for arm in arms
+            if isinstance(arm, exp.EQ)
+            and isinstance(arm.left, exp.Column)
+            and arm.left.table == alias
+            and arm.left.name == "id"
+            and _bound_value(arm.right)
+        ]
+        if shadow and len(shadow) + len(self_id) == len(arms):
+            return {SHADOW}
+    # ~id.in_(_relevant_user_blocks(...)) and ~_users_block_each_other(a, b): either way a negated predicate over
+    # user_blocks that names this relation's id.
+    if isinstance(term, exp.Not):
+        blocks = any(source.name == "user_blocks" for source in term.find_all(exp.Table))
+        if blocks and _mentions(term, alias, "id"):
+            return {BLOCKS}
+    return set()
+
+
+def level_relations(node: exp.Expression) -> list[tuple[str, str]]:
+    """The base tables this level reads, as (the name its columns are qualified with, the table)."""
+    found: list[tuple[str, str]] = []
+
+    def add(relation: exp.Expression | None) -> None:
+        if isinstance(relation, exp.Subquery) and not relation.args.get("alias"):
+            # A parenthesised join tree, as pg_dump writes a view's FROM.
+            add(relation.this)
+            for nested in relation.args.get("joins") or []:
+                add(nested.this)
+        elif isinstance(relation, exp.Table):
+            found.append((relation.alias_or_name, relation.name))
+
+    origin = from_clause(node)
+    if origin is not None:
+        add(origin.this)
+    if isinstance(node, (exp.Update, exp.Delete)):
+        add(node.this)
+    for join in node.args.get("joins") or []:
+        add(join.this)
+    return found
+
+
+def level_filters(node: exp.Expression) -> list[tuple[exp.Expression, str | None]]:
+    """Conjuncts that filter rows at this level, each with the relation it is restricted to, or None for all.
+
+    An inner join's ON filters the joined result exactly as the WHERE does, so it counts for every relation. An
+    outer join's ON only decides what the joined relation contributes, so it counts for that relation alone.
+    """
+    terms: list[tuple[exp.Expression, str | None]] = []
+    where = node.args.get("where")
+    if isinstance(where, exp.Where):
+        terms += [(term, None) for term in conjuncts(where.this)]
+    for join in node.args.get("joins") or []:
+        on = join.args.get("on")
+        if on is None:
+            continue
+        introduced = join.this.alias_or_name if isinstance(join.this, exp.Expression) else None
+        scope = introduced if join.args.get("side") else None
+        terms += [(term, scope) for term in conjuncts(on)]
+    return terms
+
+
+# Neither is a visibility clause. Both say the relation is restricted to users the statement was handed rather
+# than users it chose, so whether that is safe depends on where the identifiers came from, not on the statement.
+PINNED_ID = "pinned"  # named by bound values: a lookup of users the caller or an earlier query named
+KEYED_ID = "keyed"  # equated to a column of the enclosing query: an attribute lookup on a row already in play
+# The columns that name one user.
+USER_IDENTIFIERS = {"id", "username", "email"}
+
+
+def identity_mark(term: exp.Expression, alias: str) -> str | None:
+    """How, if at all, this conjunct restricts the relation to users named elsewhere."""
+    if isinstance(term, exp.Paren):
+        return identity_mark(term.this, alias)
+    # `username IN (...) OR id IN (...)`, as GetLiteUsers builds: still only the users it was handed.
+    if isinstance(term, exp.Or):
+        arms = [identity_mark(arm, alias) for arm in term.flatten()]
+        if any(mark is None for mark in arms):
+            return None
+        return PINNED_ID if all(mark == PINNED_ID for mark in arms) else KEYED_ID
+    if isinstance(term, exp.EQ):
+        column, values = term.left, [term.right]
+    elif isinstance(term, exp.In) and term.args.get("expressions"):
+        column, values = term.this, term.args["expressions"]
+    else:
+        return None
+    if not (isinstance(column, exp.Column) and column.table == alias and column.name in USER_IDENTIFIERS):
+        return None
+    if all(_bound_value(value) for value in values):
+        return PINNED_ID
+    if all(isinstance(value, exp.Column) and value.table != alias for value in values):
+        return KEYED_ID
+    return None
+
+
+def classify_marks(marks: set[str]) -> str:
+    if not (IS_VISIBLE in marks or {BANNED, DELETED} <= marks):
+        return UNFILTERED
+    if SHADOW in marks and BLOCKS in marks:
+        return FULL
+    if BLOCKS in marks:
+        return MUTUAL
+    if SHADOW in marks:
+        return UNSHADOWED
+    return VISIBLE_ONLY
+
+
+def share_identity(term: exp.Expression, aliases: set[str]) -> tuple[str, str] | None:
+    """The two user relations this equality proves are the same person, if that is what it does.
+
+    `FROM users JOIN lite_users ON lite_users.id = users.id` reads one person through two relations, so a filter
+    on either side decides which rows both of them contribute.
+    """
+    if not isinstance(term, exp.EQ):
+        return None
+    left, right = term.left, term.right
+    if not (isinstance(left, exp.Column) and isinstance(right, exp.Column)):
+        return None
+    if left.name != "id" or right.name != "id":
+        return None
+    if left.table in aliases and right.table in aliases and left.table != right.table:
+        return (left.table, right.table)
+    return None
+
+
+def keyed_columns(filters: list[tuple[exp.Expression, str | None]], alias: str) -> set[tuple[str, str]]:
+    """The columns of other relations that this user relation's id is equated to."""
+    keyed: set[tuple[str, str]] = set()
+    for term, scope in filters:
+        if scope is not None and scope != alias:
+            continue
+        if not isinstance(term, exp.EQ):
+            continue
+        for side, other in ((term.left, term.right), (term.right, term.left)):
+            if (
+                isinstance(side, exp.Column)
+                and side.table == alias
+                and side.name == "id"
+                and isinstance(other, exp.Column)
+                and other.table != alias
+            ):
+                keyed.add((other.table, other.name))
+    return keyed
+
+
+def guaranteed_visible(filters: list[tuple[exp.Expression, str | None]]) -> dict[tuple[str, str], set[str]]:
+    """Columns a filtered EXISTS proves name a visible user, which is what where_users_column_visible builds.
+
+    Only a top level EXISTS counts. One inside an OR, or negated, holds for some rows and not others, so it
+    proves nothing about the column.
+    """
+    guaranteed: dict[tuple[str, str], set[str]] = {}
+    for term, scope in filters:
+        if scope is not None:
+            continue
+        node = term.this if isinstance(term, exp.Paren) else term
+        if not isinstance(node, exp.Exists):
+            continue
+        inner = node.this
+        if isinstance(inner, exp.Subquery):
+            inner = inner.this
+        if not isinstance(inner, exp.Select):
+            continue
+        for alias, (_, marks) in level_user_marks(inner).items():
+            if classify_marks(marks) not in VISIBILITY_SAFE:
+                continue
+            for column in keyed_columns(level_filters(inner), alias):
+                guaranteed[column] = guaranteed.get(column, set()) | marks
+    return guaranteed
+
+
+def level_user_marks(
+    node: exp.Expression, inherited: dict[tuple[str, str], set[str]] | None = None
+) -> dict[str, tuple[str, set[str]]]:
+    """For each user relation this level reads, the table and the visibility clauses that apply to it."""
+    relations = {alias: table for alias, table in level_relations(node) if table in USER_RELATIONS}
+    if not relations:
+        return {}
+    filters = level_filters(node)
+    marks = {alias: set[str]() for alias in relations}
+    for term, scope in filters:
+        for alias in relations:
+            if scope is None or scope == alias:
+                marks[alias] |= clause_marks(term, alias, relations[alias])
+                identity = identity_mark(term, alias)
+                if identity is not None:
+                    marks[alias].add(identity)
+    # An identity equality carries a filter from one relation to the other. From an outer join's ON it only
+    # carries into the relation that join brings in, since the other side keeps its unmatched rows either way.
+    edges: list[tuple[str, str]] = []
+    for term, scope in filters:
+        pair = share_identity(term, set(relations))
+        if pair is None:
+            continue
+        edges += [(pair[0], pair[1]), (pair[1], pair[0])] if scope is None else [(pair[0], scope), (pair[1], scope)]
+    for _ in range(len(relations)):
+        for source, sink in edges:
+            if source != sink:
+                marks[sink] |= marks[source]
+    # A relation read through a column an EXISTS has already proved visible is that same visible user. A proof
+    # made at an enclosing level holds here too: it constrains every row this level is evaluated against.
+    proved = {**(inherited or {}), **guaranteed_visible(filters)}
+    for alias in relations:
+        for column in keyed_columns(filters, alias):
+            if column in proved:
+                marks[alias] |= proved[column]
+    return {alias: (relations[alias], marks[alias]) for alias in relations}
+
+
+def walk_user_relations(ast: exp.Expression) -> list[tuple[str, str, str, set[str]]]:
+    """Every read of users or lite_users in the statement, as (alias, table, how filtered, which clauses)."""
+    found: list[tuple[str, str, str, set[str]]] = []
+    # The rows a write touches are the writes dimension's business, not a disclosure question, so the relation it
+    # writes to is not judged here. Anything else it reads is.
+    target = ast.this.alias_or_name if isinstance(ast, (exp.Update, exp.Delete)) else None
+
+    def visit(node: exp.Expression, inherited: dict[tuple[str, str], set[str]]) -> None:
+        if isinstance(node, (exp.Select, exp.Update, exp.Delete)):
+            for alias, (table, marks) in level_user_marks(node, inherited).items():
+                # Only the statement's own level writes to the target. A nested query reading the same table
+                # under the same name is an ordinary read, and exempting it would be a free pass.
+                if not (node is ast and alias == target):
+                    found.append((alias, table, classify_marks(marks), marks))
+            inherited = {**inherited, **guaranteed_visible(level_filters(node))}
+        for child in node.args.values():
+            for item in child if isinstance(child, list) else [child]:
+                if isinstance(item, exp.Expression):
+                    visit(item, inherited)
+
+    visit(ast, {})
+    return found
+
+
+@check("visibility")
+def check_visibility(shape: Shape, schema: Schema) -> Verdict:
+    """Does every read of a user apply the visibility filter?
+
+    Deleted, banned, shadowbanned and blocked users must not be shown, and couchers.sql.users_visible is the one
+    predicate that hides all four. A read that carries it clears; a read that carries less is either an anonymous
+    caller, an admin surface, or a leak, and which of the three cannot be told from the SQL, so it is listed
+    against the call site that issued it.
+
+    Only reads of the user relations themselves are judged. A query that returns bare user ids without joining a
+    user relation is outside this dimension, and so is a query that filters a user id column through the EXISTS
+    that where_users_column_visible builds, whose own users relation is judged where it stands.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    reads = walk_user_relations(shape.ast)
+    if not reads:
+        return Verdict(CLEAR, "reads no user relation")
+    worst = max(reads, key=lambda item: VISIBILITY_RANK.index(item[2]))
+    # The viewer side of users_visible_to_each_other carries no shadow clause, which is right for the viewer and
+    # wrong for anybody else, so it only clears alongside the other side it is being compared against.
+    if worst[2] == MUTUAL and not any(read[2] == FULL for read in reads):
+        return Verdict(OPEN, f"{worst[2]} but no fully filtered relation to pair it with: {worst[0]} ({worst[1]})")
+    if worst[2] in VISIBILITY_SAFE:
+        return Verdict(CLEAR, f"{len(reads)} user relation(s), each filtered")
+    carries = ", ".join(sorted(worst[3])) or "nothing"
+    return Verdict(OPEN, f"{worst[2]}: {worst[0]} ({worst[1]}) carries {carries}")
+
+
+# ---------------------------------------------------------------------------- moderation
+
+
+# Every table whose rows carry a moderation state, as the schema dump has them. users is left out: it declares
+# __moderation_has_own_visibility_mechanism__, and its own visibility is the visibility dimension's business.
+# moderation_log and moderation_queue are the moderation machinery itself, only read by the moderation service.
+MODERATED_EXEMPT = {"users", "moderation_log", "moderation_queue"}
+STATE_TABLE = "moderation_states"
+STATE_COLUMN = "moderation_state_id"
+
+# How a read of moderated content is filtered, best first.
+STATE_JOINED = "state joined"  # where_moderated_content_visible: joined to its state, visibility constrained
+STATE_TESTED = "state tested"  # moderation_state_column_visible: the state is reached through the column instead
+# The state is reached, but one of the arms lets the row through without ever naming a visibility.
+STATE_PARTLY_TESTED = "state partly tested"
+STATE_UNCONSTRAINED = "state unconstrained"  # joined to its state but nothing says which visibilities pass
+NO_STATE = "no state"
+MODERATION_RANK = [STATE_JOINED, STATE_TESTED, STATE_PARTLY_TESTED, STATE_UNCONSTRAINED, NO_STATE]
+MODERATION_SAFE = {STATE_JOINED, STATE_TESTED}
+
+
+def moderated_tables(schema: Schema) -> set[str]:
+    return {
+        table for (table, column) in schema.foreign_keys if column == STATE_COLUMN and table not in MODERATED_EXEMPT
+    } | {table for (table, column) in schema.view_columns if column == STATE_COLUMN and table not in MODERATED_EXEMPT}
+
+
+def disjuncts(term: exp.Expression) -> list[exp.Expression]:
+    """The arms of a predicate that only one of has to hold. A filter that is not present in every arm filters
+    nothing, so this is what a claim about a predicate has to be checked against."""
+    if isinstance(term, exp.Paren):
+        return disjuncts(term.this)
+    if isinstance(term, exp.Or):
+        return [arm for side in term.flatten() for arm in disjuncts(side)]
+    return [term]
+
+
+def constrains_visibility(term: exp.Expression, state_alias: str) -> bool:
+    """Whether this conjunct says which moderation visibilities pass.
+
+    where_moderated_content_visible emits one OR of the visibilities a viewer may see, so every arm names the
+    visibility column. An OR with an arm that does not is a predicate that lets unmoderated rows through.
+    """
+    return all(
+        any(column.table == state_alias and column.name == "visibility" for column in arm.find_all(exp.Column))
+        for arm in disjuncts(term)
+    )
+
+
+def state_column_kind(term: exp.Expression, alias: str) -> str | None:
+    """How this conjunct reaches the row's moderation state through its moderation_state_id column.
+
+    moderation_state_column_visible emits `moderation_state_id IS NULL OR EXISTS (SELECT ... FROM
+    moderation_states WHERE id = moderation_state_id AND <visibilities>)`. Every arm has to be either the NULL
+    case or an EXISTS onto that same state, or the conjunct is not this form at all. An arm that reaches the
+    state but lets the row through without naming a visibility is reported separately: it is the form, with a
+    hole in it.
+    """
+    reached = False
+    complete = True
+    for arm in disjuncts(term):
+        if _is_null(arm, alias, STATE_COLUMN):
+            continue
+        node = arm.this if isinstance(arm, exp.Paren) else arm
+        if not isinstance(node, exp.Exists):
+            return None
+        inner = node.this
+        if isinstance(inner, exp.Subquery):
+            inner = inner.this
+        if not isinstance(inner, exp.Select):
+            return None
+        inner_filters = level_filters(inner)
+        matched = [
+            name
+            for name, table in level_relations(inner)
+            if table == STATE_TABLE and (alias, STATE_COLUMN) in keyed_columns(inner_filters, name)
+        ]
+        if not matched:
+            return None
+        reached = True
+        if not any(constrains_visibility(t, state) for t, _ in inner_filters for state in matched):
+            complete = False
+    if not reached:
+        return None
+    return STATE_TESTED if complete else STATE_PARTLY_TESTED
+
+
+def classify_moderated_relation(
+    alias: str, filters: list[tuple[exp.Expression, str | None]], states: list[str]
+) -> tuple[str, set[str]]:
+    marks: set[str] = set()
+    for term, scope in filters:
+        if scope is not None and scope != alias:
+            continue
+        identity = identity_mark(term, alias)
+        if identity is not None:
+            marks.add(identity)
+        through_column = state_column_kind(term, alias)
+        if through_column is not None:
+            marks.add(through_column)
+    joined = [
+        state
+        for state in states
+        if (alias, STATE_COLUMN) in keyed_columns(filters, state)
+        # A state brought in by an outer join leaves the content row in the result when nothing matches, so it
+        # decides nothing about that row.
+        and not any(scope == state for _, scope in filters)
+    ]
+    if joined:
+        marks.add(STATE_UNCONSTRAINED)
+        if any(constrains_visibility(term, state) for term, _ in filters for state in joined):
+            marks.add(STATE_JOINED)
+    for kind in MODERATION_RANK:
+        if kind in marks:
+            return kind, marks
+    return NO_STATE, marks
+
+
+def walk_moderated_relations(ast: exp.Expression, schema: Schema) -> list[tuple[str, str, str, set[str]]]:
+    """Every read of moderated content, as (alias, table, how it is filtered, which marks it carries)."""
+    tables = moderated_tables(schema)
+    found: list[tuple[str, str, str, set[str]]] = []
+    target = ast.this.alias_or_name if isinstance(ast, (exp.Update, exp.Delete)) else None
+
+    def visit(node: exp.Expression) -> None:
+        if isinstance(node, (exp.Select, exp.Update, exp.Delete)):
+            relations = level_relations(node)
+            states = [alias for alias, table in relations if table == STATE_TABLE]
+            filters = level_filters(node)
+            for alias, table in relations:
+                # Only the statement's own level writes to the target; a nested query reading the same table
+                # under the same name is an ordinary read.
+                if table in tables and not (node is ast and alias == target):
+                    kind, marks = classify_moderated_relation(alias, filters, states)
+                    found.append((alias, table, kind, marks))
+        for child in node.args.values():
+            for item in child if isinstance(child, list) else [child]:
+                if isinstance(item, exp.Expression):
+                    visit(item)
+
+    visit(ast)
+    return found
+
+
+@check("moderation")
+def check_moderation(shape: Shape, schema: Schema) -> Verdict:
+    """Does every read of moderated content check the visibility its moderation state carries?
+
+    Content under the unified moderation system is hidden, shadowed, unlisted or visible, and the row itself does
+    not say which: the answer lives in the moderation_states row its moderation_state_id names. A read that does
+    not reach that row shows hidden content to everyone. couchers.sql.where_moderated_content_visible joins the
+    state and constrains its visibility; moderation_state_column_visible reaches it through the column instead,
+    for rows that carry a state without being the moderated content themselves.
+
+    Which visibilities a given read should accept is not decidable from the SQL: is_list_operation drops the
+    unlisted arm, and the moderation service is meant to see everything. So this clears a read that constrains
+    the visibility at all, and lists the rest against the call site that issued it.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    reads = walk_moderated_relations(shape.ast, schema)
+    if not reads:
+        return Verdict(CLEAR, "reads no moderated content")
+    unsafe = [read for read in reads if read[2] not in MODERATION_SAFE]
+    if not unsafe:
+        return Verdict(CLEAR, f"{len(reads)} moderated relation(s), each checked against its state")
+    # One statement can read several moderated tables in different ways, and the weakest is not always the one
+    # worth reading, so name each of them rather than only the worst.
+    seen: dict[tuple[str, str, str], set[str]] = {}
+    for alias, table, kind, marks in sorted(unsafe, key=lambda read: MODERATION_RANK.index(read[2])):
+        seen.setdefault((kind, alias, table), set()).update(marks - set(MODERATION_RANK))
+    parts = [
+        f"{kind}: {alias} ({table}) carries {', '.join(sorted(marks)) or 'nothing'}"
+        for (kind, alias, table), marks in seen.items()
+    ]
+    return Verdict(OPEN, "; ".join(parts[:4]))
+
+
+# ---------------------------------------------------------------------------- nulls
+
+
+# What a construct that mixes negation with NULL does to the result, best first.
+NULL_SAFE = "null safe"
+UNKNOWN_NULLS = "nullability unknown"
+DROPS_NULLS = "drops null rows"  # rows where the operand is NULL silently fail a test they read as passing
+OUTER_DEFEATED = "outer join defeated"  # the padded rows are filtered away again, so the join is really inner
+VANISHES = "result can vanish"  # NOT IN over a subquery that can yield NULL: no row matches, ever
+NULL_RANK = [NULL_SAFE, UNKNOWN_NULLS, DROPS_NULLS, OUTER_DEFEATED, VANISHES]
+
+# Three valued logic, as a predicate comes out under a set of columns known to be NULL.
+TRUE, FALSE, NULL, UNKNOWN = "true", "false", "null", "unknown"
+
+COMPARISONS = (exp.EQ, exp.NEQ, exp.GT, exp.GTE, exp.LT, exp.LTE, exp.Like, exp.ILike)
+
+
+def outer_aliases(node: exp.Expression) -> set[str]:
+    """The relations an outer join at this level can pad with NULLs, whatever their columns are declared."""
+    padded: set[str] = set()
+    earlier: set[str] = set()
+    origin = from_clause(node)
+    if origin is not None and isinstance(origin.this, exp.Expression):
+        earlier.add(origin.this.alias_or_name)
+    for join in node.args.get("joins") or []:
+        side = str(join.args.get("side") or "").upper()
+        introduced = join.this.alias_or_name if isinstance(join.this, exp.Expression) else None
+        if introduced and side in ("LEFT", "FULL"):
+            padded.add(introduced)
+        if side in ("RIGHT", "FULL"):
+            padded |= earlier
+        if introduced:
+            earlier.add(introduced)
+    return padded
+
+
+@dataclass
+class NullScope:
+    """What deciding nullability at one query level needs: how to resolve a column, and what can pad it."""
+
+    frames: list[Frame]
+    schema: Schema
+    padded: set[str]  # relations an outer join at this level can fill with NULLs
+    derived: dict[str, exp.Expression]  # the nested query behind each CTE and derived table name in scope
+
+
+def derived_sources(node: exp.Expression) -> dict[str, exp.Expression]:
+    """The nested queries this level names: its CTEs and its aliased derived tables."""
+    found: dict[str, exp.Expression] = {}
+    with_clause = node.args.get("with_") or node.args.get("with")
+    for cte in with_clause.expressions if with_clause else []:
+        found[cte.alias_or_name] = cte.this
+    origin = from_clause(node)
+    candidates = ([origin.this] if origin is not None else []) + [join.this for join in node.args.get("joins") or []]
+    for candidate in candidates:
+        if isinstance(candidate, exp.Subquery) and candidate.alias_or_name:
+            found[candidate.alias_or_name] = candidate.this
+    return found
+
+
+def nested_scope(query: exp.Select, outer: NullScope) -> NullScope:
+    return NullScope(
+        outer.frames + [scope_frame(query, outer.frames)],
+        outer.schema,
+        outer_aliases(query),
+        {**outer.derived, **derived_sources(query)},
+    )
+
+
+def query_selects(query: exp.Expression) -> list[exp.Expression]:
+    """A query's output columns, taken from a set operation's leftmost branch: that is where postgres takes the
+    output names from, whatever the other branches call theirs."""
+    while isinstance(query, exp.Subquery):
+        query = query.this
+    if isinstance(query, exp.SetOperation):
+        return query_selects(query.this)
+    return list(query.selects) if isinstance(query, exp.Select) else []
+
+
+def query_column_nullable(query: exp.Expression, index: int, scope: NullScope, depth: int = 0) -> bool | None:
+    """Whether a nested query's index'th output column can be NULL.
+
+    A set operation is taken branch by branch and positionally, since either branch can supply the row and they
+    name their columns independently: `SELECT blocked_user_id ... UNION SELECT blocking_user_id ...` is one
+    column, whatever the second branch calls it.
+    """
+    if depth > 4:
+        return None
+    while isinstance(query, exp.Subquery):
+        query = query.this
+    if isinstance(query, exp.SetOperation):
+        sides = [
+            query_column_nullable(query.this, index, scope, depth + 1),
+            query_column_nullable(query.expression, index, scope, depth + 1),
+        ]
+        return True if True in sides else (None if None in sides else False)
+    if not isinstance(query, exp.Select) or index >= len(query.selects):
+        return None
+    projection = query.selects[index]
+    return expression_nullable(
+        projection.this if isinstance(projection, exp.Alias) else projection, nested_scope(query, scope), depth + 1
+    )
+
+
+def expression_nullable(node: exp.Expression, scope: NullScope, depth: int = 0) -> bool | None:
+    """Whether this expression can come out NULL, or None when the schema does not settle it.
+
+    A bound parameter counts as never NULL: SQLAlchemy renders `column != None` as `column IS NOT NULL` rather
+    than binding a NULL, so a `?` here stands for a value the caller actually supplied.
+    """
+    while isinstance(node, (exp.Paren, exp.Cast, exp.Neg)):
+        node = node.this
+    if isinstance(node, exp.Null):
+        return True
+    if isinstance(node, (exp.Literal, exp.Boolean, exp.Placeholder, exp.Parameter)):
+        return False
+    # count() over no rows is 0, not NULL, and EXISTS is always true or false.
+    if isinstance(node, (exp.Count, exp.Exists)):
+        return False
+    if isinstance(node, exp.Coalesce):
+        arms = [expression_nullable(arm, scope, depth) for arm in [node.this, *(node.expressions or [])]]
+        return False if False in arms else (None if None in arms else True)
+    if isinstance(node, exp.Column):
+        if node.table and node.table in scope.padded:
+            return True
+        # A derived table is followed into rather than resolved through: an outer join or a union inside it can
+        # produce a NULL the base column it forwards is declared never to hold.
+        query = scope.derived.get(node.table)
+        if query is not None and depth <= 4:
+            names = [projection.alias_or_name for projection in query_selects(query)]
+            return query_column_nullable(query, names.index(node.name), scope, depth) if node.name in names else None
+        origin = resolve_column(node, scope.frames)
+        return None if origin is None else scope.schema.nullable(origin)
+    return None
+
+
+def predicate_null_free(term: exp.Expression, scope: NullScope) -> bool | None:
+    """Whether this predicate is always true or false, never NULL.
+
+    NULL propagates through every comparison, and an AND or an OR of something that can be NULL can be NULL too.
+    IS NULL, IS NOT NULL and EXISTS are the forms that are always definite whatever their operands hold.
+    """
+    if isinstance(term, exp.Paren):
+        return predicate_null_free(term.this, scope)
+    if isinstance(term, (exp.Is, exp.Exists, exp.Boolean)):
+        return True
+    if isinstance(term, exp.Not):
+        return predicate_null_free(term.this, scope)
+    if isinstance(term, (exp.And, exp.Or)):
+        sides = [predicate_null_free(side, scope) for side in (term.left, term.right)]
+        return False if False in sides else (None if None in sides else True)
+    operands: list[exp.Expression] = []
+    if isinstance(term, exp.In):
+        operands = [term.this, *(term.expressions or [])]
+        if term.args.get("query") is not None:
+            return None
+    elif isinstance(term, COMPARISONS):
+        operands = [term.left, term.right]
+    elif isinstance(term, exp.Column):
+        # A boolean column standing on its own as a predicate, which is how `NOT is_deleted` is written.
+        operands = [term]
+    else:
+        return None
+    nullable = [expression_nullable(operand, scope) for operand in operands]
+    return False if True in nullable else (None if None in nullable else True)
+
+
+def _touches(node: exp.Expression, alias: str) -> bool:
+    return any(column.table == alias for column in node.find_all(exp.Column))
+
+
+def _under_nulls(term: exp.Expression, alias: str) -> str:
+    """How this predicate comes out with every column of the relation set to NULL and everything else unknown."""
+    if isinstance(term, exp.Paren):
+        return _under_nulls(term.this, alias)
+    if isinstance(term, exp.Is) and isinstance(term.expression, exp.Null):
+        if not _touches(term.this, alias):
+            return UNKNOWN
+        # `alias.column IS NULL` holds for exactly the padded rows, which is the anti join idiom.
+        return FALSE if term.args.get("negate") else TRUE
+    if isinstance(term, exp.Not):
+        return {TRUE: FALSE, FALSE: TRUE, NULL: NULL, UNKNOWN: UNKNOWN}[_under_nulls(term.this, alias)]
+    if isinstance(term, (exp.And, exp.Or)):
+        sides = [_under_nulls(side, alias) for side in (term.left, term.right)]
+        dominant = FALSE if isinstance(term, exp.And) else TRUE
+        recessive = TRUE if isinstance(term, exp.And) else FALSE
+        if dominant in sides:
+            return dominant
+        if all(side == recessive for side in sides):
+            return recessive
+        return NULL if NULL in sides else UNKNOWN
+    if isinstance(term, (exp.In, *COMPARISONS)):
+        return NULL if _touches(term, alias) else UNKNOWN
+    return UNKNOWN
+
+
+def not_in_kind(node: exp.In, scope: NullScope) -> str:
+    """What `x NOT IN (...)` does here, which turns on which side the NULLs can be on.
+
+    A NULL anywhere in the right hand side makes the predicate NULL for every row that does not match, so nothing
+    passes and the statement quietly returns nothing at all. A NULL on the left only drops that row.
+    """
+    query = node.args.get("query")
+    if query is not None:
+        right = query_column_nullable(query, 0, scope) if len(query_selects(query)) == 1 else None
+    else:
+        candidates = [expression_nullable(value, scope) for value in node.expressions or []]
+        right = True if True in candidates else (None if None in candidates else False)
+    if right is True:
+        return VANISHES
+    left = expression_nullable(node.this, scope)
+    if right is None or left is None:
+        return UNKNOWN_NULLS
+    return DROPS_NULLS if left else NULL_SAFE
+
+
+def describe(term: exp.Expression) -> str:
+    rendered = " ".join(term.sql(dialect=DIALECT).split())
+    return rendered if len(rendered) <= 70 else rendered[:69] + "…"
+
+
+def level_null_kinds(node: exp.Expression, scope: NullScope) -> list[tuple[str, str]]:
+    """Every construct at this level whose result turns on how NULL behaves, as (what it does, the construct).
+
+    Only negations are judged. `column = ?` also drops the rows where the column is NULL, but that is what an
+    equality means; it is `!=`, `NOT IN` and `NOT (...)` that read as "everything except" and quietly are not.
+    """
+    found: list[tuple[str, str]] = []
+    for term in own_nodes(node, exp.Not, exp.NEQ):
+        if isinstance(term, exp.Not):
+            if isinstance(term.this, exp.In):
+                found.append((not_in_kind(term.this, scope), describe(term)))
+                continue
+            definite = predicate_null_free(term.this, scope)
+            kind = NULL_SAFE if definite else (UNKNOWN_NULLS if definite is None else DROPS_NULLS)
+        else:
+            sides = [expression_nullable(side, scope) for side in (term.left, term.right)]
+            kind = DROPS_NULLS if True in sides else (UNKNOWN_NULLS if None in sides else NULL_SAFE)
+        found.append((kind, describe(term)))
+
+    # An outer join says the unmatched rows still belong in the result. A filter at the same level that throws
+    # them away again contradicts that, and leaves an inner join written the long way round.
+    for alias in sorted(scope.padded):
+        defeating = [
+            term for term, where in level_filters(node) if where is None and _under_nulls(term, alias) in (FALSE, NULL)
+        ]
+        kind = OUTER_DEFEATED if defeating else NULL_SAFE
+        tail = f", then filtered by {describe(defeating[0])}" if defeating else ""
+        found.append((kind, f"{alias} kept by an outer join{tail}"))
+    return found
+
+
+def walk_null_kinds(ast: exp.Expression, schema: Schema) -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+
+    def visit(node: exp.Expression, scope: NullScope) -> None:
+        if isinstance(node, (exp.Select, exp.Update, exp.Delete)):
+            scope = NullScope(
+                scope.frames + [scope_frame(node, scope.frames)],
+                schema,
+                outer_aliases(node),
+                {**scope.derived, **derived_sources(node)},
+            )
+            found.extend(level_null_kinds(node, scope))
+        for child in node.args.values():
+            for item in child if isinstance(child, list) else [child]:
+                if isinstance(item, exp.Expression):
+                    visit(item, scope)
+
+    visit(ast, NullScope([], schema, set(), {}))
+    return found
+
+
+@check("nulls")
+def check_nulls(shape: Shape, schema: Schema) -> Verdict:
+    """Does anything here depend on NULL behaving the way it does not?
+
+    Postgres compares against NULL with three valued logic, and a WHERE keeps only the rows its predicate makes
+    true, so NULL and false are the same answer to a filter. Negation is where that bites: `x != 'a'` reads as
+    "everything but a" and silently omits the rows where x is NULL, and `x NOT IN (subquery)` returns nothing at
+    all, for every row, as soon as one row of that subquery is NULL. An outer join is the other half of it, since
+    it manufactures NULLs no column is declared to hold.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    kinds = walk_null_kinds(shape.ast, schema)
+    if not kinds:
+        return Verdict(CLEAR, "nothing that turns on NULL")
+    unsafe = [item for item in kinds if item[0] != NULL_SAFE]
+    if not unsafe:
+        return Verdict(CLEAR, f"{len(kinds)} construct(s), none of which can meet a NULL")
+    unsafe.sort(key=lambda item: NULL_RANK.index(item[0]), reverse=True)
+    return Verdict(OPEN, "; ".join(f"{kind}: {what}" for kind, what in unsafe[:3]))
+
+
+# ---------------------------------------------------------------------------- bounds
+
+
+# Tables whose size is fixed by the repository rather than by use: copy_resources_to_database truncates and
+# refills them from files under resources/ (couchers/resources.py:155).
+STATIC_TABLES = {"regions", "languages", "timezone_areas"}
+
+# How many rows a read can hand back, best first.
+NO_ROWS = "no rows"  # a filter that can never hold, which is what SQLAlchemy renders `column.in_([])` as
+ONE_ROW = "one row"  # an aggregate over the whole result, or a single relation pinned to a key
+LIMITED = "limited"  # a LIMIT, so the count is whatever the code or the caller asked for
+PINNED_LIST = "pinned to a list"  # keyed to identifiers the statement was handed, so bounded by that list
+STATIC = "static table"  # every relation it reads is fixed by the repository
+SCOPED = "scoped"  # tied to one identified entity, and grows with that entity's own data
+UNSCOPED = "unscoped"  # nothing ties it to anything: it grows with the database
+BOUNDS_RANK = [NO_ROWS, ONE_ROW, LIMITED, PINNED_LIST, STATIC, SCOPED, UNSCOPED]
+# SCOPED counts as bounded: the read grows with one entity the caller named, not with the database. It does not
+# promise that entity is small, and this dimension has nothing to say about how many messages one conversation
+# can hold.
+BOUNDS_SAFE = {NO_ROWS, ONE_ROW, LIMITED, PINNED_LIST, STATIC, SCOPED}
+
+
+def constantly_false(node: exp.Expression) -> bool:
+    """Whether a top level conjunct can never hold. SQLAlchemy renders `column.in_([])` as a false constant, so
+    the statement is sent, reads nothing and returns nothing."""
+    for term, where in level_filters(node):
+        if where is not None:
+            continue
+        while isinstance(term, exp.Paren):
+            term = term.this
+        if isinstance(term, exp.Boolean) and not term.this:
+            return True
+        if isinstance(term, exp.NEQ) and _bound_value(term.left) and term.left.sql() == term.right.sql():
+            return True
+    return False
+
+
+class Anchor(NamedTuple):
+    """A restriction of a read to rows the statement identified, rather than to rows that share a property."""
+
+    table: str
+    column: str
+    single: bool  # the predicate allows exactly one value of the column
+    key: bool  # one value of the column names at most one row, rather than however many belong to it
+
+
+def identified(column: exp.Column, relations: dict[str, str], schema: Schema) -> tuple[str, str, bool] | None:
+    """The (table, column, is a key) this reference names, if it identifies rows at all.
+
+    Only a key or a foreign key does. `messages.conversation_id = ?` names one conversation and bounds the read by
+    that conversation's size; `users.hosting_status = ?` names a property, and the rows that have it grow with the
+    database.
+    """
+    tables = set(relations.values())
+    table = relations.get(column.table) or (next(iter(tables)) if not column.table and len(tables) == 1 else None)
+    if table is None:
+        return None
+    if schema.is_key(table, column.name):
+        return (table, column.name, True)
+    if (table, column.name) in schema.foreign_keys:
+        return (table, column.name, False)
+    # One column of a composite key names rows only together with the rest of that key, which result_bound
+    # checks for; on its own it still says the read is after particular rows rather than after a property.
+    if any(column.name in key for key in schema.key_columns(table) if len(key) > 1):
+        return (table, column.name, False)
+    return None
+
+
+def anchoring(term: exp.Expression, relations: dict[str, str], schema: Schema) -> list[Anchor]:
+    """How this predicate restricts the read to identified rows, empty when it does not restrict it to any."""
+    if isinstance(term, exp.Paren):
+        return anchoring(term.this, relations, schema)
+    if isinstance(term, exp.EQ):
+        for side, other in ((term.left, term.right), (term.right, term.left)):
+            if isinstance(side, exp.Column) and _bound_value(other):
+                named = identified(side, relations, schema)
+                return [Anchor(named[0], named[1], True, named[2])] if named else []
+    if isinstance(term, exp.In) and isinstance(term.this, exp.Column):
+        values = term.args.get("expressions") or []
+        named = identified(term.this, relations, schema)
+        if values and named and all(_bound_value(value) for value in values):
+            return [Anchor(named[0], named[1], False, named[2])]
+    if isinstance(term, exp.And):
+        return [anchor for side in (term.left, term.right) for anchor in anchoring(side, relations, schema)]
+    if isinstance(term, exp.Or):
+        # `username = ? OR email = ?` names rows in each arm, so the arms together still name a fixed number of
+        # them. Only if every arm does, though: one arm that names nothing lets the whole table through.
+        arms = [anchoring(arm, relations, schema) for arm in disjuncts(term)]
+        if all(arms):
+            return [anchor._replace(single=False) for arm in arms for anchor in arm]
+    return []
+
+
+def anchors(node: exp.Expression, schema: Schema) -> list[Anchor]:
+    """Every top level restriction of this level to identified rows."""
+    relations = dict(level_relations(node))
+    return [
+        anchor for term, where in level_filters(node) if where is None for anchor in anchoring(term, relations, schema)
+    ]
+
+
+def result_bound(node: exp.Expression, schema: Schema) -> tuple[str, str]:
+    """How many rows this read can hand back, and what decides it."""
+    if node.args.get("limit") is not None:
+        return LIMITED, "LIMIT"
+    if isinstance(node, exp.SetOperation):
+        branches = [result_bound(node.this, schema), result_bound(node.expression, schema)]
+        return max(branches, key=lambda branch: BOUNDS_RANK.index(branch[0]))
+    if isinstance(node, exp.Subquery):
+        return result_bound(node.this, schema)
+    if not isinstance(node, exp.Select):
+        return UNSCOPED, "not a select"
+    if constantly_false(node):
+        return NO_ROWS, "a filter that can never hold"
+
+    # An aggregate wrapped in something else still aggregates: `coalesce(sum(amount), 0)` and
+    # `concat(?, string_agg(geojson, ?), ?)` each collapse the whole result to one row. An aggregate inside a
+    # scalar subquery does not, so nested levels are not looked into.
+    projections = [p.this if isinstance(p, exp.Alias) else p for p in node.selects]
+    aggregated = [isinstance(p, exp.AggFunc) or any(own_nodes(p, exp.AggFunc)) for p in projections]
+    if projections and not node.args.get("group") and all(aggregated):
+        return ONE_ROW, "aggregate over the whole result"
+
+    relations = dict(level_relations(node))
+    if relations and set(relations.values()) <= STATIC_TABLES:
+        return STATIC, ", ".join(sorted(set(relations.values())))
+
+    found = anchors(node, schema)
+    # Naming one row of one relation only bounds the result when there is nothing to fan out into: a user joined
+    # to their messages is one user and as many messages as they have sent.
+    if len(set(relations.values())) == 1 and found:
+        table = next(iter(relations.values()))
+        pinned = {anchor.column for anchor in found if anchor.single}
+        if any(set(key) <= pinned for key in schema.key_columns(table)):
+            return ONE_ROW, f"{table} named by key"
+        keyed = [anchor for anchor in found if anchor.key]
+        if keyed:
+            return PINNED_LIST, f"{table}.{keyed[0].column}"
+    if found:
+        return SCOPED, ", ".join(sorted({f"{anchor.table}.{anchor.column}" for anchor in found}))
+    if not relations:
+        return ONE_ROW, "reads no relation"
+    return UNSCOPED, ", ".join(sorted(set(relations.values())))
+
+
+@check("bounds")
+def check_bounds(shape: Shape, schema: Schema) -> Verdict:
+    """How many rows can this read hand back, and is that number bounded by anything but the size of the database?
+
+    A statement that works on a test database with ten users and falls over on the real one does so silently until
+    it does not. The question is whether the row count is decided by a LIMIT, by an aggregate, by identifiers the
+    caller supplied, or by nothing at all.
+
+    Only the rows the statement returns are judged, so only the top level. A nested query's cardinality is a cost,
+    not a result, and how it ties itself to the query around it is the nesting dimension's business.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    if not isinstance(shape.ast, (exp.Select, exp.SetOperation)):
+        # An INSERT, UPDATE or DELETE returns rows only through RETURNING, and how many it touches is the writes
+        # dimension's question.
+        return Verdict(CLEAR, "not a read")
+    kind, why = result_bound(shape.ast, schema)
+    if kind in BOUNDS_SAFE:
+        return Verdict(CLEAR, f"{kind}: {why}")
+    return Verdict(OPEN, f"{kind}: {why}")
+
+
+@check("writes")
+def check_writes(shape: Shape, schema: Schema) -> Verdict:
+    """How many rows can this statement mutate?
+
+    An UPDATE or DELETE anchored on a primary or unique key touches at most the one row it names. Anything else is
+    a bulk mutation whose blast radius is decided by its predicate, which is worth reading even when it is right.
+    """
+    if shape.ast is None:
+        return Verdict(OPEN, f"not parsed: {shape.parse_error}")
+    # A data modifying CTE mutates rows the outer statement never names, so the outer form says nothing about it.
+    if any(node is not shape.ast for node in shape.ast.find_all(exp.Update, exp.Delete, exp.Insert)):
+        return Verdict(OPEN, "data modifying CTE")
+    if not isinstance(shape.ast, (exp.Update, exp.Delete)):
+        if isinstance(shape.ast, exp.Insert):
+            conflict = shape.ast.args.get("conflict")
+            if conflict is not None and conflict.args.get("expressions"):
+                return Verdict(OPEN, "upsert: ON CONFLICT DO UPDATE")
+            if is_literal_row_source(shape.ast.expression):
+                return Verdict(CLEAR, "insert of literal rows")
+            return Verdict(OPEN, "insert from a query")
+        return Verdict(CLEAR, "not a write")
+    tables = statement_tables(shape.ast)
+    target = shape.ast.find(exp.Table)
+    if target is None:
+        return Verdict(OPEN, "no target table found")
+    if len(tables) > 1 or has_subquery(shape.ast):
+        return Verdict(OPEN, "write whose target rows are chosen by a join or nested query")
+    key = key_anchored(shape.ast, target.name, schema)
+    if key is None:
+        return Verdict(OPEN, f"unkeyed write to {target.name}")
+    return Verdict(CLEAR, f"keyed on {target.name}({', '.join(key)})")
+
+
+# ---------------------------------------------------------------------------- reporting
+
+
+def fetch(location: str) -> bytes:
+    if location.startswith(("http://", "https://")):
+        with urllib.request.urlopen(location) as response:
+            return response.read()  # type: ignore[no-any-return]
+    return Path(location).read_bytes()
+
+
+def load_data(location: str) -> dict[str, Any]:
+    raw = fetch(location)
+    if raw[:2] == b"\x1f\x8b":
+        raw = gzip.decompress(raw)
+    return json.loads(raw)  # type: ignore[no-any-return]
+
+
+LEDGER = Path(__file__).with_name("query_audit_reviewed.json")
+
+
+def apply_ledger(verdicts: dict[str, dict[str, Verdict]], ledger: dict[str, Any]) -> None:
+    """Fold the recorded human reviews into the verdicts, so only what nobody has read yet stays open."""
+    for state, shapes in ((REVIEWED, ledger.get("reviewed", {})), (BUG, ledger.get("bugs", {}))):
+        for shape_id, entries in shapes.items():
+            for entry in entries:
+                verdict = verdicts.get(shape_id, {}).get(entry["dimension"])
+                # Only an open verdict is claimed: if a check has since learned to clear the shape by itself, or
+                # the shape now fails for a different reason, the entry is stale and should not paper over it.
+                if verdict is not None and verdict.state == OPEN:
+                    verdict.state = state
+                    verdict.reason = f"{verdict.reason} - {entry['note']}"
+
+
+def summarise(shapes: dict[str, Shape], verdicts: dict[str, dict[str, Verdict]]) -> None:
+    print(f"{len(shapes)} query shapes, {sum(s.executions for s in shapes.values())} executions\n")
+    print(f"{'dimension':<12} {'clear':>7} {'reviewed':>9} {'bug':>5} {'open':>7}")
+    for dimension in CHECKS:
+        states = Counter(verdicts[shape_id][dimension].state for shape_id in shapes)
+        print(f"{dimension:<12} {states[CLEAR]:>7} {states[REVIEWED]:>9} {states[BUG]:>5} {states[OPEN]:>7}")
+    settled = [
+        shape_id
+        for shape_id in shapes
+        if all(verdict.state in (CLEAR, REVIEWED) for verdict in verdicts[shape_id].values())
+    ]
+    bugs = [shape_id for shape_id in shapes if any(v.state == BUG for v in verdicts[shape_id].values())]
+    print(f"\nsettled: {len(settled)}   open: {len(shapes) - len(settled) - len(bugs)}   known bugs: {len(bugs)}")
+    for shape_id in bugs:
+        for dimension, verdict in verdicts[shape_id].items():
+            if verdict.state == BUG:
+                print(f"  {shape_id} [{dimension}] {verdict.reason}")
+
+
+def open_reasons(shapes: dict[str, Shape], verdicts: dict[str, dict[str, Verdict]], dimension: str) -> None:
+    reasons: Counter[str] = Counter()
+    for shape_id in shapes:
+        verdict = verdicts[shape_id][dimension]
+        if verdict.state == OPEN:
+            # Group by the kind of reason, not the specific tables named in it.
+            reasons[re.sub(r":.*", "", verdict.reason)] += 1
+    print(f"\nopen on {dimension}:")
+    for reason, count in reasons.most_common():
+        print(f"  {count:>5}  {reason}")
+
+
+def listing(shapes: dict[str, Shape], verdicts: dict[str, dict[str, Verdict]], dimension: str, limit: int) -> None:
+    print(f"\nshapes open on {dimension}:")
+    for shape_id, shape in shapes.items():
+        verdict = verdicts[shape_id][dimension]
+        if verdict.state != OPEN:
+            continue
+        site = shape.app_sites[0] if shape.app_sites else (shape.sites[0] if shape.sites else "?")
+        print(f"\n  {shape_id}  {verdict.reason}")
+        print(f"    {site.split(' <- ')[0]}   [{', '.join(shape.spans[:2])}]")
+        print(f"    {shape.sql[:limit]}")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--data", required=True, help="path or URL of the merged query log (data.json.gz)")
+    parser.add_argument("--schema", required=True, help="path or URL of the schema dump (schema.sql)")
+    parser.add_argument("--reasons", action="store_true", help="break the open shapes down by reason")
+    parser.add_argument("--list", metavar="DIMENSION", help="print every shape still open on one dimension")
+    parser.add_argument("--sql-chars", type=int, default=400, help="how much of each statement --list prints")
+    parser.add_argument("--json", metavar="FILE", help="write the full per shape verdicts here")
+    parser.add_argument("--ledger", default=str(LEDGER), help="recorded human reviews, keyed by shape id")
+    parser.add_argument(
+        "--no-ledger", action="store_true", help="ignore the recorded reviews and show every open shape"
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    schema = parse_schema(fetch(args.schema).decode())
+    shapes = load_shapes(load_data(args.data))
+    verdicts = {
+        shape_id: {dimension: function(shape, schema) for dimension, function in CHECKS.items()}
+        for shape_id, shape in shapes.items()
+    }
+
+    if not args.no_ledger and Path(args.ledger).exists():
+        apply_ledger(verdicts, json.loads(Path(args.ledger).read_text()))
+
+    summarise(shapes, verdicts)
+    if args.reasons:
+        for dimension in CHECKS:
+            open_reasons(shapes, verdicts, dimension)
+    if args.list:
+        if args.list not in CHECKS:
+            parser.error(f"unknown dimension {args.list!r}, expected one of {', '.join(CHECKS)}")
+        listing(shapes, verdicts, args.list, args.sql_chars)
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    shape_id: {
+                        "sql": shape.sql,
+                        "executions": shape.executions,
+                        "sites": shape.sites[:5],
+                        "spans": shape.spans[:5],
+                        "verdicts": {d: vars(v) for d, v in verdicts[shape_id].items()},
+                    }
+                    for shape_id, shape in shapes.items()
+                },
+                indent=1,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/scripts/query_audit_reviewed.json
+++ b/app/scripts/query_audit_reviewed.json
@@ -1,0 +1,3735 @@
+{
+ "reviewed": {
+  "0074911b31fe": [
+   {
+    "dimension": "moderation",
+    "reason": "state unconstrained: host_requests (host_requests) carries nothing",
+    "note": "check_database_consistency walks every moderated row against its state to find rows whose state is missing or wrong, so constraining the visibility would defeat the check."
+   }
+  ],
+  "01be634762f7": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries keyed",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "020fa65f1204": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed."
+   }
+  ],
+  "025cc6058447": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: content_reports",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "0380cc77f368": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "0396c8739811": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "03b65a5f2f67": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "04d0729ca9c2": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries keyed",
+    "note": "Counts or lists the caller's own recent actions to decide whether they are rate limited, and to fill in the warning email to moderators."
+   }
+  ],
+  "05b41be5c445": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: group_chat_subscriptions.group_chat_id = messages.conversation_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "062df4b84e06": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "072428655dcd": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: group_chat_subscriptions.group_chat_id = messages.conversation_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: group_chat_subscriptions kept by an outer join, then filtered by group_chat_subscriptions.user_id = CAST(2 AS BIGINT)",
+    "note": "Read against source: Ping's unseen message count outer joins group_chat_subscriptions and then inner joins group_chats onto that same relation's group_chat_id before filtering it by user_id (servicers/api.py:245). The outer join has no effect and the count is right; it is redundant, not wrong."
+   }
+  ],
+  "074605134819": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "080b7a8fd1d9": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to login_tokens",
+    "note": "Purge job or token consumption: deletes every token that is not currently valid, or the caller's own tokens by user_id."
+   }
+  ],
+  "08b7c8c00b6a": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "09c00804ea6b": [
+   {
+    "dimension": "nesting",
+    "reason": "no equality: reads users.geom but no equality ties the two levels",
+    "note": "Spatial containment (ST_Contains / ST_DWithin) against timezone_areas or a node's geography. A geometric relation has no equality to correlate on; the subquery is bounded by LIMIT 1 or by the enclosing row's own key."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "09c99cbe47a1": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_organizers kept by an outer join, then filtered by event_organizers.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "09f60f5b5d2c": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "0a6d77ae5c8e": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "0b616e1951c1": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "0b6cffa7d251": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "0b856fdf03ba": [
+   {
+    "dimension": "visibility",
+    "reason": "visible and unshadowed: users (users) carries banned, deleted, shadow",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "0bdec05d5cf4": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: group_chat_subscriptions, group_chats, messages, moderation_states, users",
+    "note": "Notification fan out inside a background job: the read finds every recipient of one piece of content or every notification still to send, which is the work the job was queued to do."
+   }
+  ],
+  "0e1c88a88248": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: event_log",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "0e4d70803748": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to login_tokens",
+    "note": "Purge job or token consumption: deletes every token that is not currently valid, or the caller's own tokens by user_id."
+   }
+  ],
+  "0eb5d53d5526": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "0edd06b5ade8": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "0f9ac3c28a32": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: user_badges",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "1020a9542061": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "1099ddeba7ff": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters, nodes",
+    "note": "Reads the community tree, whose size is set by how many communities the project has created rather than by how many users or messages there are. get_node_parents_recursively walks upwards from one node, so it is bounded by the depth of that tree."
+   }
+  ],
+  "10b5d8f0d698": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: sessions",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "10d4a3786e62": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries pinned",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "117158993e31": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed."
+   }
+  ],
+  "11975ecefbc2": [
+   {
+    "dimension": "joins",
+    "reason": "non key: nonvisible_user_access.actor_user_id = users.id",
+    "note": "Correct join, unprovable from constraints: logging.nonvisible_user_access is in the logging schema and declares only a primary key, no foreign keys to public.users."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "120bd3f250a4": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "124da8912ceb": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: ota_packages",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions. The tables are curated by admins rather than filled by users."
+   }
+  ],
+  "127398157f39": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "132ffc438bb1": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "EXISTS over the user's own profile gallery, to decide whether they have an avatar or a complete profile. Both columns reference photo_galleries.id."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "14a33fb31882": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: group_chat_subscriptions.group_chat_id = messages.conversation_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "1592c1045b30": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "163d53abd1c6": [
+   {
+    "dimension": "visibility",
+    "reason": "visible and unshadowed: users (users) carries banned, deleted, pinned, shadow",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "16d18d2524fd": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "17436641d82a": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries pinned",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here. Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "175cdb81b2b5": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   },
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   },
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation, with the joined <= messages.time and left IS NULL OR left >= messages.time bounds present, as verified across all 31 shapes in this class."
+   }
+  ],
+  "1a05cd5f7b13": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "1c04531d59ca": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible. Report deliberately does not filter visibility, and says so at the call site: you have to be able to report a user who has blocked you or who is shadowbanned."
+   }
+  ],
+  "1d3e568be1f8": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries keyed",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   }
+  ],
+  "1d9b2b6c8422": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Loads the caller's own row, by context.user_id."
+   }
+  ],
+  "1dbda67c1a59": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_queue",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "1ecf33c9482c": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to user_blocks",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "2236ad0cd81e": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries keyed",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "22bed602ddd5": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: ota_packages",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions. The tables are curated by admins rather than filled by users."
+   }
+  ],
+  "22f09e3f6e57": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: invoices",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "23c23903aa3b": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:338, send_request_notifications, surfing side. Read at source: joins users to host_requests on initiator_user_id and messages on conversation_id, both foreign keys, scoped to one user id. Moderation visibility is evaluated against HostRequest.initiator_user_id, which the join makes equal to the viewer, so the author branch is deliberately vacuous there."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:338, send_request_notifications, surfing side. Read at source: joins users to host_requests on initiator_user_id and messages on conversation_id, both foreign keys, scoped to one user id. Moderation visibility is evaluated against HostRequest.initiator_user_id, which the join makes equal to the viewer, so the author branch is deliberately vacuous there."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:338, send_request_notifications, surfing side. Read at source: joins users to host_requests on initiator_user_id and messages on conversation_id, both foreign keys, scoped to one user id. Moderation visibility is evaluated against HostRequest.initiator_user_id, which the join makes equal to the viewer, so the author branch is deliberately vacuous there."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Notification fan out: the recipient is named by id and the statement carries where_users_column_visible and where_moderated_content_visible_to_user_column for the other party."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: the only negation is users_visible's block clause, `id NOT IN (SELECT blocked_user_id ... UNION SELECT blocking_user_id ...)`. Both columns of user_blocks are NOT NULL, and the same construct is cleared mechanically in 138 other shapes."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Notification fan out inside a background job: the read finds every recipient of one piece of content or every notification still to send, which is the work the job was queued to do."
+   }
+  ],
+  "240d5c2e372e": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to timezone_areas",
+    "note": "Resource bootstrap in copy_resources_to_database, which replaces the table wholesale."
+   }
+  ],
+  "245907d5d7dd": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   },
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   },
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation, with the joined <= messages.time and left IS NULL OR left >= messages.time bounds present, as verified across all 31 shapes in this class."
+   }
+  ],
+  "256d867ba9ad": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "25cce6cda4eb": [
+   {
+    "dimension": "joins",
+    "reason": "non key: user_response_rates.user_id = users.id",
+    "note": "Correct join, unprovable from constraints: the view's user_id is a UNION ALL of host_requests.recipient_user_id and activeness_probes.user_id, both foreign keys to users.id, so the two branches do not share a single origin column."
+   }
+  ],
+  "260c204aace1": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "26a6d4bef403": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: public_trips (public_trips) carries pinned",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "26f103e8d3e0": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "292cc14b6d58": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to event_community_invite_requests",
+    "note": "Denies the other undecided requests for the same occurrence, as the code comments; scoped by occurrence_id."
+   }
+  ],
+  "29377c7e212d": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "2963bb4f84b9": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "2a8419d656de": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "2ae883b373a6": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "2b4f7a052ca6": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "2b563bf773fe": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "2bbbcedc9acf": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: replies (replies) carries nothing",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "2d8c16f4d99d": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "2d99f6f3c62a": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "2dd22a22a85d": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: public_trips (public_trips) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "30be84f0e19b": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: comments.moderation_state_id = moderation_queue.moderation_state_id",
+    "note": "Correlates a queue item to the content it moderates. Both columns reference moderation_states.id and the relationship is one to one by construction, though no unique constraint enforces it."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries nothing; no state: discussions (discussions) carries nothing; no state: event_occurrences (event_occurrences) carries nothing; no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "30e53288973f": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: lite_users (lite_users) carries is_visible, keyed",
+    "note": "Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: lite_users, volunteers",
+    "note": "The volunteers table is curated by editors, not filled by users: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR and the public read is the team page."
+   }
+  ],
+  "318ee39d6544": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed. Editor surface: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR, enforced by check_permissions. The rows are Volunteer staff records the volunteer opted into showing."
+   }
+  ],
+  "328634ac2e0a": [
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   }
+  ],
+  "332a6fbbe8f0": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "33cdba330416": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "3559a77ed0d5": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "3575505247d4": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "367bcbaf08b2": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: event_log",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "36c10b4fb24b": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "36e1fd2cec55": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "37506f542d5b": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Loads the caller's own row, by context.user_id. Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "378626f1820b": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: discussions (discussions) carries nothing",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   }
+  ],
+  "38c237975551": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: content_reports",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "398c222ee7d5": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "39a0870a2e29": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: invoices",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "3a1d86225b69": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: strong_verification_attempts",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "3c0128437ab8": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "3c17322a238f": [
+   {
+    "dimension": "nesting",
+    "reason": "non key: comments.id = moderation_states.object_id",
+    "note": "The UMS polymorphic association, which can carry no foreign key. Verified that all 32 occurrences of an id = moderation_states.object_id correlation, across every shape that has one, also constrain object_type on the same alias, so a row can only match a state of its own type."
+   }
+  ],
+  "3c1c3a6fa65e": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "3c5c2ee49c27": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_organizers kept by an outer join, then filtered by event_organizers.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "3cb3ce29fcb7": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/search.py:193, _search_users. Read at source: select(User) with users_visible(context) applied, then a full text and trigram filter, ordered by rank and limited to page_size + 1. Single relation; pagination is by rank threshold."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/search.py:193, _search_users. Read at source: select(User) with users_visible(context) applied, then a full text and trigram filter, ordered by rank and limited to page_size + 1. Single relation; pagination is by rank threshold."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/search.py:193, _search_users. Read at source: select(User) with users_visible(context) applied, then a full text and trigram filter, ordered by rank and limited to page_size + 1. Single relation; pagination is by rank threshold."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 2559.",
+    "note": "Read against source: UserSearch builds this as select(User, rank, snippet).where(users_visible(context)) at search.py:248. The statement looks unfiltered only because the fingerprinter's literal collapse ate its FROM and WHERE clauses."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 2559.",
+    "note": "Read against source: user search, which reads no moderated content."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 2559.",
+    "note": "Read against source: the only negation is users_visible's block clause, `id NOT IN (SELECT blocked_user_id ... UNION SELECT blocking_user_id ...)`. Both columns of user_blocks are NOT NULL, and the same construct is cleared mechanically in 138 other shapes."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 2559.",
+    "note": "Read against source: execute_search_statement paginates, applying a page size before executing (servicers/search.py:193)."
+   }
+  ],
+  "3d704f8c988a": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "3e01bb9698ee": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "40970133a9aa": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: volunteers",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "41cf9d0b82e4": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "42412cb68302": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "429c5f6e8cdf": [
+   {
+    "dimension": "nesting",
+    "reason": "no equality: reads nodes.geom but no equality ties the two levels",
+    "note": "Spatial containment (ST_Contains / ST_DWithin) against timezone_areas or a node's geography. A geometric relation has no equality to correlate on; the subquery is bounded by LIMIT 1 or by the enclosing row's own key."
+   }
+  ],
+  "42ec433f78b6": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: volunteers",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "430f81b9a504": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "43d7cddb40b8": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:560, send_reference_reminders. Read at source: two union branches, each joining users twice on initiator_user_id and recipient_user_id and anti-joining Reference on host_request_id together with the writer's own from_user_id, all foreign keys. The anti-join condition is in the ON clause, not the WHERE, so the outer join is not silently turned inner. Both sides apply users_visible_to_each_other."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:560, send_reference_reminders. Read at source: two union branches, each joining users twice on initiator_user_id and recipient_user_id and anti-joining Reference on host_request_id together with the writer's own from_user_id, all foreign keys. The anti-join condition is in the ON clause, not the WHERE, so the outer join is not silently turned inner. Both sides apply users_visible_to_each_other."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:560, send_reference_reminders. Read at source: two union branches, each joining users twice on initiator_user_id and recipient_user_id and anti-joining Reference on host_request_id together with the writer's own from_user_id, all foreign keys. The anti-join condition is in the ON clause, not the WHERE, so the outer join is not silently turned inner. Both sides apply users_visible_to_each_other."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: send_reference_reminders applies users_visible_to_each_other to both parties of each host request (jobs/handlers.py:528 and :548), and asserts user.is_visible on every row it uses."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: send_reference_reminders selects host requests whose reference is not yet written. Host request moderation is not consulted, which only decides whether the author is reminded to write a reference about a stay they were a party to."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: the only negation is `NOT (EXISTS ...)` over user_blocks, and EXISTS is true or false whatever its operands hold."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "44b89b5fa6b7": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: public_trips (public_trips) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "46012c6ffdfb": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "469ce571c995": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "46e3c25142ea": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: group_chat_subscriptions.group_chat_id = messages.conversation_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "489a843a3576": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: api_calls",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "491cec174cb5": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "4991ede019ca": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: host_requests, messages, users",
+    "note": "Notification fan out inside a background job: the read finds every recipient of one piece of content or every notification still to send, which is the work the job was queued to do."
+   }
+  ],
+  "49d930aeef88": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to account_deletion_tokens",
+    "note": "Purge job or token consumption: deletes every token that is not currently valid, or the caller's own tokens by user_id."
+   }
+  ],
+  "4ac54ad75226": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Counts signups against the caller's own invite codes. Discloses a count, not an identity."
+   }
+  ],
+  "4b3d477d3b7c": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Stripe webhook, authenticated by webhook signature rather than by a user. Looks a user up by Stripe customer id or billing email to record an invoice or grant a badge."
+   }
+  ],
+  "4c79350ee8fd": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: host_requests",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "4cd4ee32f95c": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to event_occurrences",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "4cd7b9d94518": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries nothing; no state: discussions (discussions) carries nothing; no state: event_occurrences (event_occurrences) carries nothing; no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "4cee9f9a7d92": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "4d60d48bf92f": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "4eeae0347c41": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   }
+  ],
+  "4f2fdc121978": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: ota_packages",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions. The tables are curated by admins rather than filled by users."
+   }
+  ],
+  "4f3c44aac2b6": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "50dbdc93c2d5": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: event_occurrences",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "519a6c3d4988": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "51b5799a6b13": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "53ae59a16808": [
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   }
+  ],
+  "53ee5a388f2c": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "53f3c1b86c12": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "54f037b3e301": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_occurrence_attendees kept by an outer join, then filtered by event_occurrence_attendees.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "552ccf3c4621": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "566554ddfef3": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/references.py:158, get_pending_references_to_write. Read at source: same union of a surfed and a hosted branch, LiteUser joined on the other party's id, Reference anti-joined on host_request_id and the caller's from_user_id in the ON clause, with column visibility and list moderation visibility applied to both branches."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/references.py:158, get_pending_references_to_write. Read at source: same union of a surfed and a hosted branch, LiteUser joined on the other party's id, Reference anti-joined on host_request_id and the caller's from_user_id in the ON clause, with column visibility and list moderation visibility applied to both branches."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/references.py:158, get_pending_references_to_write. Read at source: same union of a surfed and a hosted branch, LiteUser joined on the other party's id, Reference anti-joined on host_request_id and the caller's from_user_id in the ON clause, with column visibility and list moderation visibility applied to both branches."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "get_pending_references_to_write filters both parties with where_users_column_visible and where_moderated_content_visible; AvailableWriteReferences selects no user relation and is scoped to host requests the caller is a party to."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: get_pending_references_to_write applies where_moderated_content_visible to the host requests it lists (references.py:131 and :150)."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: the outer join onto \"references\" carries its filter in its own ON clause and the WHERE tests `Reference.id == None`, which is the anti join idiom the outer join is there for (servicers/references.py:135 and :151)."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: get_pending_references_to_write is scoped to the caller's own host requests (servicers/references.py:134 and :153)."
+   }
+  ],
+  "568077c99c68": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "5703dc3738d9": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "586feffcfb07": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "5943bec5f14b": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "598ac833c036": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to password_reset_tokens",
+    "note": "Purge job or token consumption: deletes every token that is not currently valid, or the caller's own tokens by user_id."
+   }
+  ],
+  "5a5c15c81b4f": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "5b4710058833": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "Gallery items joined to the user whose profile gallery they belong to. Both columns reference photo_galleries.id, and the DISTINCT ON (gallery_id) derived table picks the first item as the avatar."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "5ba8ea829941": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to sessions",
+    "note": "Logs out the user's other sessions; scoped by user_id and excluding the current token."
+   }
+  ],
+  "5bbfde3773b6": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "5ca67a64425c": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to emails",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "5cd77685c472": [
+   {
+    "dimension": "nesting",
+    "reason": "no equality: reads users.geom but no equality ties the two levels",
+    "note": "Spatial containment (ST_Contains / ST_DWithin) against timezone_areas or a node's geography. A geometric relation has no equality to correlate on; the subquery is bounded by LIMIT 1 or by the enclosing row's own key."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "5d6e99671382": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:359, send_request_notifications, hosting side. Mirror of the surfing query on recipient_user_id, and moderation visibility is evaluated against the recipient, who is not the author, so shadowed requests are correctly withheld from the host."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:359, send_request_notifications, hosting side. Mirror of the surfing query on recipient_user_id, and moderation visibility is evaluated against the recipient, who is not the author, so shadowed requests are correctly withheld from the host."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:359, send_request_notifications, hosting side. Mirror of the surfing query on recipient_user_id, and moderation visibility is evaluated against the recipient, who is not the author, so shadowed requests are correctly withheld from the host."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Notification fan out: the recipient is named by id and the statement carries where_users_column_visible and where_moderated_content_visible_to_user_column for the other party."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: the only negation is users_visible's block clause, `id NOT IN (SELECT blocked_user_id ... UNION SELECT blocking_user_id ...)`. Both columns of user_blocks are NOT NULL, and the same construct is cleared mechanically in 138 other shapes."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Notification fan out inside a background job: the read finds every recipient of one piece of content or every notification still to send, which is the work the job was queued to do."
+   }
+  ],
+  "5ebf4629b16b": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_log, moderation_queue",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "5f6797367d50": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "5f78f4802d12": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: page_versions.page_id = page_versions.page_id",
+    "note": "Self join of page_versions on their page against a DISTINCT ON (page_id) derived table, to pick the current version. Correlated on the page."
+   }
+  ],
+  "616e5ea2175d": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_subscriptions kept by an outer join, then filtered by event_subscriptions.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "62508a1e048a": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "where_users_column_visible filters the trip's author. The remaining users reads are the scalar subqueries in _same_gender_filter, which read one column of the viewer and of that same already filtered author."
+   }
+  ],
+  "625a3e75ad5c": [
+   {
+    "dimension": "nesting",
+    "reason": "no equality: reads users.geom but no equality ties the two levels",
+    "note": "Spatial containment (ST_Contains / ST_DWithin) against timezone_areas or a node's geography. A geometric relation has no equality to correlate on; the subquery is bounded by LIMIT 1 or by the enclosing row's own key."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Reads one column of a user named by id for internal bookkeeping (locale, timezone, postcard name, hosting status history, node geography). Nothing about the user reaches another user. GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed."
+   }
+  ],
+  "62be66cce662": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "631a5a25a5db": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "635f2479531b": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "63674e0baf7c": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries keyed, pinned",
+    "note": "Loads the caller's own row, by context.user_id. GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed. Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "63ca75dc0cf2": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: public_trips (public_trips) carries nothing",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "661ffe923e8c": [
+   {
+    "dimension": "moderation",
+    "reason": "state unconstrained: group_chats (group_chats) carries nothing",
+    "note": "check_database_consistency walks every moderated row against its state to find rows whose state is missing or wrong, so constraining the visibility would defeat the check."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: group_chats, moderation_states",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "664917bd07cd": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "675c693097d1": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "EXISTS over the user's own profile gallery, to decide whether they have an avatar or a complete profile. Both columns reference photo_galleries.id."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "6768a3d29678": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "678e09712251": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: feature_usage",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "6799e2265553": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "EXISTS over the user's own profile gallery, to decide whether they have an avatar or a complete profile. Both columns reference photo_galleries.id."
+   }
+  ],
+  "67b1b1ee8ea6": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: experiment_exposures",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "67c00fe1d068": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Builds the body of the rate limit warning email sent to moderators. It lists the users the rate limited caller contacted, and goes to moderators only."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries keyed",
+    "note": "Counts or lists the caller's own recent actions to decide whether they are rate limited, and to fill in the warning email to moderators."
+   }
+  ],
+  "681c497e3495": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "6860c0dc7d8f": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "695947a30475": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: password_reset_tokens",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "69ecc0afc935": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "6ca2753aea43": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "6cc18099da88": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: host_requests",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "6d3f8cf39ab4": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: emails",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "6dd82f949d3c": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: host_requests, moderation_states, users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "6e5cb3d4574f": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "6ee18e000fe8": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to regions_visited",
+    "note": "Resource bootstrap in copy_resources_to_database, which replaces the table wholesale."
+   }
+  ],
+  "6f5207843750": [
+   {
+    "dimension": "nulls",
+    "reason": "nullability unknown: NOT lite_users.id IN (SELECT anon_1.blocked_user_id FROM (SELECT user\u2026",
+    "note": "Read against source: the left hand side is lite_users.id, which this dimension calls unknown because every view in the schema is built over an outer join or a union. lite_users selects users.id with users on the preserved side of all three of its LEFT JOINs (schema.sql:1380), so it is never NULL."
+   }
+  ],
+  "6fc0d30ff78c": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Editor surface: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR, enforced by check_permissions. The rows are Volunteer staff records the volunteer opted into showing."
+   }
+  ],
+  "7260336c1e2b": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "7274d5ba174f": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "732448e2624c": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "74491f7aba30": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: discussions (discussions) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads. Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content. Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   }
+  ],
+  "74b01b477bb6": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "The volunteers table is curated by editors, not filled by users: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR and the public read is the team page."
+   }
+  ],
+  "75d5c1e870a1": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: signup_flows",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "7650befad6f2": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "7675b5fdb4b5": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to friend_relationships",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "76de8294261e": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "78bf83ce44af": [
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   }
+  ],
+  "78d3d7c563a1": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: password_reset_tokens",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "79069ecfca47": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries keyed, pinned",
+    "note": "Loads the caller's own row, by context.user_id. GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed. Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "79de535c2f8f": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Reads the friendship between the viewer and one other user, which both of them are a party to, to decide what the viewer may see of that user."
+   }
+  ],
+  "79eeec067f8b": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "7b294d0fe009": [
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   }
+  ],
+  "7bc8822e5a22": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Loads the caller's own row, by context.user_id. Reads one column of a user named by id to label a prometheus counter. Nothing reaches a viewer."
+   }
+  ],
+  "7d1fcad83610": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:879, update_recommendation_scores. Read at source: six aggregate subqueries, each outer joined on subquery.c.user_id == User.id, and the UPDATE targets users on User.id == scores.c.user_id. Every relation is tied by the users primary key."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:879, update_recommendation_scores. Read at source: six aggregate subqueries, each outer joined on subquery.c.user_id == User.id, and the UPDATE targets users on User.id == scores.c.user_id. Every relation is tied by the users primary key."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "jobs/handlers.py:879, update_recommendation_scores. Read at source: six aggregate subqueries, each outer joined on subquery.c.user_id == User.id, and the UPDATE targets users on User.id == scores.c.user_id. Every relation is tied by the users primary key."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: update_recommendation_scores outer joins six subqueries onto users and reads every one of them through coalesce, with no filter on any padded side (jobs/handlers.py:869 onwards)."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "7d788d5e1267": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "7e58b61cffd1": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "7ece473dfe02": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "7ed370431b8e": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Loads the caller's own row, by context.user_id. Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads. Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible. Stripe webhook, authenticated by webhook signature rather than by a user. Looks a user up by Stripe customer id or billing email to record an invoice or grant a badge."
+   }
+  ],
+  "7ee1883d5600": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "7fc7799c0e09": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "7fea4079bb4b": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "7fed91982e63": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "80539f838dbd": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "809a47dee1ff": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to notifications",
+    "note": "Marks notifications seen; scoped by user_id and by id or topic_action/key."
+   }
+  ],
+  "817c086c0c21": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Counts or lists the caller's own recent actions to decide whether they are rate limited, and to fill in the warning email to moderators."
+   }
+  ],
+  "82bf08915d09": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "82eb84ee008b": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: strong_verification_attempts",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "833388575bb9": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: photo_galleries, users",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "8367309bf626": [
+   {
+    "dimension": "visibility",
+    "reason": "visible and unshadowed: users (users) carries banned, deleted, shadow",
+    "note": "Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "83baa4351dda": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "83f6a8ef12a5": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries keyed",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "8449897f6509": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries keyed",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "8503b85581bb": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/references.py:462, AvailableWriteReferences. Same construction as get_pending_references_to_write, additionally scoped to one other user on both branches."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/references.py:462, AvailableWriteReferences. Same construction as get_pending_references_to_write, additionally scoped to one other user on both branches."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/references.py:462, AvailableWriteReferences. Same construction as get_pending_references_to_write, additionally scoped to one other user on both branches."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "get_pending_references_to_write filters both parties with where_users_column_visible and where_moderated_content_visible; AvailableWriteReferences selects no user relation and is scoped to host requests the caller is a party to."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: AvailableWriteReferences is scoped to host requests between the caller and the user they name, and returns only whether a reference may be written."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: the outer join onto \"references\" carries its filter in its own ON clause and the WHERE tests `Reference.id == None`, which is the anti join idiom the outer join is there for (servicers/references.py:135 and :151)."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: Required keyword: 'expression' missing for <class 'sqlglot.expressions.core.Dot'>. Line 1, Col: 220.",
+    "note": "Read against source: AvailableWriteReferences is scoped to host requests the caller is a party to."
+   }
+  ],
+  "852b9d38516d": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "8583758402a4": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "8644770a8772": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "864747624eab": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_organizers kept by an outer join, then filtered by event_organizers.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "86a0db911c5d": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "86acd0f78180": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_occurrence_attendees kept by an outer join, then filtered by event_occurrence_attendees.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "873106569a0f": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "87f60c53dc7f": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "881dc2e86d5e": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "8b4a6441cc6c": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_log",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "8c446102a3d1": [
+   {
+    "dimension": "moderation",
+    "reason": "state unconstrained: host_requests (host_requests) carries nothing",
+    "note": "check_database_consistency walks every moderated row against its state to find rows whose state is missing or wrong, so constraining the visibility would defeat the check."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: host_requests, moderation_states",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "8c65cbcf4927": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "8dc5ffd74d77": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: lite_users (lite_users) carries is_visible, keyed",
+    "note": "Editor surface: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR, enforced by check_permissions. The rows are Volunteer staff records the volunteer opted into showing."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: lite_users, volunteers",
+    "note": "The volunteers table is curated by editors, not filled by users: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR and the public read is the team page."
+   }
+  ],
+  "8dc9e7d17835": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "8e322d1984ec": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "EXISTS over the user's own profile gallery, to decide whether they have an avatar or a complete profile. Both columns reference photo_galleries.id."
+   }
+  ],
+  "9274ed343e40": [
+   {
+    "dimension": "writes",
+    "reason": "insert from a query",
+    "note": "Inserts a row derived from a keyed select of the same user's data, or a DEFAULT VALUES insert."
+   }
+  ],
+  "92c52528c8da": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: event_occurrences",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "93b822302fd8": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: discussions (discussions) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "95b229ff20c4": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody. Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "95c63027f2e8": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "96211ed001f3": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: replies (replies) carries nothing",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here."
+   }
+  ],
+  "9649262ed8f1": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "where_users_column_visible filters the trip's author. The remaining users reads are the scalar subqueries in _same_gender_filter, which read one column of the viewer and of that same already filtered author."
+   }
+  ],
+  "964ad224df59": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "965f67e62356": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "96677ac0990c": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: comments",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "969806f95c37": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "9726625bbbb2": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to user_activity",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "97407c683a3d": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "97ccf0e4b22f": [
+   {
+    "dimension": "nesting",
+    "reason": "non key: comments.id = moderation_states.object_id",
+    "note": "The UMS polymorphic association, which can carry no foreign key. Verified that all 32 occurrences of an id = moderation_states.object_id correlation, across every shape that has one, also constrain object_type on the same alias, so a row can only match a state of its own type."
+   }
+  ],
+  "9838fa7161a1": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to conversations",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "99eb4d7943e0": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "9a516a819063": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Reads one column of a user named by id for internal bookkeeping (locale, timezone, postcard name, hosting status history, node geography). Nothing about the user reaches another user."
+   }
+  ],
+  "9aae2c980992": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: activeness_probes",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "9cc60e3d7e07": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "9cc6b72673fb": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "9cca12b163c6": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "9da0d151027f": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "9e122632fc87": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "9e3c6390b617": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "9f1fd4f3a625": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: emails",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "9f54b7c79f35": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to account_deletion_tokens",
+    "note": "Purge job or token consumption: deletes every token that is not currently valid, or the caller's own tokens by user_id."
+   }
+  ],
+  "9f97f24eb446": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: page_versions.page_id = page_versions.page_id",
+    "note": "Self join of page_versions on their page against a DISTINCT ON (page_id) derived table, to pick the current version. Correlated on the page."
+   }
+  ],
+  "a000685035ae": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "a0336da49174": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters, nodes",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "a0359e3355a8": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: smss",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "a12db20e3abc": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries keyed",
+    "note": "Counts or lists the caller's own recent actions to decide whether they are rate limited, and to fill in the warning email to moderators."
+   }
+  ],
+  "a1f420f2eda6": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "a2bf15c904e9": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: native_client_users",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "a2ebf21d61b6": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/api.py:731, ListMutualFriends. Read at source: the caller's accepted friendships and the target's, each unioned over both directions of friend_relationships and excluding the other party, then intersected. The resulting ids feed a select(User) that applies users_visible(context)."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/api.py:731, ListMutualFriends. Read at source: the caller's accepted friendships and the target's, each unioned over both directions of friend_relationships and excluding the other party, then intersected. The resulting ids feed a select(User) that applies users_visible(context)."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "servicers/api.py:731, ListMutualFriends. Read at source: the caller's accepted friendships and the target's, each unioned over both directions of friend_relationships and excluding the other party, then intersected. The resulting ids feed a select(User) that applies users_visible(context)."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: ListMutualFriends applies users_visible(context) at api.py:731."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: ListMutualFriends applies where_moderated_content_visible to each of the four friend-relationship branches it unions (api.py:698 onwards)."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: the only negation is users_visible's block clause, `id NOT IN (SELECT blocked_user_id ... UNION SELECT blocking_user_id ...)`. Both columns of user_blocks are NOT NULL, and the same construct is cleared mechanically in 138 other shapes. The other negations are `friend_relationships.from_user_id != ?` and `to_user_id != ?`, both NOT NULL."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: ListMutualFriends is scoped to the friendships between the caller and one named user (servicers/api.py:698 onwards)."
+   }
+  ],
+  "a34d42bf9c49": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "a3f5b1f36ab3": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "a51cadc0ff30": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "a61955b6635d": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_subscriptions kept by an outer join, then filtered by event_subscriptions.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "a63111ee934a": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters",
+    "note": "Reads the community tree, whose size is set by how many communities the project has created rather than by how many users or messages there are. get_node_parents_recursively walks upwards from one node, so it is bounded by the depth of that tree."
+   }
+  ],
+  "a63b5d7fa023": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "a6d6a4eb1869": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: discussions (discussions) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "a721bf2979b3": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to background_jobs",
+    "note": "Test fixture or test body manipulating its own data."
+   }
+  ],
+  "a72da5bb66ae": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "a84e24d48acb": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "a8e4bd83942b": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: contributor_forms",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "a8f4735f3d68": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "a90034a0cb23": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed."
+   }
+  ],
+  "a9044d7bc712": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to regions",
+    "note": "Resource bootstrap in copy_resources_to_database, which replaces the table wholesale."
+   }
+  ],
+  "a9d9904fa7ca": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: nodes",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "aa110801c33e": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "aa97d69c8890": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_states",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "ab06aa8c12c1": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Builds the body of the rate limit warning email sent to moderators. It lists the users the rate limited caller contacted, and goes to moderators only."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries keyed",
+    "note": "Counts or lists the caller's own recent actions to decide whether they are rate limited, and to fill in the warning email to moderators."
+   }
+  ],
+  "ab3aaa7437fb": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "abc3cbeef4db": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "ad5a0700a670": [
+   {
+    "dimension": "nesting",
+    "reason": "no equality: reads users.geom but no equality ties the two levels",
+    "note": "Spatial containment (ST_Contains / ST_DWithin) against timezone_areas or a node's geography. A geometric relation has no equality to correlate on; the subquery is bounded by LIMIT 1 or by the enclosing row's own key."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Loads the caller's own row, by context.user_id."
+   }
+  ],
+  "adde468626f6": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: pg_depend",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "ae8ec648432a": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   },
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   },
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation, with the joined <= messages.time and left IS NULL OR left >= messages.time bounds present, as verified across all 31 shapes in this class."
+   }
+  ],
+  "aeae0004e40c": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "af0a0cc560a7": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: initiated_uploads",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "af3cbb597464": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "b00aecca05ef": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_organizers kept by an outer join, then filtered by event_organizers.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "b1c5a97f80cc": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "b2297e690bc4": [
+   {
+    "dimension": "moderation",
+    "reason": "state unconstrained: group_chats (group_chats) carries nothing",
+    "note": "check_database_consistency walks every moderated row against its state to find rows whose state is missing or wrong, so constraining the visibility would defeat the check."
+   }
+  ],
+  "b29439f6bfc4": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: group_chats, messages, moderation_states",
+    "note": "Notification fan out inside a background job: the read finds every recipient of one piece of content or every notification still to send, which is the work the job was queued to do."
+   }
+  ],
+  "b328bc71bbf4": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "b3701fdaeed5": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "Gallery items joined to the user whose profile gallery they belong to. Both columns reference photo_galleries.id, and the DISTINCT ON (gallery_id) derived table picks the first item as the avatar."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "b384be7cb727": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "b3f620adef1f": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "b4893d76fa32": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters, nodes",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "b65e319f80a9": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: nonvisible_user_access",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "b66a5c6aacd0": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: comments.moderation_state_id = moderation_queue.moderation_state_id",
+    "note": "Correlates a queue item to the content it moderates. Both columns reference moderation_states.id and the relationship is one to one by construction, though no unique constraint enforces it."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries nothing; no state: discussions (discussions) carries nothing; no state: event_occurrences (event_occurrences) carries nothing; no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "b6b31fba1ffd": [
+   {
+    "dimension": "visibility",
+    "reason": "visible and unshadowed: users (users) carries banned, deleted, pinned, shadow",
+    "note": "Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "b6ccfc4a1d36": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries deleted, pinned",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "b7fb2cb735ce": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "b80a91f5b091": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to users",
+    "note": "VerifyPhone clears the same phone number off other accounts; scoped by phone and excluding the caller."
+   }
+  ],
+  "b82d7bbda96a": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "where_users_column_visible filters the trip's author. The remaining users reads are the scalar subqueries in _same_gender_filter, which read one column of the viewer and of that same already filtered author."
+   }
+  ],
+  "b8e06247c646": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "ba3f6ebba8a1": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "bae74e89b817": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries keyed",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "bd03739df582": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "bd8ee6a4a22e": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: donation_initiations",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "bdc07c97ad18": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "be7c91d40fc2": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "be852819e596": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "bfe6d03866ab": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: comments.moderation_state_id = moderation_queue.moderation_state_id",
+    "note": "Correlates a queue item to the content it moderates. Both columns reference moderation_states.id and the relationship is one to one by construction, though no unique constraint enforces it."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries nothing; no state: discussions (discussions) carries nothing; no state: event_occurrences (event_occurrences) carries nothing; no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "c01731a571b8": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, pinned",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "c058acda37de": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "c0a989a6f1d6": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "c0c1248fbeec": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "c1a2c7fde28a": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "c2eb36ae3388": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "c2f4943dda1d": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: activeness_probes",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "c3382673cb69": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   }
+  ],
+  "c3e62902ae61": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: admin_tags",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions. The tables are curated by admins rather than filled by users."
+   }
+  ],
+  "c3f0b6a8ca15": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "c4181a4401c2": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "c6dd4223cd99": [
+   {
+    "dimension": "nesting",
+    "reason": "non key: comments.id = moderation_states.object_id",
+    "note": "The UMS polymorphic association, which can carry no foreign key. Verified that all 32 occurrences of an id = moderation_states.object_id correlation, across every shape that has one, also constrain object_type on the same alias, so a row can only match a state of its own type."
+   }
+  ],
+  "c7c3bccfa9eb": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: cluster_subscription_counts, cluster_subscriptions, clusters, nodes",
+    "note": "Reads the community tree, whose size is set by how many communities the project has created rather than by how many users or messages there are. get_node_parents_recursively walks upwards from one node, so it is bounded by the depth of that tree."
+   }
+  ],
+  "c898e72c5b90": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "c8a3b9cfe55c": [
+   {
+    "dimension": "nesting",
+    "reason": "non key: comments.id = moderation_states.object_id",
+    "note": "The UMS polymorphic association, which can carry no foreign key. Verified that all 32 occurrences of an id = moderation_states.object_id correlation, across every shape that has one, also constrain object_type on the same alias, so a row can only match a state of its own type."
+   }
+  ],
+  "c8f0457a08c5": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "c8f340e19faf": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "c90385854b54": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "c9bd5e4d3f52": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "cb6ca134aeda": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_states",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "cc215628652d": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "cced5b6ced5d": [
+   {
+    "dimension": "nesting",
+    "reason": "no equality: reads host_requests.initiator_user_id but no equality ties the two levels",
+    "note": "Ping's unseen-request count: the correlation is users.id = CASE WHEN initiator_user_id = ? THEN recipient_user_id ELSE initiator_user_id END, an equality on the users primary key, so it selects exactly the other party to the request."
+   }
+  ],
+  "ced7934fe7af": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "cede275a3620": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "d15842a3a6d0": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "d277a03b30b3": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: native_client_users",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "d31029c6c4e5": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "d351e1bab467": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: lite_users (lite_users) carries is_visible, keyed",
+    "note": "Editor surface: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR, enforced by check_permissions. The rows are Volunteer staff records the volunteer opted into showing."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: lite_users, volunteers",
+    "note": "The volunteers table is curated by editors, not filled by users: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR and the public read is the team page."
+   }
+  ],
+  "d3cbbe14edf5": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: cluster_subscription_counts, clusters, nodes",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "d3fd04bc8f3a": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "d4192c8276d7": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to notifications",
+    "note": "Marks notifications seen; scoped by user_id and by id or topic_action/key."
+   }
+  ],
+  "d442d182b2aa": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: group_chat_subscriptions.group_chat_id = messages.conversation_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "d447d58dca4c": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "d44aee18d8f0": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "d4b00b256474": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: page_versions.page_id = page_versions.page_id",
+    "note": "Self join of page_versions on their page against a DISTINCT ON (page_id) derived table, to pick the current version. Correlated on the page."
+   }
+  ],
+  "d4e472885a49": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries keyed",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "d564ea6a21b1": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: activeness_probes",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "d5f600b15ea3": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries nothing",
+    "note": "check_database_consistency walks every moderated row against its state to find rows whose state is missing or wrong, so constraining the visibility would defeat the check."
+   }
+  ],
+  "d68e119d3e4e": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "d6b1b36a3e67": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: friend_relationships",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "d6b58e2832cf": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: account_deletion_tokens",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "d748cb4625f5": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "d7aebc7d7195": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries nothing; no state: discussions (discussions) carries nothing; no state: event_occurrences (event_occurrences) carries nothing; no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_states",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions. The tables are curated by admins rather than filled by users."
+   }
+  ],
+  "d84f33d3c51b": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries pinned",
+    "note": "Editor surface: editor.proto declares option (auth_level) = AUTH_LEVEL_EDITOR, enforced by check_permissions. Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "d8c7d1a41f1d": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "d9641ef3ff17": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "daa97ec2cacd": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users_1 (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "daf5d7235ce5": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: clusters",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "db0e234505d7": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to sessions",
+    "note": "Logs out the user's other sessions; scoped by user_id and excluding the current token."
+   }
+  ],
+  "dbc2ad3f6b09": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_states",
+    "note": "check_database_consistency walks every row of the tables it checks against their moderation states to find rows whose state is missing or wrong, so bounding the read would defeat the check."
+   }
+  ],
+  "dbd4de40a493": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "dd1485a4101a": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "dd439cfbb1a9": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: activeness_probes",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "dd5ce44bde35": [
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   }
+  ],
+  "dd8ac2c82229": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: background_jobs",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "de0674660971": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "dea27ff31c6d": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here. Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "dee250000007": [
+   {
+    "dimension": "writes",
+    "reason": "insert from a query",
+    "note": "Inserts a row derived from a keyed select of the same user's data, or a DEFAULT VALUES insert."
+   }
+  ],
+  "df1633b0ebf1": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "df2736987971": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "df7b313605fe": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "e06fcd331fb2": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "e09cbcd9bd4b": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "e1243ad39715": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "e199513be8e7": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "e39b77426cb8": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries deleted, pinned",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "e42e7aa8b2fa": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody."
+   }
+  ],
+  "e43ec548e0f7": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads. GetUser, GetLiteUser and GetLiteUsers deliberately fetch by identifier with no SQL visibility filter: visibility is enforced when the row is serialized. user_model_to_pb and lite_user_to_pb call is_not_visible and return a ghost profile, and raise GhostUserSerializationError when the caller has not passed a ghost flag, so the path is fail closed. Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "e56ac115b872": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "EXISTS over the user's own profile gallery, to decide whether they have an avatar or a complete profile. Both columns reference photo_galleries.id."
+   }
+  ],
+  "e5ab23c56f91": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: api_calls",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "e7105cb5d0e7": [
+   {
+    "dimension": "writes",
+    "reason": "write whose target rows are chosen by a join or nested query",
+    "note": "mark_all_threads_seen advancing last_seen_message_id; scoped by the caller's user_id and by the subquery listing their own threads."
+   }
+  ],
+  "e7db48ed1c8c": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: event_occurrences",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "e8604d06e433": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = messages.conversation_id",
+    "note": "Self join of messages on their conversation, paired with messages.id < messages_1.id to select the latest message. Correlated on the conversation and ordered, so it cannot reach another conversation's messages."
+   }
+  ],
+  "e8bfc08c3b26": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_subscriptions kept by an outer join, then filtered by event_subscriptions.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "eac80a0edbd9": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "eac89e94dfe0": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "where_users_column_visible filters the trip's author. The remaining users reads are the scalar subqueries in _same_gender_filter, which read one column of the viewer and of that same already filtered author."
+   }
+  ],
+  "eb14adc5fb30": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: strong_verification_attempts, users",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "ec7011f66797": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "is_not_visible is the visibility check itself and deliberately selects invisible users; BlockUser, UnblockUser and GetBlockedUsers filter User.is_visible and are scoped to the caller's own blocks."
+   }
+  ],
+  "ed68835d2688": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries pinned",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody."
+   }
+  ],
+  "ed6ced362a66": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "ede1ee328f21": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: replies (replies) carries pinned",
+    "note": "Notification fan out: the moderated row is loaded by id to build the notification payload, and the notification carries that row's moderation_state_id, so the gate is applied when the notification is read or delivered rather than here. Precondition on the caller's own content: an overlap, duplicate or already-written check, or an edit or delete of a row the caller authored. It returns nothing about anybody else's content."
+   }
+  ],
+  "eff11e18e04b": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "resources.py:203, copy_resources_to_database. A batch of literal INSERT INTO timezone_areas (tzid, geom) VALUES statements; the geometry literals are what exceed the cap. No relation is read."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "resources.py:203, copy_resources_to_database. A batch of literal INSERT INTO timezone_areas (tzid, geom) VALUES statements; the geometry literals are what exceed the cap. No relation is read."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "resources.py:203, copy_resources_to_database. A batch of literal INSERT INTO timezone_areas (tzid, geom) VALUES statements; the geometry literals are what exceed the cap. No relation is read."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: bulk insert of timezone_areas polygons. Reads no user relation."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: bulk insert of timezone_areas polygons. Reads no moderated content."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Statement carries no negation and no outer join, so there is nothing for this dimension to judge."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: bulk insert of timezone_areas polygons from a repository file, so it returns no rows at all."
+   }
+  ],
+  "f070c865603f": [
+   {
+    "dimension": "writes",
+    "reason": "data modifying CTE",
+    "note": "The touch_user CTE bumps users.last_active for the calling user, keyed on users.id, and upserts that user's activity row on its unique key."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Authentication path: it has to find banned, deleted and shadowbanned accounts in order to authenticate them and tell them why they are refused. The interceptor's own lookup is the caller's row, reached through their session token, and does filter User.is_visible."
+   }
+  ],
+  "f17f986f6abb": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Builds the body of the rate limit warning email sent to moderators. It lists the users the rate limited caller contacted, and goes to moderators only."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries nothing",
+    "note": "Counts or lists the caller's own recent actions to decide whether they are rate limited, and to fill in the warning email to moderators."
+   }
+  ],
+  "f1d7cb0f6e8a": [
+   {
+    "dimension": "nesting",
+    "reason": "shared parent: photo_gallery_items.gallery_id = users.profile_gallery_id",
+    "note": "EXISTS over the user's own profile gallery, to decide whether they have an avatar or a complete profile. Both columns reference photo_galleries.id."
+   }
+  ],
+  "f3065b5ffd07": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "f3270baa7006": [
+   {
+    "dimension": "visibility",
+    "reason": "visible only: users (users) carries banned, deleted, keyed",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer, and returns nothing to anybody."
+   }
+  ],
+  "f3d9e3eefdfb": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to languages",
+    "note": "Resource bootstrap in copy_resources_to_database, which replaces the table wholesale."
+   }
+  ],
+  "f4ec60911cb2": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: group_chats (group_chats) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "f52433be90c5": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "f5f62488d6be": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "f6ac4738508f": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "f774bae3ed76": [
+   {
+    "dimension": "writes",
+    "reason": "insert from a query",
+    "note": "Inserts a row derived from a keyed select of the same user's data, or a DEFAULT VALUES insert."
+   },
+   {
+    "dimension": "nesting",
+    "reason": "non key: hosting_meetup_status_history.hosting_status = users.hosting_status",
+    "note": "Compares the user's current hosting and meetup status against the latest recorded history row, to skip writing an unchanged one. The comparison is the point; row identity is pinned by a bound user_id on both levels."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Reads one column of a user named by id for internal bookkeeping (locale, timezone, postcard name, hosting status history, node geography). Nothing about the user reaches another user."
+   }
+  ],
+  "f77b0feb7650": [
+   {
+    "dimension": "nesting",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "The wide identity reload of a single user, keyed on users.id. Issued from User.__repr__ via the debug log line in auth.py:135, which runs after session.commit() has expired the instance. Correct SQL, but see the efficiency note: it is the most executed shape in the suite."
+   },
+   {
+    "dimension": "joins",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "The wide identity reload of a single user, keyed on users.id. Issued from User.__repr__ via the debug log line in auth.py:135, which runs after session.commit() has expired the instance. Correct SQL, but see the efficiency note: it is the most executed shape in the suite."
+   },
+   {
+    "dimension": "writes",
+    "reason": "not parsed: truncated by the recorder",
+    "note": "The wide identity reload of a single user, keyed on users.id. Issued from User.__repr__ via the debug log line in auth.py:135, which runs after session.commit() has expired the instance. Correct SQL, but see the efficiency note: it is the most executed shape in the suite."
+   },
+   {
+    "dimension": "visibility",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: SELECT users.* WHERE users.id = the caller's own id, triggered by User.__repr__ and by has_completed_profile on the caller's row. Cut mid column list because the User table is wider than the recorder's cap."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: SELECT users.* by primary key. Reads no moderated content."
+   },
+   {
+    "dimension": "nulls",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Statement carries no negation and no outer join, so there is nothing for this dimension to judge."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "not parsed: statement truncated by the recorder's 4096 char cap",
+    "note": "Read against source: SELECT users.* by primary key, so it returns at most one row. It is unjudged only because the recorder cut the statement."
+   }
+  ],
+  "f786b7693d9c": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: public_trips (public_trips) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "f83a52f1b81d": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to regions_lived",
+    "note": "Resource bootstrap in copy_resources_to_database, which replaces the table wholesale."
+   }
+  ],
+  "f88886e2c00c": [
+   {
+    "dimension": "joins",
+    "reason": "shared parent: messages.conversation_id = group_chat_subscriptions.group_chat_id",
+    "note": "Messages correlated to a chat subscription by conversation. Verified across all 31 such shapes that each also carries the group_chat_subscriptions.joined <= messages.time and left IS NULL OR left >= messages.time bounds, so no message outside a user's membership window is reachable."
+   }
+  ],
+  "f8ddacef466d": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: friend_relationships (friend_relationships) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "f948b6e73203": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no request path whose caller could be disclosed to."
+   }
+  ],
+  "f966dc4535e5": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries nothing",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "fa3e66ad929a": [
+   {
+    "dimension": "nulls",
+    "reason": "outer join defeated: event_subscriptions kept by an outer join, then filtered by event_subscriptions.user_id IS NOT NULL",
+    "note": "Read against source: ListMyEvents and EventSearch outer join event_subscriptions, event_organizers and event_occurrence_attendees so one statement can answer subscribed OR organizing OR attending, and combine the arms with or_(*where_) (servicers/events.py:1230 onwards, servicers/search.py:814 onwards). The recorded shapes each requested a single arm, so the OR collapses to one term and the outer join degenerates to an inner join, which is the right answer for that request. See finding 8 for the combination that does not collapse cleanly."
+   }
+  ],
+  "fadf7a6e9b02": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries pinned",
+    "note": "Loads the caller's own row, by context.user_id. Admin surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions in couchers/middleware/interceptors.py, and these RPCs exist precisely to act on banned, deleted and shadowbanned users. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "fb04b58d8265": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: lite_users (lite_users) carries pinned",
+    "note": "Second stage of user search. The ids come from _user_search_inner, whose statement in this same log carries the full users_visible filter (banned, deleted, shadow and blocks); these statements only fetch columns for ids already chosen. UserSearch itself applies users_visible at search.py:248."
+   }
+  ],
+  "fb90f93f914c": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: moderation_queue",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "fbe075b68007": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: event_occurrences (event_occurrences) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads. Second stage of a listing: the ids come from a statement that applied where_moderated_content_visible, and this one only fetches the columns for ids already chosen, or lazily loads a row the caller already holds."
+   }
+  ],
+  "fc11205b35de": [
+   {
+    "dimension": "visibility",
+    "reason": "visible and unshadowed: users (users) carries banned, deleted, keyed, shadow",
+    "note": "Logged out public surface: users_visible with a logged out context is User.is_visible plus shadowed_at IS NULL, with no block clause because there is no viewer to have blocked anyone. The signup page counters and the team page filter User.is_visible only, and expose an aggregate count and opt-in staff records."
+   }
+  ],
+  "fc660980c353": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: replies (replies) carries pinned",
+    "note": "Admin and moderation surface: admin.proto and moderation.proto declare option (auth_level) = AUTH_LEVEL_ADMIN, enforced by check_permissions, and the moderation service exists to see content at every visibility. helpers/upload_uses.py is reached only from Admin.ListUploads."
+   }
+  ],
+  "fcf8add9da72": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: account_deletion_tokens",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, where the table holds the handful of rows the test just made."
+   }
+  ],
+  "fd0a51d30d50": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: notifications (notifications) carries keyed",
+    "note": "No application frame in any recorded stack for this shape: the statement is written by test or dev seeding code, so there is no viewer for moderation to hide anything from."
+   }
+  ],
+  "fe06af95e0c8": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries banned, keyed, shadow",
+    "note": "where_reference_user_visible is deliberately weaker than users_visible, and says so: references involving deleted or blocked users stay visible so reference history is preserved, and only banned or shadowed users hide theirs. ListReferences and get_num_references must use the same filter or the count diverges from the list."
+   },
+   {
+    "dimension": "moderation",
+    "reason": "no state: references_1 (references) carries nothing; no state: host_requests (host_requests) carries keyed",
+    "note": "An existence test inside a statement whose own moderated relation is filtered: the reciprocal-reference check, the has-replies test that decides whether a deleted comment is shown as a stub, and the subquery that finds the DM between two users. None of them returns the row it tests for."
+   }
+  ],
+  "fe77a90a67ec": [
+   {
+    "dimension": "visibility",
+    "reason": "unfiltered: users (users) carries nothing",
+    "note": "Background job or metric: it runs on a schedule with no viewer to disclose anything to, so the visibility filter is not the relevant control here."
+   },
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: strong_verification_attempts, users",
+    "note": "Background job: it exists to walk the table and act on every row that qualifies, so an unbounded read is what it is for. It runs on a schedule with no caller waiting on it, and returns nothing to anybody."
+   }
+  ],
+  "ffbb42289dd2": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to notifications",
+    "note": "Marks notifications seen; scoped by user_id and by id or topic_action/key."
+   }
+  ]
+ },
+ "bugs": {
+  "3c17322a238f": [
+   {
+    "dimension": "moderation",
+    "reason": "state partly tested: notifications (notifications) carries nothing; no state: comments (comments) carries keyed; no state: discussions (discussions) carries keyed; no state: event_occurrences (event_occurrences) carries keyed",
+    "note": "BUG: moderation_state_column_visible (couchers/sql.py:226) builds its author arm as object_type = X AND EXISTS(author = me), with no test on the state's visibility, so for the author of the linked content the predicate passes at every visibility including hidden. Its own docstring and where_moderated_content_visible both restrict that arm to shadowed."
+   }
+  ],
+  "4b3d477d3b7c": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "BUG: a lookup by a column used as a unique identifier that carries neither a unique constraint nor an index, so it scans a table that grows with the user base and nothing enforces that at most one row matches, though the code reads it with scalar_one_or_none. users.new_email_token, users.undelete_token, users.stripe_customer_id and signup_flows.email_token are all plain mapped_column(String), while signup_flows.flow_token in the same file is unique=True."
+   }
+  ],
+  "7e7b784b2358": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: host_requests (host_requests) carries nothing",
+    "note": "BUG: public_trip_to_pb's offers_count (public_trips.py:80) counts every non-cancelled host request on the trip with no moderation filter, while the owner's thread list is filtered. Offers start shadowed, so the owner is shown a count of offers they cannot open."
+   }
+  ],
+  "970ddf0c87fe": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: signup_flows",
+    "note": "BUG: a lookup by a column used as a unique identifier that carries neither a unique constraint nor an index, so it scans a table that grows with the user base and nothing enforces that at most one row matches, though the code reads it with scalar_one_or_none. users.new_email_token, users.undelete_token, users.stripe_customer_id and signup_flows.email_token are all plain mapped_column(String), while signup_flows.flow_token in the same file is unique=True."
+   }
+  ],
+  "97ccf0e4b22f": [
+   {
+    "dimension": "moderation",
+    "reason": "state partly tested: notifications (notifications) carries nothing; no state: comments (comments) carries keyed; no state: discussions (discussions) carries keyed; no state: event_occurrences (event_occurrences) carries keyed",
+    "note": "BUG: moderation_state_column_visible (couchers/sql.py:226) builds its author arm as object_type = X AND EXISTS(author = me), with no test on the state's visibility, so for the author of the linked content the predicate passes at every visibility including hidden. Its own docstring and where_moderated_content_visible both restrict that arm to shadowed."
+   }
+  ],
+  "a697e2aef8dc": [
+   {
+    "dimension": "writes",
+    "reason": "unkeyed write to event_occurrences",
+    "note": "BUG: UpdateEvent(update_all_future=True) at servicers/events.py:809 has no EventOccurrence.event_id filter, so it rewrites every future occurrence of every event in the database."
+   }
+  ],
+  "a72da5bb66ae": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "BUG: a lookup by a column used as a unique identifier that carries neither a unique constraint nor an index, so it scans a table that grows with the user base and nothing enforces that at most one row matches, though the code reads it with scalar_one_or_none. users.new_email_token, users.undelete_token, users.stripe_customer_id and signup_flows.email_token are all plain mapped_column(String), while signup_flows.flow_token in the same file is unique=True."
+   }
+  ],
+  "c1a24a9fe330": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: comments (comments) carries keyed",
+    "note": "BUG: total_num_responses (threads.py:69) filters the replies by their own moderation state but joins comments only to reach the thread, so replies under a comment GetThread hides are still counted."
+   }
+  ],
+  "c6dd4223cd99": [
+   {
+    "dimension": "moderation",
+    "reason": "state partly tested: notifications (notifications) carries nothing; no state: comments (comments) carries keyed; no state: discussions (discussions) carries keyed; no state: event_occurrences (event_occurrences) carries keyed",
+    "note": "BUG: moderation_state_column_visible (couchers/sql.py:226) builds its author arm as object_type = X AND EXISTS(author = me), with no test on the state's visibility, so for the author of the linked content the predicate passes at every visibility including hidden. Its own docstring and where_moderated_content_visible both restrict that arm to shadowed."
+   }
+  ],
+  "c8a3b9cfe55c": [
+   {
+    "dimension": "moderation",
+    "reason": "state partly tested: notifications (notifications) carries pinned; no state: comments (comments) carries keyed; no state: discussions (discussions) carries keyed; no state: event_occurrences (event_occurrences) carries keyed",
+    "note": "BUG: moderation_state_column_visible (couchers/sql.py:226) builds its author arm as object_type = X AND EXISTS(author = me), with no test on the state's visibility, so for the author of the linked content the predicate passes at every visibility including hidden. Its own docstring and where_moderated_content_visible both restrict that arm to shadowed."
+   }
+  ],
+  "e1243ad39715": [
+   {
+    "dimension": "bounds",
+    "reason": "unscoped: users",
+    "note": "BUG: a lookup by a column used as a unique identifier that carries neither a unique constraint nor an index, so it scans a table that grows with the user base and nothing enforces that at most one row matches, though the code reads it with scalar_one_or_none. users.new_email_token, users.undelete_token, users.stripe_customer_id and signup_flows.email_token are all plain mapped_column(String), while signup_flows.flow_token in the same file is unique=True."
+   }
+  ],
+  "fc11205b35de": [
+   {
+    "dimension": "moderation",
+    "reason": "no state: references (references) carries nothing",
+    "note": "BUG: GetPublicUser counts references with only users_visible (public.py:216), while get_num_references (api.py:1044) also applies where_moderated_content_visible and where_references_not_hidden_by_reciprocity. New references start shadowed, so the public profile's count includes references no listing shows."
+   }
+  ]
+ }
+}

--- a/app/scripts/query_audit_selftest.py
+++ b/app/scripts/query_audit_selftest.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["sqlglot>=27"]
+# ///
+"""Checks query_audit.py: negative controls per dimension, and an independent cross-check of every clear.
+
+An audit is only worth what its checker is worth, and a checker that fails to see a construct also fails to judge
+it, which comes out as a clear rather than as an error. Two independent things are done about that here:
+
+  controls     statements built to fail a dimension, each with the verdict it has to get. A dimension that cannot
+               tell the real helper's output from the same statement with one clause dropped is not discriminating,
+               and its clears mean nothing.
+  cross-check  every clear re-derived from the raw statement text by regex, on unrelated machinery. Where the AST
+               walk says it judged n joins and the text holds more JOIN keywords than that, something was not seen.
+
+Both are cheap and neither shares code with the thing it checks. Run with uv, which resolves sqlglot from the
+header above:
+
+  uv run app/scripts/query_audit_selftest.py --schema schema.sql --data data.json.gz
+
+Both arguments accept a URL as well as a path, so the artifacts the last develop pipeline published can be used
+directly:
+
+  --schema https://develop--schema.preview.couchershq.org/schema.sql
+  --data https://develop--test-artifacts.preview.couchershq.org/queries/data.json.gz
+
+--data is optional: without it the controls run and the cross-check is skipped. Exits non-zero if any control
+fails or any clear is contradicted.
+"""
+
+import argparse
+import re
+import sys
+
+import query_audit as qa
+
+VERBOSE = False
+
+# ---------------------------------------------------------------------------- visibility controls
+
+# what couchers.sql.users_visible emits, clause by clause, so a case can drop exactly one of them
+VISIBLE = "users.banned_at IS NULL AND users.deleted_at IS NULL"
+SHADOW = "(users.shadowed_at IS NULL OR users.id = 1)"
+BLOCKS = (
+    "users.id NOT IN (SELECT anon_1.blocked_user_id FROM (SELECT user_blocks.blocked_user_id AS blocked_user_id "
+    "FROM user_blocks WHERE user_blocks.blocking_user_id = 1 UNION SELECT user_blocks.blocking_user_id AS "
+    "blocking_user_id FROM user_blocks WHERE user_blocks.blocked_user_id = 1) AS anon_1)"
+)
+FULL = f"{VISIBLE} AND {SHADOW} AND {BLOCKS}"
+
+VISIBILITY_CASES = [
+    # the helper's own output clears, and dropping any one clause of it does not
+    (qa.CLEAR, "users_visible's own output", f"SELECT users.id FROM users WHERE {FULL}"),
+    (qa.OPEN, "without the block anti join", f"SELECT users.id FROM users WHERE {VISIBLE} AND {SHADOW}"),
+    (qa.OPEN, "without the shadow clause", f"SELECT users.id FROM users WHERE {VISIBLE} AND {BLOCKS}"),
+    (qa.OPEN, "without banned and deleted", f"SELECT users.id FROM users WHERE {SHADOW} AND {BLOCKS}"),
+    (
+        qa.OPEN,
+        "without the deleted clause",
+        f"SELECT users.id FROM users WHERE users.banned_at IS NULL AND {SHADOW} AND {BLOCKS}",
+    ),
+    # a filter that only applies inside an OR arm filters nothing
+    (
+        qa.OPEN,
+        "the whole filter inside one arm of an OR",
+        f"SELECT users.id FROM users WHERE users.city = 'x' OR ({FULL})",
+    ),
+    # the identity join: lite_users inherits the filter on users, but only across a real id equality
+    (
+        qa.CLEAR,
+        "an identity join carries the filter across",
+        f"SELECT lite_users.id FROM users JOIN lite_users ON lite_users.id = users.id WHERE {FULL}",
+    ),
+    (
+        qa.OPEN,
+        "the same join on a non-identity column",
+        f"SELECT lite_users.id FROM users JOIN lite_users ON lite_users.username = users.username WHERE {FULL}",
+    ),
+    (
+        qa.OPEN,
+        "an id equality that names a different person",
+        f"SELECT lite_users.id FROM users JOIN lite_users ON lite_users.id = users.profile_gallery_id WHERE {FULL}",
+    ),
+    # an outer join's ON carries into the joined relation only, not back into the base
+    (
+        qa.OPEN,
+        "an outer join's ON does not filter the base relation",
+        "SELECT users.id FROM users LEFT JOIN lite_users ON lite_users.id = users.id AND lite_users.is_visible",
+    ),
+    # the EXISTS proof: the joined user is the one the EXISTS filtered
+    (
+        qa.CLEAR,
+        "a filtered EXISTS on the column the relation is read through",
+        "SELECT host_requests.id FROM host_requests JOIN lite_users ON lite_users.id = host_requests.initiator_user_id "
+        f"WHERE EXISTS (SELECT 1 FROM users WHERE users.id = host_requests.initiator_user_id AND {FULL})",
+    ),
+    # ... but not when the EXISTS is about a different column
+    (
+        qa.OPEN,
+        "the same EXISTS about a different column",
+        "SELECT host_requests.id FROM host_requests JOIN lite_users ON lite_users.id = host_requests.initiator_user_id "
+        f"WHERE EXISTS (SELECT 1 FROM users WHERE users.id = host_requests.recipient_user_id AND {FULL})",
+    ),
+    # ... nor when the EXISTS is only one arm of an OR, so it does not hold for every row
+    (
+        qa.OPEN,
+        "the EXISTS as one arm of an OR",
+        "SELECT host_requests.id FROM host_requests JOIN lite_users ON lite_users.id = host_requests.initiator_user_id "
+        "WHERE host_requests.status = 'pending' OR EXISTS (SELECT 1 FROM users WHERE users.id = "
+        f"host_requests.initiator_user_id AND {FULL})",
+    ),
+    # ... nor when it is negated
+    (
+        qa.OPEN,
+        "the EXISTS negated",
+        "SELECT host_requests.id FROM host_requests JOIN lite_users ON lite_users.id = host_requests.initiator_user_id "
+        f"WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.id = host_requests.initiator_user_id AND {FULL})",
+    ),
+    # ... nor when the EXISTS itself is unfiltered
+    (
+        qa.OPEN,
+        "the EXISTS over an unfiltered users",
+        "SELECT host_requests.id FROM host_requests JOIN lite_users ON lite_users.id = host_requests.initiator_user_id "
+        "WHERE EXISTS (SELECT 1 FROM users WHERE users.id = host_requests.initiator_user_id)",
+    ),
+    # a proof made at an enclosing level reaches a correlated subquery at a deeper one
+    (
+        qa.CLEAR,
+        "an enclosing proof reaching a deeper level",
+        "SELECT public_trips.id FROM public_trips WHERE EXISTS (SELECT 1 FROM users WHERE users.id = "
+        f"public_trips.user_id AND {FULL}) AND (SELECT users.gender FROM users WHERE users.id = public_trips.user_id) "
+        "= 'Woman'",
+    ),
+    # lite_users' own is_visible column, and the same statement without it
+    (
+        qa.CLEAR,
+        "lite_users.is_visible, which is banned and deleted at once",
+        "SELECT lite_users.id FROM lite_users WHERE lite_users.is_visible AND lite_users.shadowed_at IS NULL AND "
+        "lite_users.id NOT IN (SELECT user_blocks.blocked_user_id FROM user_blocks WHERE "
+        "user_blocks.blocking_user_id = 1)",
+    ),
+    (
+        qa.OPEN,
+        "the same without is_visible",
+        "SELECT lite_users.id FROM lite_users WHERE lite_users.shadowed_at IS NULL AND "
+        "lite_users.id NOT IN (SELECT user_blocks.blocked_user_id FROM user_blocks WHERE "
+        "user_blocks.blocking_user_id = 1)",
+    ),
+    # users_visible_to_each_other: the viewer side carries no shadow clause by design and still clears
+    (
+        qa.CLEAR,
+        "users_visible_to_each_other's own output",
+        "SELECT users_1.id FROM users AS users_1, users AS users_2 WHERE users_1.banned_at IS NULL AND "
+        "users_1.deleted_at IS NULL AND users_2.banned_at IS NULL AND users_2.deleted_at IS NULL AND "
+        "users_2.shadowed_at IS NULL AND NOT (EXISTS (SELECT 1 FROM user_blocks WHERE "
+        "user_blocks.blocking_user_id = users_1.id AND user_blocks.blocked_user_id = users_2.id OR "
+        "user_blocks.blocking_user_id = users_2.id AND user_blocks.blocked_user_id = users_1.id))",
+    ),
+    # ... and the same with one of the two users left unfiltered does not
+    (
+        qa.OPEN,
+        "the same with one side left unfiltered",
+        "SELECT users_1.id FROM users AS users_1, users AS users_2 WHERE users_1.banned_at IS NULL AND "
+        "users_1.deleted_at IS NULL AND users_2.shadowed_at IS NULL AND NOT (EXISTS (SELECT 1 FROM user_blocks "
+        "WHERE user_blocks.blocking_user_id = users_1.id AND user_blocks.blocked_user_id = users_2.id))",
+    ),
+    # a relation with no user in it at all
+    (qa.CLEAR, "reads no user relation", "SELECT messages.id FROM messages WHERE messages.conversation_id = 1"),
+    # the write target is not judged here, but a user it reads is
+    (qa.CLEAR, "the write target is not judged here", "UPDATE users SET last_active = now() WHERE users.id = 1"),
+    (
+        qa.OPEN,
+        "a write that reads an unfiltered user",
+        "UPDATE user_blocks SET blocked_user_id = 1 FROM users WHERE users.username = 'x'",
+    ),
+]
+
+
+def visibility_controls(schema: qa.Schema) -> list[str]:
+    failures = []
+    for expected, label, sql in VISIBILITY_CASES:
+        shape = qa.Shape(id="control", sql=sql, example=sql, write=False, ast=qa._parse(sql), parse_error=None)
+        verdict = qa.check_visibility(shape, schema)
+        if verdict.state != expected:
+            failures.append(f"{label}: want {expected} got {verdict.state} ({verdict.reason})")
+        elif VERBOSE:
+            print(f"  ok   {label:<58} -> {verdict.state}")
+    return failures
+
+
+# ---------------------------------------------------------------------------- moderation controls
+
+# what where_moderated_content_visible emits for a single item read of a host request
+JOINED = (
+    "SELECT host_requests.id FROM host_requests "
+    "JOIN moderation_states AS moderation_states_1 ON moderation_states_1.id = host_requests.moderation_state_id "
+    "WHERE (moderation_states_1.visibility = 'visible' OR moderation_states_1.visibility = 'unlisted' "
+    "OR moderation_states_1.visibility = 'shadowed' AND host_requests.initiator_user_id = 1)"
+)
+# what moderation_state_column_visible would emit if its author arm tested the visibility, as its docstring says
+TESTED = (
+    "SELECT notifications.id FROM notifications WHERE notifications.moderation_state_id IS NULL OR (EXISTS "
+    "(SELECT moderation_states_1.id FROM moderation_states AS moderation_states_1 WHERE moderation_states_1.id = "
+    "notifications.moderation_state_id AND (moderation_states_1.visibility = 'visible' OR "
+    "moderation_states_1.visibility = 'unlisted' OR moderation_states_1.visibility = 'shadowed' AND "
+    "moderation_states_1.object_type = 'comment' AND (EXISTS (SELECT 1 FROM comments WHERE comments.id = "
+    "moderation_states_1.object_id AND comments.author_user_id = 1)))))"
+)
+AUTHOR_ARM = "moderation_states_1.visibility = 'shadowed' AND moderation_states_1.object_type"
+
+# Each case names one relation in a statement and the classification it must get, so a case says something about
+# that relation rather than about whatever the weakest relation in the statement happens to be.
+MODERATION_CASES = [
+    ("host_requests", qa.STATE_JOINED, "the helper's own output", JOINED),
+    (
+        "host_requests",
+        qa.STATE_UNCONSTRAINED,
+        "joined but no visibility test",
+        "SELECT host_requests.id FROM host_requests JOIN moderation_states AS moderation_states_1 "
+        "ON moderation_states_1.id = host_requests.moderation_state_id WHERE host_requests.status = 'pending'",
+    ),
+    (
+        "host_requests",
+        qa.NO_STATE,
+        "no state at all",
+        "SELECT host_requests.id FROM host_requests WHERE host_requests.status = 'pending'",
+    ),
+    # an OR arm that never names the visibility lets rows through at any visibility: this is the real defect in
+    # moderation_state_column_visible, and the check has to see it
+    (
+        "host_requests",
+        qa.STATE_UNCONSTRAINED,
+        "an arm that does not name the visibility",
+        JOINED.replace("moderation_states_1.visibility = 'shadowed' AND host_requests", "host_requests"),
+    ),
+    (
+        "host_requests",
+        qa.NO_STATE,
+        "state joined to another table's column",
+        "SELECT host_requests.id FROM host_requests JOIN notifications ON notifications.id = host_requests.id "
+        "JOIN moderation_states AS moderation_states_1 ON moderation_states_1.id = notifications.moderation_state_id "
+        "WHERE moderation_states_1.visibility = 'visible'",
+    ),
+    (
+        "host_requests",
+        qa.NO_STATE,
+        "outer joined state",
+        "SELECT host_requests.id FROM host_requests LEFT JOIN moderation_states AS moderation_states_1 "
+        "ON moderation_states_1.id = host_requests.moderation_state_id AND moderation_states_1.visibility = 'visible'",
+    ),
+    ("notifications", qa.STATE_TESTED, "the column form, with every arm constrained", TESTED),
+    (
+        "notifications",
+        qa.STATE_PARTLY_TESTED,
+        "the column form with an unconstrained author arm",
+        TESTED.replace(AUTHOR_ARM, "moderation_states_1.object_type"),
+    ),
+    (
+        "notifications",
+        qa.NO_STATE,
+        "the column form reaching a different column's state",
+        TESTED.replace("moderation_states_1.id = notifications.moderation_state_id", "moderation_states_1.id = 7"),
+    ),
+    (
+        "notifications",
+        qa.NO_STATE,
+        "the column form with the NULL arm replaced by an unrelated one",
+        TESTED.replace("notifications.moderation_state_id IS NULL", "notifications.is_seen = false"),
+    ),
+    # the EXISTS behind the authorship test is itself an unfiltered read of moderated content, and stays open
+    ("comments", qa.NO_STATE, "the authorship EXISTS inside the column form", TESTED),
+]
+
+MODERATION_STATEMENT_CASES = [
+    (qa.CLEAR, "reads no moderated content", "SELECT messages.id FROM messages WHERE messages.conversation_id = 1"),
+    (
+        qa.CLEAR,
+        "the write target is not judged here",
+        "UPDATE host_requests SET status = 'accepted' WHERE host_requests.conversation_id = 1",
+    ),
+    (
+        qa.OPEN,
+        "a write that reads other moderated content",
+        "UPDATE users SET name = 'x' FROM host_requests WHERE host_requests.initiator_user_id = users.id",
+    ),
+]
+
+
+def moderation_controls(schema: qa.Schema) -> list[str]:
+    failures = []
+    for table, expected, label, sql in MODERATION_CASES:
+        reads = {read[1]: read[2] for read in qa.walk_moderated_relations(qa._parse(sql), schema)}
+        got = reads.get(table)
+        if got != expected:
+            failures.append(f"{label}: {table} want {expected} got {got}")
+        elif VERBOSE:
+            print(f"  ok   {label:<58} {table} -> {got}")
+    for expected, label, sql in MODERATION_STATEMENT_CASES:
+        shape = qa.Shape(id="control", sql=sql, example=sql, write=False, ast=qa._parse(sql), parse_error=None)
+        verdict = qa.check_moderation(shape, schema)
+        if verdict.state != expected:
+            failures.append(f"{label}: want {expected} got {verdict.state} ({verdict.reason})")
+        elif VERBOSE:
+            print(f"  ok   {label:<58} -> {verdict.state}")
+    return failures
+
+
+# ---------------------------------------------------------------------------- nulls controls
+
+# users.hometown, users.phone and users.profile_gallery_id are nullable; users.id and username are not.
+NOT_IN_BLOCKS = (
+    "SELECT users.id FROM users WHERE users.id NOT IN (SELECT anon_1.blocked_user_id FROM "
+    "(SELECT user_blocks.blocked_user_id AS blocked_user_id FROM user_blocks WHERE user_blocks.blocking_user_id = 1 "
+    "UNION SELECT user_blocks.blocking_user_id AS blocking_user_id FROM user_blocks "
+    "WHERE user_blocks.blocked_user_id = 1) AS anon_1)"
+)
+
+# Each case names the construct it is about and the classification it must get, so a case says something about
+# that construct rather than about whatever the weakest one in the statement happens to be.
+NULLS_CASES = [
+    # --- NOT IN: a NULL on the right makes every row fail, so the statement returns nothing at all
+    (qa.NULL_SAFE, "users_visible's block clause, through a union in a derived table", NOT_IN_BLOCKS),
+    (
+        qa.VANISHES,
+        "one branch of that union made nullable",
+        NOT_IN_BLOCKS.replace("user_blocks.blocking_user_id AS blocking_user_id", "users.hometown AS hometown").replace(
+            "FROM user_blocks WHERE user_blocks.blocked_user_id = 1", "FROM users"
+        ),
+    ),
+    (
+        qa.VANISHES,
+        "NOT IN over a nullable column",
+        "SELECT users.id FROM users WHERE users.username NOT IN (SELECT users.hometown FROM users)",
+    ),
+    (
+        qa.NULL_SAFE,
+        "NOT IN over a not null column",
+        "SELECT users.id FROM users WHERE users.username NOT IN (SELECT users.username FROM users)",
+    ),
+    (
+        qa.VANISHES,
+        "NOT IN over the padded side of an outer join inside the subquery",
+        "SELECT users.id FROM users WHERE users.id NOT IN "
+        "(SELECT b.blocked_user_id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id)",
+    ),
+    (
+        qa.NULL_SAFE,
+        "the same subquery with the join made inner",
+        "SELECT users.id FROM users WHERE users.id NOT IN "
+        "(SELECT b.blocked_user_id FROM users JOIN user_blocks AS b ON b.blocking_user_id = users.id)",
+    ),
+    (qa.VANISHES, "NOT IN a literal list holding a NULL", "SELECT users.id FROM users WHERE users.id NOT IN (1, NULL)"),
+    (qa.NULL_SAFE, "NOT IN a literal list", "SELECT users.id FROM users WHERE users.id NOT IN (1, 2)"),
+    (
+        qa.DROPS_NULLS,
+        "NOT IN with a nullable left hand side",
+        "SELECT users.id FROM users WHERE users.hometown NOT IN (SELECT users.username FROM users)",
+    ),
+    (
+        qa.UNKNOWN_NULLS,
+        "NOT IN with a view column on the left",
+        "SELECT lite_users.id FROM lite_users WHERE lite_users.id NOT IN (SELECT users.id FROM users)",
+    ),
+    # --- inequality: the rows where the column is NULL are not "everything except", they are simply gone
+    (qa.NULL_SAFE, "!= on a not null column", "SELECT users.id FROM users WHERE users.username != 'x'"),
+    (qa.DROPS_NULLS, "!= on a nullable column", "SELECT users.id FROM users WHERE users.hometown != 'x'"),
+    (
+        qa.DROPS_NULLS,
+        "!= against the padded side of an outer join, which is both that and a defeated join",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id "
+        "WHERE b.blocked_user_id != users.id",
+    ),
+    # --- NOT over a compound predicate
+    (
+        qa.NULL_SAFE,
+        "NOT over not null operands",
+        "SELECT users.id FROM users WHERE NOT (users.username = 'x' AND users.id = 1)",
+    ),
+    (
+        qa.DROPS_NULLS,
+        "NOT over a nullable operand",
+        "SELECT users.id FROM users WHERE NOT (users.username = 'x' AND users.hometown = 'y')",
+    ),
+    (
+        qa.NULL_SAFE,
+        "NOT over an IS NULL, which is definite whatever the column holds",
+        "SELECT users.id FROM users WHERE NOT (users.hometown IS NULL AND users.phone IS NULL)",
+    ),
+    (
+        qa.NULL_SAFE,
+        "NOT EXISTS, which is definite too",
+        "SELECT users.id FROM users WHERE NOT (EXISTS (SELECT 1 FROM user_blocks "
+        "WHERE user_blocks.blocking_user_id = users.id))",
+    ),
+    (
+        qa.NULL_SAFE,
+        "NOT over a not null boolean column",
+        "SELECT e.id FROM event_occurrences AS e WHERE NOT e.is_deleted",
+    ),
+    (qa.DROPS_NULLS, "NOT over a nullable boolean column", "SELECT users.id FROM users WHERE NOT users.camping_ok"),
+    # --- an outer join that is filtered back into an inner one
+    (
+        qa.OUTER_DEFEATED,
+        "an equality on the padded side, in the WHERE",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id "
+        "WHERE b.blocked_user_id = 1",
+    ),
+    (
+        qa.NULL_SAFE,
+        "the same equality, in the outer join's own ON",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id "
+        "AND b.blocked_user_id = 1",
+    ),
+    (
+        qa.NULL_SAFE,
+        "the anti join idiom, which is what an outer join is for",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id WHERE b.id IS NULL",
+    ),
+    (
+        qa.NULL_SAFE,
+        "an equality that keeps the padded rows explicitly",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id "
+        "WHERE (b.blocked_user_id = 1 OR b.id IS NULL)",
+    ),
+    (
+        qa.OUTER_DEFEATED,
+        "IS NOT NULL on the padded side",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id WHERE b.id IS NOT NULL",
+    ),
+    (
+        qa.OUTER_DEFEATED,
+        "a right join, which pads what came before it",
+        "SELECT users.id FROM users RIGHT JOIN user_blocks AS b ON b.blocking_user_id = users.id WHERE users.id = 1",
+    ),
+    (
+        qa.NULL_SAFE,
+        "a filter on the relation the outer join does not pad",
+        "SELECT users.id FROM users LEFT JOIN user_blocks AS b ON b.blocking_user_id = users.id WHERE users.id = 1",
+    ),
+]
+
+
+def nulls_controls(schema: qa.Schema) -> list[str]:
+    failures = []
+    for expected, label, sql in NULLS_CASES:
+        kinds = {kind for kind, _ in qa.walk_null_kinds(qa._parse(sql), schema)}
+        # A case that should be clean has to be clean outright; a case that should be caught has to be caught, and
+        # may well be caught twice, as a `!=` against an outer joined relation is.
+        ok = kinds == {qa.NULL_SAFE} if expected == qa.NULL_SAFE else expected in kinds
+        if not ok:
+            failures.append(f"{label}: want {expected} got {sorted(kinds)}")
+        elif VERBOSE:
+            print(f"  ok   {label:<58} -> {', '.join(sorted(kinds))}")
+    return failures
+
+
+# ---------------------------------------------------------------------------- bounds controls
+
+BOUNDS_CASES = [
+    (qa.UNSCOPED, "a bare read of a growing table", "SELECT users.id FROM users"),
+    (qa.LIMITED, "a LIMIT", "SELECT users.id FROM users LIMIT 10"),
+    (qa.LIMITED, "a bound LIMIT", "SELECT users.id FROM users ORDER BY users.id LIMIT $1"),
+    (qa.ONE_ROW, "an aggregate over the whole result", "SELECT count(*) FROM users"),
+    (
+        qa.ONE_ROW,
+        "an aggregate inside another call is still an aggregate",
+        "SELECT coalesce(sum(invoices.amount), 0) FROM invoices",
+    ),
+    (
+        qa.UNSCOPED,
+        "the same aggregate with a grouping, which returns one row per group",
+        "SELECT count(*) FROM users GROUP BY users.city",
+    ),
+    (
+        qa.UNSCOPED,
+        "an aggregate in a scalar subquery, which does not collapse the outer result",
+        "SELECT (SELECT count(*) FROM user_blocks) AS c, users.id FROM users",
+    ),
+    (qa.ONE_ROW, "a primary key equality", "SELECT users.id FROM users WHERE users.id = 1"),
+    (qa.ONE_ROW, "a unique column equality", "SELECT users.id FROM users WHERE users.username = 'x'"),
+    (
+        qa.UNSCOPED,
+        "an equality on a property rather than an identifier",
+        "SELECT users.id FROM users WHERE users.hosting_status = 'can_host'",
+    ),
+    (
+        qa.SCOPED,
+        "a foreign key equality, which names one entity and grows with it",
+        "SELECT messages.id FROM messages WHERE messages.conversation_id = 1",
+    ),
+    (qa.PINNED_LIST, "a list of identifiers", "SELECT users.id FROM users WHERE users.id IN (1, 2, 3)"),
+    (
+        qa.UNSCOPED,
+        "IN a subquery, which is not a list the statement was handed",
+        "SELECT users.id FROM users WHERE users.id IN (SELECT user_blocks.blocked_user_id FROM user_blocks)",
+    ),
+    (
+        qa.PINNED_LIST,
+        "an OR whose every arm names rows",
+        "SELECT users.id FROM users WHERE users.username = 'x' OR users.email = 'y'",
+    ),
+    (
+        qa.UNSCOPED,
+        "an OR with one arm that names nothing",
+        "SELECT users.id FROM users WHERE users.username = 'x' OR users.city = 'y'",
+    ),
+    (qa.STATIC, "a table the repository fixes the size of", "SELECT regions.code FROM regions"),
+    (
+        qa.UNSCOPED,
+        "a static table joined to a growing one",
+        "SELECT regions.code FROM regions JOIN users ON users.geom IS NOT NULL",
+    ),
+    (qa.NO_ROWS, "an empty IN list, as SQLAlchemy renders it", "SELECT users.id FROM users WHERE false"),
+    (
+        qa.SCOPED,
+        "a key equality on one side of a join that fans out into the other",
+        "SELECT messages.id FROM users JOIN messages ON messages.author_id = users.id WHERE users.id = 1",
+    ),
+    (
+        qa.UNSCOPED,
+        "a union is only as bounded as its worst branch",
+        "SELECT users.id FROM users WHERE users.id = 1 UNION SELECT users.id FROM users",
+    ),
+    (qa.LIMITED, "a LIMIT on the union itself", "SELECT users.id FROM users UNION SELECT users.id FROM users LIMIT 5"),
+    (
+        qa.ONE_ROW,
+        "every column of a composite unique key",
+        "SELECT moderation_states.id FROM moderation_states "
+        "WHERE moderation_states.object_type = 'comment' AND moderation_states.object_id = 1",
+    ),
+    (
+        qa.SCOPED,
+        "only part of a composite unique key",
+        "SELECT moderation_states.id FROM moderation_states WHERE moderation_states.object_type = 'comment'",
+    ),
+    (qa.ONE_ROW, "no relation at all", "SELECT 1"),
+]
+
+
+def bounds_controls(schema: qa.Schema) -> list[str]:
+    failures = []
+    for expected, label, sql in BOUNDS_CASES:
+        got = qa.result_bound(qa._parse(sql), schema)
+        if got[0] != expected:
+            failures.append(f"{label}: want {expected} got {got}")
+        elif VERBOSE:
+            print(f"  ok   {label:<58} -> {got[0]}")
+    return failures
+
+
+CONTROLS = {
+    "visibility": (visibility_controls, len(VISIBILITY_CASES)),
+    "moderation": (moderation_controls, len(MODERATION_CASES) + len(MODERATION_STATEMENT_CASES)),
+    "nulls": (nulls_controls, len(NULLS_CASES)),
+    "bounds": (bounds_controls, len(BOUNDS_CASES)),
+}
+
+
+# ---------------------------------------------------------------------------- cross-check
+
+MODERATED = (
+    r"comments|discussions|event_occurrences|friend_relationships|group_chats|host_requests|notifications|"
+    r"public_trips|\"?references\"?|replies"
+)
+
+
+def cross_check(shapes: dict[str, qa.Shape], verdicts: dict[str, dict[str, qa.Verdict]]) -> list[str]:
+    """Re-derive every clear from the raw statement text, by regex rather than from the AST.
+
+    Anything the AST walk fails to see it also fails to judge, and a missed join or subquery turns into a false
+    clear, so the counts a verdict reports are compared against what the text plainly holds. Only an undercount is
+    a contradiction: the walk resolves views and CTEs, so it legitimately judges more than the text shows.
+    """
+    bad: list[str] = []
+
+    def flag(shape_id: str, message: str, text: str) -> None:
+        bad.append(f"{shape_id} | {message} | {text[:110]}")
+
+    for shape_id, shape in shapes.items():
+        sql, ex = shape.sql, shape.example
+        verdict = verdicts[shape_id]
+
+        nesting = verdict["nesting"]
+        if nesting.state == qa.CLEAR and nesting.reason == "nothing nested":
+            for text, label in ((sql, "fp"), (ex, "ex")):
+                if re.search(r"\(\s*SELECT\b", text, re.I):
+                    flag(shape_id, f"nesting clear but subselect in {label}", text)
+                if re.match(r"\s*WITH\b", text, re.I):
+                    flag(shape_id, f"nesting clear but CTE in {label}", text)
+                if re.search(r"\bUNION\b|\bEXCEPT\b|\bINTERSECT\b", text, re.I):
+                    flag(shape_id, f"nesting clear but set op in {label}", text)
+
+        if (
+            nesting.state == qa.CLEAR
+            and nesting.reason != "nothing nested"
+            and "not a relational" not in nesting.reason
+        ):
+            match = re.match(r"(\d+) nested", nesting.reason)
+            if match:
+                counted = int(match.group(1))
+                # Every nested level opens with SELECT somewhere after the first one.
+                # Each branch of a set operation is a sibling, not a nested level.
+                branches = len(re.findall(r"\bUNION\b|\bEXCEPT\b|\bINTERSECT\b", ex, re.I))
+                seen = max(0, len(re.findall(r"\bSELECT\b", ex, re.I)) - 1 - branches)
+                if counted < seen:
+                    flag(shape_id, f"nesting clear counting {counted} levels but {seen} nested SELECTs present", ex)
+
+        joins = verdict["joins"]
+        if joins.state == qa.CLEAR:
+            seen = len(re.findall(r"\bJOIN\b", ex, re.I))
+            if joins.reason == "no joins":
+                if seen:
+                    flag(shape_id, f"joins clear as 'no joins' but {seen} JOIN keywords", ex)
+                if re.search(r"\bFROM\s+[\w.\"]+\s*,", ex, re.I):
+                    flag(shape_id, "joins clear as 'no joins' but comma join in FROM", ex)
+            else:
+                counted = int(re.match(r"(\d+) join", joins.reason).group(1))
+                if counted < seen:
+                    flag(shape_id, f"joins clear counting {counted} but {seen} JOIN keywords present", ex)
+
+        vis = verdict["visibility"]
+        if vis.state == qa.CLEAR:
+            # Every place a user relation can enter a statement: a FROM, a JOIN, or a comma join.
+            relations = re.findall(r'(?:FROM|JOIN|,)\s+(?:public\.)?"?(users|lite_users)"?(?![\w."])', ex, re.I)
+            if vis.reason == "reads no user relation":
+                if relations:
+                    flag(shape_id, f"visibility clear as reading no user relation but {len(relations)} present", ex)
+            else:
+                counted = int(re.match(r"(\d+) user relation", vis.reason).group(1))
+                if counted < len(relations):
+                    flag(shape_id, f"visibility counted {counted} user relations but {len(relations)} present", ex)
+                # Something has to be doing the filtering the verdict claims.
+                if not re.search(r"banned_at IS NULL|\bis_visible\b", ex, re.I):
+                    flag(shape_id, "visibility clear but no banned_at or is_visible test in the text", ex)
+                if not re.search(r"shadowed_at IS NULL", ex, re.I):
+                    flag(shape_id, "visibility clear but no shadowed_at test in the text", ex)
+                if not re.search(r"user_blocks", ex, re.I):
+                    flag(shape_id, "visibility clear but no user_blocks test in the text", ex)
+
+        mod = verdict["moderation"]
+        if mod.state == qa.CLEAR:
+            # The relation a write targets is the writes dimension's business and this dimension skips it, so the
+            # leading UPDATE / DELETE FROM / INSERT INTO clause is not part of what it claims about.
+            body = re.sub(r"^\s*(UPDATE|DELETE FROM|INSERT INTO)\s+[\w.\"]+", "", ex, flags=re.I)
+            relations = re.findall(rf"(?:FROM|JOIN|,)\s+(?:public\.)?({MODERATED})(?![\w.\"])", body, re.I)
+            if mod.reason == "reads no moderated content":
+                if relations:
+                    flag(shape_id, f"moderation clear as reading no moderated content but {len(relations)} present", ex)
+            else:
+                counted = int(re.match(r"(\d+) moderated relation", mod.reason).group(1))
+                if counted < len(relations):
+                    flag(shape_id, f"moderation counted {counted} relations but {len(relations)} present", ex)
+                if not re.search(r"\bmoderation_states\b", ex, re.I):
+                    flag(shape_id, "moderation clear but no moderation_states in the text", ex)
+                if not re.search(r"\.visibility\b", ex, re.I):
+                    flag(shape_id, "moderation clear but no visibility test in the text", ex)
+
+        nulls = verdict["nulls"]
+        if nulls.state == qa.CLEAR:
+            # A negation inside a string literal is text, not a predicate, and the example carries real values.
+            text = re.sub(r"'(?:[^']|'')*'", "''", ex)
+            # `IS NOT NULL` and `IS NOT DISTINCT FROM` are one definite operator, not a negation of anything.
+            negations = len(re.findall(r"\bNOT\b", text, re.I)) - len(re.findall(r"\bIS\s+NOT\b", text, re.I))
+            inequalities = len(re.findall(r"!=|<>", text))
+            outer_joins = len(re.findall(r"\b(?:LEFT|RIGHT|FULL)\s+(?:OUTER\s+)?JOIN\b", text, re.I))
+            seen = negations + inequalities + outer_joins
+            if nulls.reason == "nothing that turns on NULL":
+                if seen:
+                    flag(shape_id, f"nulls clear as turning on nothing but {seen} negations or outer joins present", ex)
+            else:
+                counted = int(re.match(r"(\d+) construct", nulls.reason).group(1))
+                if counted < seen:
+                    flag(shape_id, f"nulls counted {counted} constructs but {seen} present", ex)
+
+        bounds = verdict["bounds"]
+        if bounds.state == qa.CLEAR:
+            text = re.sub(r"'(?:[^']|'')*'", "''", ex)
+            kind, _, why = bounds.reason.partition(": ")
+            aggregate = re.search(
+                r"\b(count|sum|avg|min|max|string_agg|array_agg|json_agg|bool_or|bool_and)\s*\(", text, re.I
+            )
+            grouped = re.search(r"\bGROUP BY\b", text, re.I)
+            limited = re.search(r"\bLIMIT\b", text, re.I)
+            # Whatever else the reason claims, a read with nothing to restrict it cannot be bounded.
+            if (
+                kind not in ("not a read", "static table")
+                and why != "reads no relation"
+                and not (
+                    re.search(r"\bWHERE\b", text, re.I)
+                    or limited
+                    or grouped
+                    or aggregate
+                    or not re.search(r"\bFROM\b", text, re.I)
+                )
+            ):
+                flag(shape_id, f"bounds clear as '{bounds.reason}' but no WHERE, LIMIT, GROUP BY or aggregate", ex)
+            if kind == qa.LIMITED and not limited:
+                flag(shape_id, "bounds clear as limited but no LIMIT in the text", ex)
+            # A GROUP BY is not checked here: the text cannot say which level it belongs to, and a grouped subquery
+            # inside an ungrouped aggregate is an ordinary shape.
+            if why == "aggregate over the whole result" and not aggregate:
+                flag(shape_id, "bounds clear as an aggregate over the whole result but no aggregate in the text", ex)
+            # `WITH ... INSERT` is a write however it opens, so a WITH only counts as a read when nothing in it writes.
+            reads = re.match(r"\s*SELECT\b", ex, re.I) or (
+                re.match(r"\s*WITH\b", ex, re.I) and not re.search(r"\b(INSERT|UPDATE|DELETE)\b", ex, re.I)
+            )
+            if kind == "not a read" and reads:
+                flag(shape_id, "bounds clear as not a read but the statement returns rows", ex)
+            if kind == qa.STATIC:
+                others = set(re.findall(r"(?:FROM|JOIN)\s+(?:public\.)?\"?(\w+)\"?", text, re.I)) - {
+                    "regions",
+                    "languages",
+                    "timezone_areas",
+                }
+                if others:
+                    flag(shape_id, f"bounds clear as a static table but also reads {sorted(others)}", ex)
+            # Every column the verdict rests on has to actually be restricted in the statement.
+            if kind in (qa.SCOPED, qa.PINNED_LIST) or why.endswith("named by key"):
+                for ref in re.findall(r"\b\w+\.\w+\b", why):
+                    column = ref.split(".")[1]
+                    # SQLAlchemy writes a bind on either side, so `id = ?` and `? = id` both count.
+                    restricted = rf"\b{re.escape(column)}\s*(=|\bIN\b)|=\s*[\w.\"]*\b{re.escape(column)}\b"
+                    if not re.search(restricted, text, re.I):
+                        flag(shape_id, f"bounds rests on {ref} but it is not restricted in the text", ex)
+
+        writes = verdict["writes"]
+        if writes.state == qa.CLEAR and writes.reason.startswith("keyed on"):
+            match = re.match(r"keyed on (\w+)\(([^)]*)\)", writes.reason)
+            table, columns = match.group(1), [column.strip() for column in match.group(2).split(",")]
+            for column in columns:
+                if not re.search(rf"\b{re.escape(table)}\.{re.escape(column)}\s*=", sql, re.I) and not re.search(
+                    rf"\b{re.escape(column)}\s*=", sql, re.I
+                ):
+                    flag(shape_id, f"writes keyed on {table}.{column} but no equality found", sql)
+        if writes.state == qa.CLEAR and writes.reason == "insert of literal rows":
+            if not re.match(r"\s*INSERT\b", sql, re.I):
+                flag(shape_id, "insert-clear but not INSERT", sql)
+            if re.search(r"\bSELECT\b", sql, re.I) and not re.search(
+                r"FROM \(VALUES .*\) AS imp_sen\(", sql, re.I | re.S
+            ):
+                flag(shape_id, "insert of literal rows but SELECT present", sql)
+            if re.search(r"\bJOIN\b", sql, re.I):
+                flag(shape_id, "insert of literal rows but JOIN present", sql)
+        if writes.state == qa.CLEAR and writes.reason == "not a write":
+            if re.match(r"\s*(INSERT|UPDATE|DELETE)\b", sql, re.I):
+                flag(shape_id, "not-a-write but is a write", sql)
+
+    return bad
+
+
+# ---------------------------------------------------------------------------- main
+
+
+def main(argv: list[str] | None = None) -> int:
+    global VERBOSE
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--schema", required=True, help="path or URL of the schema dump (schema.sql)")
+    parser.add_argument("--data", help="path or URL of the merged query log; omit to run the controls only")
+    parser.add_argument("--verbose", action="store_true", help="print every control, not just the failures")
+    args = parser.parse_args(argv)
+    VERBOSE = args.verbose
+
+    schema = qa.parse_schema(qa.fetch(args.schema).decode())
+
+    failed = 0
+    for dimension, (run, total) in CONTROLS.items():
+        failures = run(schema)
+        failed += len(failures)
+        for failure in failures:
+            print(f"FAIL [{dimension}] {failure}")
+        print(f"{dimension:<12} {total:>3} controls, {len(failures)} failures")
+
+    if args.data:
+        shapes = qa.load_shapes(qa.load_data(args.data))
+        # Before the ledger, which only ever moves an open verdict: this checks the checker, not the reviews.
+        verdicts = {
+            shape_id: {dimension: function(shape, schema) for dimension, function in qa.CHECKS.items()}
+            for shape_id, shape in shapes.items()
+        }
+        contradictions = cross_check(shapes, verdicts)
+        failed += len(contradictions)
+        seen: set[str] = set()
+        for contradiction in contradictions:
+            message = contradiction.split(" | ")[1][:45]
+            if message not in seen:
+                seen.add(message)
+                print(f"FAIL [cross-check] {contradiction}")
+        print(f"cross-check  {len(shapes):>3} shapes, {len(contradictions)} contradictions")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The backend test pipeline already publishes a log of every SQL statement the suite issues, plus a dump of the schema those statements run on, and nothing reads them back. `query_audit.py` parses each query shape in that log and judges it on seven dimensions: how joins and nested queries relate their two sides, whether reads of users and of moderated content carry the visibility filters, whether anything depends on NULL behaving the way it does not, and how many rows a statement can return or mutate. A shape stays open until every dimension clears it; the ones a dimension cannot settle from the SQL alone are read against their call site and recorded in a ledger keyed by a hash of the statement, so editing a query brings its shape back for review. `query_audit_selftest.py` checks the checker, running each dimension against statements built to fail it and re-deriving every clear from the statement text by unrelated means.

## Testing
Run it against the artifacts the last develop pipeline published:

```
uv run app/scripts/query_audit.py \
  --data https://develop--test-artifacts.preview.couchershq.org/queries/data.json.gz \
  --schema https://develop--schema.preview.couchershq.org/schema.sql
```

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._