### PR TITLE
Frontend/feature flags: Fix spinning forever due to growthbook initialization

### DIFF
--- a/app/web/features/experimentation/FeatureFlagProvider.tsx
+++ b/app/web/features/experimentation/FeatureFlagProvider.tsx
@@ -48,12 +48,11 @@ export default function FeatureFlagProvider({ children }: { children: ReactNode 
     if (process.env.NODE_ENV === "development" && process.env.NEXT_PUBLIC_FEATURE_FLAGS_OVERRIDE === "1") {
       void import("feature-flags.dev.json").then((mod) => {
         const overrides = mod.default as Record<string, unknown>;
-        growthbook.initSync({
-          payload: {
-            features: Object.fromEntries(
-              Object.entries(overrides).map(([key, value]) => [key, { defaultValue: value }]),
-            ),
-          },
+        // Avoid initSync. It is meant to be used as new GrowthBook(...).initSync(...),
+        // so it assumes there are no users and doesn't notify them.
+        // Hence React components can wait on useGrowthBook().ready forever.
+        void growthbook.setPayload({
+          features: Object.fromEntries(Object.entries(overrides).map(([key, value]) => [key, { defaultValue: value }])),
         });
       });
       return;


### PR DESCRIPTION
The frontend never got notified that `feature-flags.dev.json` was loaded and spinned forever because of the way we did growthbook initialization. It's possible it worked if things raced a different way than on my machine.

## Testing
yarn start before/after.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me