### PR TITLE
Back up postgres config files and the crontab

### DIFF
--- a/app/deployment/backup.sh
+++ b/app/deployment/backup.sh
@@ -26,11 +26,19 @@ backup_time=$(date +%s)
 # really not sure what's wrong with aws cli not getting env vars the normal way
 
 echo "Backing up config..."
-tar cf - *.prod.env \
+
+crontab -l > crontab.bak 2>/dev/null || true
+
+pgdata=$(echo data/postgres/*/*)
+
+sudo tar cf - *.prod.env crontab.bak \
+  -C "$pgdata" pg_hba.conf pg_ident.conf postgresql.auto.conf \
   | age -r $CONFIG_FILE_AGE_PUBKEY \
   | AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     aws s3 cp - s3://$AWS_BACKUP_BUCKET_NAME/config/config-$backup_time.tar.age \
   && echo "Done."
+
+rm -f crontab.bak
 
 echo "Backing up database config..."
 docker exec -i app-postgres-1 pg_dumpall -U postgres --roles-only \


### PR DESCRIPTION
The daily production backup (`app/deployment/backup.sh`) uploads an age-encrypted config archive to S3 alongside the database and media dumps, but that archive only contained the `*.prod.env` files. `pg_hba.conf`, `pg_ident.conf` and `postgresql.auto.conf` live inside `PGDATA` and are edited by hand on the server, so they are covered by neither git nor the `pg_dump`/`pg_dumpall` backups, and the `ubuntu` crontab that runs the backup and the config reload was only written down as prose in `docs/ops.md`. This adds all of those to the config archive.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._