### PR TITLE
Respect moderation visibility in notifications and in listing counts

### DIFF
--- a/app/backend/src/couchers/servicers/public_trips.py
+++ b/app/backend/src/couchers/servicers/public_trips.py
@@ -77,12 +77,15 @@ def public_trip_to_pb(
         same_gender_only=public_trip.same_gender_only,
     )
     if public_trip.user_id == context.user_id:
-        pb.offers_count = session.execute(
+        offers = (
             select(func.count())
             .select_from(HostRequest)
             .where(HostRequest.public_trip_id == public_trip.id)
             .where(HostRequest.status != HostRequestStatus.cancelled)
-        ).scalar_one()
+        )
+        offers = where_users_column_visible(offers, context, HostRequest.initiator_user_id)
+        offers = where_moderated_content_visible(offers, context, HostRequest, is_list_operation=True)
+        pb.offers_count = session.execute(offers).scalar_one()
     else:
         # The viewer's own existing offer on this trip (if any), so the client can
         # show an "already offered" state and link to the thread.

--- a/app/backend/src/couchers/servicers/threads.py
+++ b/app/backend/src/couchers/servicers/threads.py
@@ -66,20 +66,19 @@ def total_num_responses(session: Session, context: CouchersContext, database_id:
         Comment,
         is_list_operation=True,
     )
-    replies = where_moderated_content_visible(
-        where_users_column_visible(
-            select(func.count())
-            .select_from(Reply)
-            .join(Comment, Comment.id == Reply.comment_id)
-            .where(Comment.thread_id == database_id)
-            .where(Reply.deleted == None),
-            context,
-            Reply.author_user_id,
-        ),
-        context,
-        Reply,
-        is_list_operation=True,
+    # the comment a reply hangs off is filtered too, but not on Comment.deleted: GetThread lists a
+    # deleted comment as a stub and still renders its replies
+    replies = (
+        select(func.count())
+        .select_from(Reply)
+        .join(Comment, Comment.id == Reply.comment_id)
+        .where(Comment.thread_id == database_id)
+        .where(Reply.deleted == None)
     )
+    replies = where_users_column_visible(replies, context, Reply.author_user_id)
+    replies = where_users_column_visible(replies, context, Comment.author_user_id)
+    replies = where_moderated_content_visible(replies, context, Reply, is_list_operation=True)
+    replies = where_moderated_content_visible(replies, context, Comment, is_list_operation=True)
     return session.execute(comments).scalar_one() + session.execute(replies).scalar_one()
 
 

--- a/app/backend/src/couchers/sql.py
+++ b/app/backend/src/couchers/sql.py
@@ -235,18 +235,21 @@ def moderation_state_column_visible(
                 )
             )
 
+    conditions = [
+        aliased_mod_state.visibility == ModerationVisibility.visible,
+        aliased_mod_state.visibility == ModerationVisibility.unlisted,
+    ]
+    if shadowed_conditions:
+        conditions.append(
+            and_(
+                aliased_mod_state.visibility == ModerationVisibility.shadowed,
+                or_(*shadowed_conditions),
+            )
+        )
+
     return or_(
         column.is_(None),
-        exists(
-            select(aliased_mod_state.id).where(
-                aliased_mod_state.id == column,
-                or_(
-                    aliased_mod_state.visibility == ModerationVisibility.visible,
-                    aliased_mod_state.visibility == ModerationVisibility.unlisted,
-                    *shadowed_conditions,
-                ),
-            )
-        ),
+        exists(select(aliased_mod_state.id).where(aliased_mod_state.id == column, or_(*conditions))),
     )
 
 

--- a/app/backend/src/tests/fixtures/misc.py
+++ b/app/backend/src/tests/fixtures/misc.py
@@ -143,207 +143,146 @@ class Moderator:
         self.user = user
         self.token = token
 
-    def approve_host_request(self, host_request_id: int, reason: str = "Test approval") -> None:
-        """
-        Approve a host request using the moderation API.
-
-        Args:
-            host_request_id: The conversation_id of the host request
-            reason: Optional reason for approval
-        """
+    def set_visibility(
+        self,
+        object_type: moderation_pb2.ModerationObjectType.ValueType,
+        object_id: int,
+        visibility: moderation_pb2.ModerationVisibility.ValueType,
+        reason: str = "Test moderation",
+    ) -> None:
+        """Move a piece of moderated content to the given visibility through the moderation API."""
+        raising = visibility in (
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            moderation_pb2.MODERATION_VISIBILITY_UNLISTED,
+        )
         with real_moderation_session(self.token) as api:
             state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_HOST_REQUEST,
-                    object_id=host_request_id,
-                )
+                moderation_pb2.GetModerationStateReq(object_type=object_type, object_id=object_id)
             )
             api.ModerateContent(
                 moderation_pb2.ModerateContentReq(
                     moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+                    action=(
+                        moderation_pb2.MODERATION_ACTION_APPROVE if raising else moderation_pb2.MODERATION_ACTION_HIDE
+                    ),
+                    visibility=visibility,
                     reason=reason,
                     clear_flags=True,
                 )
             )
+
+    def approve_host_request(self, host_request_id: int, reason: str = "Test approval") -> None:
+        """host_request_id is the conversation_id of the host request."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_HOST_REQUEST,
+            host_request_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
+
+    def hide_host_request(self, host_request_id: int, reason: str = "Test hide") -> None:
+        """host_request_id is the conversation_id of the host request."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_HOST_REQUEST,
+            host_request_id,
+            moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
+            reason,
+        )
 
     def approve_group_chat(self, group_chat_id: int, reason: str = "Test approval") -> None:
-        """
-        Approve a group chat using the moderation API.
+        """group_chat_id is the conversation_id of the group chat."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_GROUP_CHAT,
+            group_chat_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
-        Args:
-            group_chat_id: The conversation_id of the group chat
-            reason: Optional reason for approval
-        """
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_GROUP_CHAT,
-                    object_id=group_chat_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+    def set_group_chat_visibility(
+        self,
+        group_chat_id: int,
+        visibility: moderation_pb2.ModerationVisibility.ValueType,
+        reason: str = "Test moderation",
+    ) -> None:
+        self.set_visibility(moderation_pb2.MODERATION_OBJECT_TYPE_GROUP_CHAT, group_chat_id, visibility, reason)
 
     def approve_friend_request(self, friend_request_id: int, reason: str = "Test approval") -> None:
-        """
-        Approve a friend request using the moderation API.
-
-        Args:
-            friend_request_id: The ID of the friend request (FriendRelationship.id)
-            reason: Optional reason for approval
-        """
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_FRIEND_REQUEST,
-                    object_id=friend_request_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        """friend_request_id is the FriendRelationship id."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_FRIEND_REQUEST,
+            friend_request_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_event_occurrence(self, occurrence_id: int, reason: str = "Test approval") -> None:
-        """
-        Approve an event occurrence using the moderation API.
-
-        Args:
-            occurrence_id: The ID of the EventOccurrence (what the proto calls event_id)
-            reason: Optional reason for approval
-        """
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_EVENT_OCCURRENCE,
-                    object_id=occurrence_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        """occurrence_id is the EventOccurrence id, which is what the proto calls event_id."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_EVENT_OCCURRENCE,
+            occurrence_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_comment(self, comment_id: int, reason: str = "Test approval") -> None:
-        """Approve a Comment using the moderation API. comment_id is the database id of the Comment."""
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_COMMENT,
-                    object_id=comment_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        """comment_id is the database id of the Comment."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_COMMENT,
+            comment_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_reply(self, reply_id: int, reason: str = "Test approval") -> None:
-        """Approve a Reply using the moderation API. reply_id is the database id of the Reply."""
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_REPLY,
-                    object_id=reply_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        """reply_id is the database id of the Reply."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_REPLY,
+            reply_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_discussion(self, discussion_id: int, reason: str = "Test approval") -> None:
-        """Approve a Discussion using the moderation API. discussion_id is the database id of the Discussion."""
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION,
-                    object_id=discussion_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        """discussion_id is the database id of the Discussion."""
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_DISCUSSION,
+            discussion_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_reference(self, reference_id: int, reason: str = "Test approval") -> None:
-        """Approve a Reference using the moderation API."""
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_REFERENCE,
-                    object_id=reference_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_REFERENCE,
+            reference_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_public_trip(self, public_trip_id: int, reason: str = "Test approval") -> None:
-        """Approve a PublicTrip using the moderation API."""
-        with real_moderation_session(self.token) as api:
-            state_res = api.GetModerationState(
-                moderation_pb2.GetModerationStateReq(
-                    object_type=moderation_pb2.MODERATION_OBJECT_TYPE_PUBLIC_TRIP,
-                    object_id=public_trip_id,
-                )
-            )
-            api.ModerateContent(
-                moderation_pb2.ModerateContentReq(
-                    moderation_state_id=state_res.moderation_state.moderation_state_id,
-                    action=moderation_pb2.MODERATION_ACTION_APPROVE,
-                    visibility=moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
-                    reason=reason,
-                    clear_flags=True,
-                )
-            )
+        self.set_visibility(
+            moderation_pb2.MODERATION_OBJECT_TYPE_PUBLIC_TRIP,
+            public_trip_id,
+            moderation_pb2.MODERATION_VISIBILITY_VISIBLE,
+            reason,
+        )
 
     def approve_thread_post(self, packed_thread_id: int, reason: str = "Test approval") -> None:
         """Approve whichever of Comment/Reply the packed thread_id refers to."""
+        self.set_thread_post_visibility(packed_thread_id, moderation_pb2.MODERATION_VISIBILITY_VISIBLE, reason)
+
+    def set_thread_post_visibility(
+        self,
+        packed_thread_id: int,
+        visibility: moderation_pb2.ModerationVisibility.ValueType,
+        reason: str = "Test moderation",
+    ) -> None:
+        """Moderate whichever of Comment/Reply the packed thread_id refers to."""
         database_id, depth = unpack_thread_id(packed_thread_id)
         if depth == 1:
-            self.approve_comment(database_id, reason=reason)
+            object_type = moderation_pb2.MODERATION_OBJECT_TYPE_COMMENT
         elif depth == 2:
-            self.approve_reply(database_id, reason=reason)
+            object_type = moderation_pb2.MODERATION_OBJECT_TYPE_REPLY
         else:
-            raise ValueError(f"approve_thread_post: thread_id {packed_thread_id} has unsupported depth {depth}")
+            raise ValueError(f"thread_id {packed_thread_id} has unsupported depth {depth}")
+        self.set_visibility(object_type, database_id, visibility, reason)

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -46,7 +46,7 @@ from tests.fixtures.db import (
     generate_user,
     make_friends,
 )
-from tests.fixtures.misc import EmailCollector, PushCollector
+from tests.fixtures.misc import EmailCollector, Moderator, PushCollector
 from tests.fixtures.sessions import (
     account_session,
     auth_api_session,
@@ -289,7 +289,7 @@ def test_UnbanUser(db):
     assert res.admin_actions[0].level == admin_pb2.ADMIN_ACTION_LEVEL_HIGH
 
 
-def test_ShadowUser(db):
+def test_ShadowUser(db, moderator: Moderator):
     super_user, super_token = generate_user(is_superuser=True)
     surfer, surfer_token = generate_user()
     host, _ = generate_user()
@@ -307,13 +307,7 @@ def test_ShadowUser(db):
                 text=valid_request_text(),
             )
         ).host_request_id
-    with session_scope() as session:
-        state = session.execute(
-            select(ModerationState)
-            .where(ModerationState.object_type == ModerationObjectType.host_request)
-            .where(ModerationState.object_id == host_request_id)
-        ).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_host_request(host_request_id)
 
     with real_admin_session(super_token) as api:
         res = api.ShadowUser(admin_pb2.ShadowUserReq(user=surfer.username, admin_note=admin_note))
@@ -336,7 +330,7 @@ def test_ShadowUser(db):
         assert state.visibility == ModerationVisibility.shadowed
 
 
-def test_UnshadowUser(db):
+def test_UnshadowUser(db, moderator: Moderator):
     super_user, super_token = generate_user(is_superuser=True)
     surfer, surfer_token = generate_user()
     host, _ = generate_user()
@@ -362,18 +356,9 @@ def test_UnshadowUser(db):
             )
         ).host_request_id
 
+    moderator.hide_host_request(admin_hidden_request_id)
     with session_scope() as session:
         session.execute(select(User).where(User.id == surfer.id)).scalar_one().shadowed_at = now()
-        session.execute(
-            select(ModerationState)
-            .where(ModerationState.object_type == ModerationObjectType.host_request)
-            .where(ModerationState.object_id == shadow_cascade_request_id)
-        ).scalar_one().visibility = ModerationVisibility.shadowed
-        session.execute(
-            select(ModerationState)
-            .where(ModerationState.object_type == ModerationObjectType.host_request)
-            .where(ModerationState.object_id == admin_hidden_request_id)
-        ).scalar_one().visibility = ModerationVisibility.hidden
 
     with real_admin_session(super_token) as api:
         res = api.UnshadowUser(admin_pb2.UnshadowUserReq(user=surfer.username, admin_note="rehabilitated"))

--- a/app/backend/src/tests/test_discussions.py
+++ b/app/backend/src/tests/test_discussions.py
@@ -459,7 +459,7 @@ def test_admin_delete_discussion(db):
         assert res.deleted
 
 
-def test_discussion_notifications_regression(db, frozen_timewarp, push_collector: PushCollector, moderator: Moderator):
+def test_discussion_notifications_regression(db, push_collector: PushCollector, moderator: Moderator):
     generate_user()
     user, token = generate_user()
     user2, token2 = generate_user()
@@ -474,7 +474,6 @@ def test_discussion_notifications_regression(db, frozen_timewarp, push_collector
         user2_id = user2.id
 
     with discussions_session(token) as api:
-        time_before_create = now()
         res = api.CreateDiscussion(
             discussions_pb2.CreateDiscussionReq(
                 title="dummy title",
@@ -482,12 +481,10 @@ def test_discussion_notifications_regression(db, frozen_timewarp, push_collector
                 owner_community_id=community_id,
             )
         )
-        time_after_create = now()
 
         assert res.title == "dummy title"
         assert res.content == "dummy content"
         assert res.slug == "dummy-title"
-        assert time_before_create <= to_aware_datetime(res.created) <= time_after_create
         assert res.creator_user_id == user.id
         assert res.owner_community_id == community_id
 

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -41,6 +41,7 @@ from couchers.proto import (
     conversations_pb2,
     editor_pb2,
     events_pb2,
+    moderation_pb2,
     notification_data_pb2,
     notifications_pb2,
 )
@@ -481,6 +482,41 @@ def test_unseen_notification_count_excludes_ums_hidden(db, moderator):
 
     with api_session(token1) as api:
         assert api.Ping(api_pb2.PingReq()).unseen_notification_count == 1
+
+
+@pytest.mark.parametrize(
+    "visibility,author_sees,other_sees",
+    [
+        (moderation_pb2.MODERATION_VISIBILITY_VISIBLE, 1, 1),
+        (moderation_pb2.MODERATION_VISIBILITY_UNLISTED, 1, 1),
+        (moderation_pb2.MODERATION_VISIBILITY_SHADOWED, 1, 0),
+        (moderation_pb2.MODERATION_VISIBILITY_HIDDEN, 0, 0),
+    ],
+)
+def test_notifications_follow_the_visibility_of_their_content(db, moderator, visibility, author_sees, other_sees):
+    author, author_token = generate_user()
+    other, other_token = generate_user()
+    sender, sender_token = generate_user()
+
+    with conversations_session(author_token) as c:
+        group_chat_id = c.CreateGroupChat(
+            conversations_pb2.CreateGroupChatReq(recipient_user_ids=[other.id, sender.id])
+        ).group_chat_id
+    moderator.approve_group_chat(group_chat_id)
+
+    with conversations_session(sender_token) as c:
+        c.SendMessage(conversations_pb2.SendMessageReq(group_chat_id=group_chat_id, text="Test message"))
+
+    process_jobs()
+
+    moderator.set_group_chat_visibility(group_chat_id, visibility)
+
+    for token, expected in [(author_token, author_sees), (other_token, other_sees)]:
+        with api_session(token) as api:
+            assert api.Ping(api_pb2.PingReq()).unseen_notification_count == expected
+        with notifications_session(token) as notifications:
+            res = notifications.ListNotifications(notifications_pb2.ListNotificationsReq())
+            assert len(res.notifications) == expected
 
 
 def test_GetVapidPublicKey(db):

--- a/app/backend/src/tests/test_public_trips.py
+++ b/app/backend/src/tests/test_public_trips.py
@@ -25,6 +25,7 @@ from couchers.models.public_trips import PublicTrip, PublicTripStatus
 from couchers.proto import public_trips_pb2, requests_pb2
 from couchers.utils import create_polygon_lat_lng, now, to_multi, today
 from tests.fixtures.db import generate_user
+from tests.fixtures.misc import Moderator
 from tests.fixtures.sessions import public_trips_session, requests_session
 
 
@@ -963,7 +964,7 @@ def test_list_public_trips_by_user_status_filter_ignored_for_others(db):
         assert [t.trip_id for t in res.public_trips] == [active]
 
 
-def test_list_public_trips_by_user_offers_count_owner(db):
+def test_list_public_trips_by_user_offers_count_owner(db, moderator: Moderator):
     traveler, traveler_token = generate_user()
     host, host_token = generate_user()
     node_id = _make_node()
@@ -978,7 +979,7 @@ def test_list_public_trips_by_user_offers_count_owner(db):
 
     # Host creates an offer via a host request linked to the trip
     with requests_session(host_token) as api:
-        api.CreateHostRequest(
+        host_request_id = api.CreateHostRequest(
             requests_pb2.CreateHostRequestReq(
                 host_user_id=traveler.id,
                 from_date=(today() + timedelta(days=5)).isoformat(),
@@ -986,13 +987,62 @@ def test_list_public_trips_by_user_offers_count_owner(db):
                 text=_valid_request_text(),
                 public_trip_id=trip_id,
             )
-        )
+        ).host_request_id
+
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        trip = next(t for t in res.public_trips if t.trip_id == trip_id)
+        assert trip.HasField("offers_count")
+        assert trip.offers_count == 0
+
+    moderator.approve_host_request(host_request_id)
 
     with public_trips_session(traveler_token) as api:
         res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
         trip = next(t for t in res.public_trips if t.trip_id == trip_id)
         assert trip.HasField("offers_count")
         assert trip.offers_count == 1
+
+
+def test_list_public_trips_by_user_offers_count_excludes_invisible_offers(db, moderator: Moderator):
+    """The count only covers offers the owner can open."""
+    traveler, traveler_token = generate_user()
+    _hidden_host, hidden_host_token = generate_user()
+    banned_host, banned_host_token = generate_user()
+    node_id = _make_node()
+
+    trip_id = _create_trip_directly(traveler.id, node_id, today() + timedelta(days=5), today() + timedelta(days=10))
+
+    offer_ids = []
+    for token in (hidden_host_token, banned_host_token):
+        with requests_session(token) as api:
+            offer_ids.append(
+                api.CreateHostRequest(
+                    requests_pb2.CreateHostRequestReq(
+                        host_user_id=traveler.id,
+                        from_date=(today() + timedelta(days=5)).isoformat(),
+                        to_date=(today() + timedelta(days=10)).isoformat(),
+                        text=_valid_request_text(),
+                        public_trip_id=trip_id,
+                    )
+                ).host_request_id
+            )
+    hidden_offer_id = offer_ids[0]
+
+    for offer_id in offer_ids:
+        moderator.approve_host_request(offer_id)
+
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        assert next(t for t in res.public_trips if t.trip_id == trip_id).offers_count == 2
+
+    moderator.hide_host_request(hidden_offer_id)
+    with session_scope() as session:
+        session.execute(select(User).where(User.id == banned_host.id)).scalar_one().banned_at = now()
+
+    with public_trips_session(traveler_token) as api:
+        res = api.ListPublicTripsByUser(public_trips_pb2.ListPublicTripsByUserReq(user_id=traveler.id))
+        assert next(t for t in res.public_trips if t.trip_id == trip_id).offers_count == 0
 
 
 def test_list_public_trips_by_user_offers_count_not_set_for_others(db):
@@ -1008,7 +1058,7 @@ def test_list_public_trips_by_user_offers_count_not_set_for_others(db):
         assert not res.public_trips[0].HasField("offers_count")
 
 
-def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
+def test_list_public_trips_by_user_offers_count_excludes_cancelled(db, moderator: Moderator):
     traveler, traveler_token = generate_user()
     hosts = [generate_user() for _ in range(5)]
     node_id = _make_node()
@@ -1017,7 +1067,7 @@ def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
 
     for _host, host_token in hosts:
         with requests_session(host_token) as api:
-            api.CreateHostRequest(
+            offer_id = api.CreateHostRequest(
                 requests_pb2.CreateHostRequestReq(
                     host_user_id=traveler.id,
                     from_date=(today() + timedelta(days=5)).isoformat(),
@@ -1025,7 +1075,8 @@ def test_list_public_trips_by_user_offers_count_excludes_cancelled(db):
                     text=_valid_request_text(),
                     public_trip_id=trip_id,
                 )
-            )
+            ).host_request_id
+        moderator.approve_host_request(offer_id)
 
     # Set one offer per status, so we cover every status the count has to consider.
     with session_scope() as session:

--- a/app/backend/src/tests/test_threads.py
+++ b/app/backend/src/tests/test_threads.py
@@ -22,6 +22,7 @@ from couchers.proto import discussions_pb2, events_pb2, moderation_pb2, threads_
 from couchers.servicers.threads import pack_thread_id
 from couchers.utils import datetime_to_iso8601_local, now
 from tests.fixtures.db import generate_user
+from tests.fixtures.misc import Moderator
 from tests.fixtures.sessions import discussions_session, events_session, real_moderation_session, threads_session
 from tests.test_communities import create_community
 
@@ -238,20 +239,14 @@ def test_shadowed_comment_visible_to_author_only(db):
         assert len(ret.replies) == 0
 
 
-def test_shadowed_reply_visible_to_author_only(db):
+def test_shadowed_reply_visible_to_author_only(db, moderator: Moderator):
     """A shadowed reply is visible to its author but not to other users."""
     author, author_token = generate_user()
     other, other_token = generate_user()
 
     _, comment_thread_id = _make_thread_and_comment(author_token, content="hi")
     # Approve the comment so the parent comment is visible to others (otherwise they can't see the comment context anyway)
-    comment_db_id = comment_thread_id // 10
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        state = session.execute(
-            select(ModerationState).where(ModerationState.id == comment.moderation_state_id)
-        ).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_thread_post(comment_thread_id)
 
     with threads_session(author_token) as api:
         api.PostReply(threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="my reply"))
@@ -268,23 +263,13 @@ def test_shadowed_reply_visible_to_author_only(db):
         assert len(ret.replies) == 0
 
 
-def _approve(session, moderation_state_id):
-    session.execute(
-        select(ModerationState).where(ModerationState.id == moderation_state_id)
-    ).scalar_one().visibility = ModerationVisibility.visible
-
-
-def test_comment_by_invisible_user_hidden(db):
+def test_comment_by_invisible_user_hidden(db, moderator: Moderator):
     """A comment by a deleted/banned user is hidden from others even when its moderation state is visible."""
     author, author_token = generate_user()
     other, other_token = generate_user()
 
     parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="from invisible user")
-    comment_db_id = comment_thread_id // 10
-
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        _approve(session, comment.moderation_state_id)
+    moderator.approve_thread_post(comment_thread_id)
 
     # while the author is visible, the comment shows
     with threads_session(other_token) as api:
@@ -299,7 +284,7 @@ def test_comment_by_invisible_user_hidden(db):
         assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
 
 
-def test_reply_by_invisible_user_hidden(db):
+def test_reply_by_invisible_user_hidden(db, moderator: Moderator):
     """A reply by a deleted/banned user is hidden from others even when its moderation state is visible."""
     commenter, commenter_token = generate_user()
     replier, replier_token = generate_user()
@@ -307,19 +292,13 @@ def test_reply_by_invisible_user_hidden(db):
 
     # comment by a user who stays visible, so the parent comment can still be navigated to
     parent_thread_id, comment_thread_id = _make_thread_and_comment(commenter_token, content="hi")
-    comment_db_id = comment_thread_id // 10
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        _approve(session, comment.moderation_state_id)
+    moderator.approve_thread_post(comment_thread_id)
 
     with threads_session(replier_token) as api:
         reply_thread_id = api.PostReply(
             threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="my reply")
         ).thread_id
-    reply_db_id = reply_thread_id // 10
-    with session_scope() as session:
-        reply = session.execute(select(Reply).where(Reply.id == reply_db_id)).scalar_one()
-        _approve(session, reply.moderation_state_id)
+    moderator.approve_thread_post(reply_thread_id)
 
     # while the replier is visible, the reply shows and is counted on the parent comment
     with threads_session(viewer_token) as api:
@@ -373,36 +352,19 @@ def test_admin_can_approve_comment(db):
         assert ret.replies[0].content == "approved comment"
 
 
-def test_admin_can_hide_comment(db):
+def test_admin_can_hide_comment(db, moderator: Moderator):
     """A moderator can hide an approved comment, removing it from non-author views."""
     author, author_token = generate_user()
     other, other_token = generate_user()
-    _moderator, moderator_token = generate_user(is_superuser=True)
 
     parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="bad comment")
-    comment_db_id = comment_thread_id // 10
-
-    with session_scope() as session:
-        comment = session.execute(select(Comment).where(Comment.id == comment_db_id)).scalar_one()
-        state_id = comment.moderation_state_id
-        # Pretend the comment was previously approved
-        state = session.execute(select(ModerationState).where(ModerationState.id == state_id)).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_thread_post(comment_thread_id)
 
     # Other user sees it
     with threads_session(other_token) as api:
         assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 1
 
-    # Moderator hides it
-    with real_moderation_session(moderator_token) as api:
-        api.ModerateContent(
-            moderation_pb2.ModerateContentReq(
-                moderation_state_id=state_id,
-                action=moderation_pb2.MODERATION_ACTION_HIDE,
-                visibility=moderation_pb2.MODERATION_VISIBILITY_HIDDEN,
-                reason="Inappropriate",
-            )
-        )
+    moderator.set_thread_post_visibility(comment_thread_id, moderation_pb2.MODERATION_VISIBILITY_HIDDEN)
 
     # Other user no longer sees it
     with threads_session(other_token) as api:
@@ -412,13 +374,13 @@ def test_admin_can_hide_comment(db):
         assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
 
 
-def test_total_num_responses_excludes_shadowed(db):
+def test_total_num_responses_excludes_shadowed(db, moderator: Moderator):
     from couchers.context import make_background_user_context  # noqa: PLC0415
     from couchers.servicers.threads import total_num_responses  # noqa: PLC0415
 
     author, author_token = generate_user()
     viewer, _ = generate_user()
-    parent_thread_id, _ = _make_thread_and_comment(author_token, content="one")
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="one")
     viewer_context = make_background_user_context(user_id=viewer.id)
 
     parent_db_id, _ = divmod(parent_thread_id, 10)
@@ -426,14 +388,7 @@ def test_total_num_responses_excludes_shadowed(db):
     with session_scope() as session:
         assert total_num_responses(session, viewer_context, parent_db_id) == 0
 
-    with session_scope() as session:
-        state = session.execute(
-            select(ModerationState).where(
-                ModerationState.object_type == ModerationObjectType.comment,
-                ModerationState.object_id == session.execute(select(Comment.id)).scalar_one(),
-            )
-        ).scalar_one()
-        state.visibility = ModerationVisibility.visible
+    moderator.approve_thread_post(comment_thread_id)
 
     with session_scope() as session:
         assert total_num_responses(session, viewer_context, parent_db_id) == 1
@@ -453,6 +408,63 @@ def test_total_num_responses_includes_own_shadowed(db):
 
     with session_scope() as session:
         assert total_num_responses(session, author_context, parent_db_id) == 1
+
+
+def test_total_num_responses_excludes_replies_under_hidden_comment(db, moderator: Moderator):
+    """A reply only counts while the comment it hangs off is visible."""
+    from couchers.context import make_background_user_context  # noqa: PLC0415
+    from couchers.servicers.threads import total_num_responses  # noqa: PLC0415
+
+    author, author_token = generate_user()
+    viewer, viewer_token = generate_user()
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="comment")
+    viewer_context = make_background_user_context(user_id=viewer.id)
+    parent_db_id, _ = divmod(parent_thread_id, 10)
+
+    with threads_session(author_token) as api:
+        reply_thread_id = api.PostReply(
+            threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="reply")
+        ).thread_id
+
+    moderator.approve_thread_post(comment_thread_id)
+    moderator.approve_thread_post(reply_thread_id)
+
+    with session_scope() as session:
+        assert total_num_responses(session, viewer_context, parent_db_id) == 2
+
+    moderator.set_thread_post_visibility(comment_thread_id, moderation_pb2.MODERATION_VISIBILITY_HIDDEN)
+
+    with threads_session(viewer_token) as api:
+        assert len(api.GetThread(threads_pb2.GetThreadReq(thread_id=parent_thread_id)).replies) == 0
+    with session_scope() as session:
+        assert total_num_responses(session, viewer_context, parent_db_id) == 0
+
+
+def test_total_num_responses_excludes_replies_under_someone_elses_shadowed_comment(db, moderator: Moderator):
+    """A reply's own author doesn't count it while the comment above it is still shadowed to them."""
+    from couchers.context import make_background_user_context  # noqa: PLC0415
+    from couchers.servicers.threads import total_num_responses  # noqa: PLC0415
+
+    author, author_token = generate_user()
+    replier, replier_token = generate_user()
+    parent_thread_id, comment_thread_id = _make_thread_and_comment(author_token, content="comment")
+    replier_context = make_background_user_context(user_id=replier.id)
+    parent_db_id, _ = divmod(parent_thread_id, 10)
+
+    with threads_session(replier_token) as api:
+        reply_thread_id = api.PostReply(
+            threads_pb2.PostReplyReq(thread_id=comment_thread_id, content="reply")
+        ).thread_id
+
+    moderator.approve_thread_post(reply_thread_id)
+
+    with session_scope() as session:
+        assert total_num_responses(session, replier_context, parent_db_id) == 0
+
+    moderator.approve_thread_post(comment_thread_id)
+
+    with session_scope() as session:
+        assert total_num_responses(session, replier_context, parent_db_id) == 2
 
 
 def test_edit_comment_creates_version_record(db):


### PR DESCRIPTION
Content under the unified moderation system starts shadowed, becomes visible when a moderator approves it, and goes hidden when a moderator takes it down. Three places didn't follow that. A notification carries the moderation state of the content it is about, with an exception letting an author see notifications about their own content before it is approved; that exception was applied without testing the visibility, so an author kept receiving push notifications, emails and the unseen count for content a moderator had hidden. A thread's response count counted replies hanging off comments the thread itself does not list, so the count sat beside a listing that showed nothing. A public trip's offers count counted host requests the owner cannot open, including ones still awaiting first review and ones from banned, deleted or blocked users. Each now applies the same rule as the listing beside it, and the moderator test fixture moves content through the moderation API rather than writing visibility into the database.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._