### PR TITLE
Enforce uniqueness on the tokens and stripe id used as identifiers

### DIFF
--- a/app/backend/src/couchers/migrations/versions/0186_unique_identifier_tokens.py
+++ b/app/backend/src/couchers/migrations/versions/0186_unique_identifier_tokens.py
@@ -1,0 +1,70 @@
+"""Unique tokens and stripe customer id
+
+Revision ID: 0186
+Revises: 0185
+Create Date: 2026-08-19 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0186"
+down_revision = "0185"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_users_unique_undelete_token",
+            "users",
+            ["undelete_token"],
+            unique=True,
+            postgresql_where="undelete_token IS NOT NULL",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_users_unique_new_email_token",
+            "users",
+            ["new_email_token"],
+            unique=True,
+            postgresql_where="new_email_token IS NOT NULL",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_users_unique_stripe_customer_id",
+            "users",
+            ["stripe_customer_id"],
+            unique=True,
+            postgresql_where="stripe_customer_id IS NOT NULL",
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+    op.create_unique_constraint("uq_signup_flows_email_token", "signup_flows", ["email_token"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_signup_flows_email_token", "signup_flows", type_="unique")
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_users_unique_stripe_customer_id",
+            table_name="users",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_users_unique_new_email_token",
+            table_name="users",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_users_unique_undelete_token",
+            table_name="users",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -184,7 +184,7 @@ class SignupFlow(Base, kw_only=True):
     flow_token: Mapped[str] = mapped_column(String, unique=True)
     email_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     email_sent: Mapped[bool] = mapped_column(Boolean, default=False)
-    email_token: Mapped[str | None] = mapped_column(String, default=None)
+    email_token: Mapped[str | None] = mapped_column(String, unique=True, default=None)
     email_token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
     ## Basic

--- a/app/backend/src/couchers/models/users.py
+++ b/app/backend/src/couchers/models/users.py
@@ -400,6 +400,26 @@ class User(Base, kw_only=True):
             unique=True,
             postgresql_where=phone_verification_verified != None,
         ),
+        # These three are each looked up by equality as though the value named exactly one user, so the database
+        # needs to enforce that; partial as the columns are null for almost every user
+        Index(
+            "ix_users_unique_undelete_token",
+            undelete_token,
+            unique=True,
+            postgresql_where=undelete_token != None,
+        ),
+        Index(
+            "ix_users_unique_new_email_token",
+            new_email_token,
+            unique=True,
+            postgresql_where=new_email_token != None,
+        ),
+        Index(
+            "ix_users_unique_stripe_customer_id",
+            stripe_customer_id,
+            unique=True,
+            postgresql_where=stripe_customer_id != None,
+        ),
         Index(
             "ix_users_active",
             id,


### PR DESCRIPTION
Several columns act as identifiers on the account paths: the account recovery flow finds a deleted user by
`undelete_token`, email changes are confirmed by `new_email_token`, the signup flow is verified by its
`email_token`, and the Stripe donations webhook finds the user who paid by `stripe_customer_id`. Every one of
these lookups is written as an equality read with `scalar_one_or_none()`, so the code asserts the value names at
most one row, but none of the four columns had a unique constraint or an index — nothing in the database held the
code's assumption up, and each read scanned a table that grows with the user base. This adds uniqueness to all
four, partial on `users` since the columns are null for almost every user.

## Testing

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._