### PR TITLE
Backend/devex: Fix postgres mounting for local backend

### DIFF
--- a/app/docker-compose.local-backend.yml
+++ b/app/docker-compose.local-backend.yml
@@ -37,7 +37,7 @@ services:
     command: ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
     # to also log all queries, add: , "-c", "log_statement=all"
     volumes:
-      - "./data/postgres/pgdata:/var/lib/postgresql/data"
+      - "./data/postgres/:/var/lib/postgresql/"
     restart: unless-stopped
     ports:
       - 6545:6545


### PR DESCRIPTION
Layout changed for Postgres v18. Was broken in #8366 and missed in #8382.

## Testing
`docker compose -f 'docker-compose.local-backend.yml' up -d --build 'postgres' --wait`

before: `container app-postgres-1 is unhealthy`
after: ` Container app-postgres-1  Healthy`.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me