### PR TITLE
Stop buildx exporting the provenance attestation in CI

### DIFF
--- a/app/.gitlab-ci.yml
+++ b/app/.gitlab-ci.yml
@@ -28,6 +28,12 @@ variables:
   BACKEND_QUERY_LOG: "true"
   PREVIEW_DOMAIN: preview.couchershq.org
   GIT_DEPTH: 1  # Speed up the checkout.
+  # buildkit >=0.32 exports the provenance attestation as an OCI artifact whose subject is
+  # the image manifest, which forces the push to be an index. GitLab's registry rejects the
+  # index while that subject manifest is still new to it, as "blob unknown to registry -
+  # <the image manifest digest>". We don't consume provenance, so don't export it.
+  # See moby/buildkit#7007.
+  BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
   DOCKER_HOST: tcp://docker:2376
   DOCKER_TLS_CERTDIR: "/certs"
   RELEASE_BRANCH: develop


### PR DESCRIPTION
CI builds every image with `docker buildx build --push` into the GitLab container registry. Since 12 August those pushes have been failing intermittently with `blob unknown to registry`, naming the image manifest rather than a layer, and have needed manual retries to get a pipeline green. buildkit 0.32 began exporting the provenance attestation as an OCI artifact whose subject is the image manifest, which turns every push into an index; GitLab's registry rejects that index while the subject manifest is still new to it (moby/buildkit#7007). We don't consume provenance anywhere, so this sets `BUILDX_NO_DEFAULT_ATTESTATIONS` and the pushes go back to being a plain manifest.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._