### PR TITLE
Index user_activity on sofa and on ip_address

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0185_index_user_activity_sofa_and_ip.py
+++ b/app/backend/src/couchers/migrations/versions/0185_index_user_activity_sofa_and_ip.py
@@ -1,0 +1,49 @@
+"""Index user_activity on sofa and on ip_address
+
+Revision ID: 0185
+Revises: 0184
+Create Date: 2026-08-18 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0185"
+down_revision = "0184"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_user_activity_sofa",
+            "user_activity",
+            ["sofa"],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_user_activity_ip_address",
+            "user_activity",
+            ["ip_address"],
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_user_activity_ip_address",
+            table_name="user_activity",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_user_activity_sofa",
+            table_name="user_activity",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -320,6 +320,8 @@ class UserActivity(Base, kw_only=True):
             # treat NULL ip_address/user_agent/sofa as equal so the upsert dedupes rows with absent columns
             postgresql_nulls_not_distinct=True,
         ),
+        Index("ix_user_activity_sofa", sofa),
+        Index("ix_user_activity_ip_address", ip_address),
     )
 
 


### PR DESCRIPTION
The `user_activity` table counts API calls per user, time period, ip address, user agent and sofa cookie. This adds an index on `sofa` and an index on `ip_address`, both created concurrently.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._