### PR TITLE
Backend/devex: Run valkey with local backend config

### DIFF
--- a/app/backend/src/run_locally.py
+++ b/app/backend/src/run_locally.py
@@ -29,6 +29,7 @@ def update_env() -> None:
         "SMTP_HOST": "localhost",
         "OPENTELEMETRY_ENDPOINT": "http://localhost:4318/v1/traces",
         "DATABASE_CONNECTION_STRING": f"postgresql://postgres:{db_password}@localhost:6545/postgres",
+        "VALKEY_HOST": "localhost",
     }
 
     os.environ.update(envs)

--- a/app/docker-compose.local-backend.yml
+++ b/app/docker-compose.local-backend.yml
@@ -13,6 +13,10 @@ services:
     extends:
       file: docker-compose.yml
       service: maildev
+  valkey:
+    extends:
+      file: docker-compose.yml
+      service: valkey
   media:
     extends:
       file: docker-compose.yml


### PR DESCRIPTION
A local frontend couldn't talk to a local backend (using `app/docker-compose.local-backend.ymd`) because valkey wasn't running, so the frontend timed out and blocked on every request.

## Testing
`make run` + `yarn start` before and after.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [x] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
