### PR TITLE
Backend/editor: Add APIs to inspect and change an event's community

### DIFF
--- a/app/backend/src/couchers/db.py
+++ b/app/backend/src/couchers/db.py
@@ -128,7 +128,7 @@ def are_friends(session: Session, context: CouchersContext, other_user: int) -> 
     return session.execute(query).scalar_one_or_none() is not None
 
 
-def get_parent_node_at_location(session: Session, shape: WKBElement) -> Node | None:
+def get_parent_node_at_location(session: Session, shape: Geom) -> Node | None:
     """
     Finds the smallest node containing the shape.
 

--- a/app/backend/src/couchers/i18n/admin_locales/en.json
+++ b/app/backend/src/couchers/i18n/admin_locales/en.json
@@ -12,6 +12,7 @@
     "deletereference_deprecated_use_ums": "DeleteReference is deprecated. Use the Unified Moderation System (UMS) to hide a reference.",
     "event_community_invite_already_decided": "That event community invite was already approved/denied.",
     "event_community_invite_not_found": "Couldn't find that event community invite.",
+    "event_move_target_must_be_specified": "Specify either a community to move the event to, or recompute it from the event's location.",
     "invalid_ota_manifest": "Could not read a valid manifest (runtimeVersion, id, createdAt) from the CDN for this version.",
     "invalid_ota_platform": "Invalid OTA platform.",
     "invalid_ota_version": "An OTA package version (CDN path) is required.",

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -12,11 +12,11 @@ from sqlalchemy.sql import exists, update
 
 from couchers import urls
 from couchers.context import CouchersContext
-from couchers.db import session_scope
+from couchers.db import get_parent_node_at_location, session_scope
 from couchers.helpers.clusters import CHILD_NODE_TYPE, create_cluster, create_node
 from couchers.jobs.enqueue import queue_job
 from couchers.materialized_views import LiteUser
-from couchers.models import EventCommunityInviteRequest, Node, User, Volunteer
+from couchers.models import EventCommunityInviteRequest, EventOccurrence, Node, NodeType, User, Volunteer
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.postal_verification import PostalVerificationAttempt
 from couchers.notifications.notify import notify
@@ -50,6 +50,52 @@ def load_community_geom(geojson: str, context: CouchersContext) -> BaseGeometry:
         context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:no_multipolygon")
 
     return geom
+
+
+def _get_event_occurrence(session: Session, occurrence_id: int, context: CouchersContext) -> EventOccurrence:
+    # deliberately unfiltered by moderation state or deletion: editors need to fix up any event
+    occurrence = session.execute(
+        select(EventOccurrence).where(EventOccurrence.id == occurrence_id)
+    ).scalar_one_or_none()
+    if not occurrence:
+        context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "event_not_found")
+    return occurrence
+
+
+def _event_community_candidate_to_pb(
+    session: Session, occurrence: EventOccurrence, node: Node, context: CouchersContext
+) -> editor_pb2.EventCommunityCandidate:
+    users_to_notify, node_id = get_users_to_notify_for_new_event(session, occurrence, node)
+    return editor_pb2.EventCommunityCandidate(
+        community=community_to_pb(session, node, context),
+        approx_users_to_notify=len(users_to_notify),
+        too_large_for_notifications=node.node_type.value <= NodeType.region.value,
+        notifies_by_proximity=node_id is None,
+    )
+
+
+def event_community_info_to_pb(
+    session: Session, occurrence: EventOccurrence, context: CouchersContext
+) -> editor_pb2.EventCommunityInfo:
+    event = occurrence.event
+    smallest_local_node = get_parent_node_at_location(session, occurrence.geom)
+
+    return editor_pb2.EventCommunityInfo(
+        event_id=occurrence.id,
+        title=event.title,
+        event_url=urls.event_link(occurrence_id=occurrence.id, slug=event.slug),
+        creator_user_id=occurrence.creator_user_id,
+        address=occurrence.address,
+        occurrence_count=event.occurrences.count(),
+        current=_event_community_candidate_to_pb(session, occurrence, event.parent_node, context),
+        smallest_local=(
+            _event_community_candidate_to_pb(session, occurrence, smallest_local_node, context)
+            if smallest_local_node
+            else None
+        ),
+        is_in_smallest_local_community=smallest_local_node is not None
+        and smallest_local_node.id == event.parent_node_id,
+    )
 
 
 def volunteer_to_pb(session: Session, volunteer: Volunteer) -> editor_pb2.Volunteer:
@@ -255,6 +301,33 @@ class Editor(editor_pb2_grpc.EditorServicer):
             )
 
         return editor_pb2.DecideEventCommunityInviteRequestRes()
+
+    def GetEventCommunityInfo(
+        self, request: editor_pb2.GetEventCommunityInfoReq, context: CouchersContext, session: Session
+    ) -> editor_pb2.EventCommunityInfo:
+        occurrence = _get_event_occurrence(session, request.event_id, context)
+        return event_community_info_to_pb(session, occurrence, context)
+
+    def MoveEventToCommunity(
+        self, request: editor_pb2.MoveEventToCommunityReq, context: CouchersContext, session: Session
+    ) -> editor_pb2.EventCommunityInfo:
+        occurrence = _get_event_occurrence(session, request.event_id, context)
+
+        if request.WhichOneof("new_parent_community") == "community_id":
+            node = session.execute(select(Node).where(Node.id == request.community_id)).scalar_one_or_none()
+        elif request.WhichOneof("new_parent_community") == "smallest_local_community":
+            node = get_parent_node_at_location(session, occurrence.geom)
+        else:
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "admin:event_move_target_must_be_specified")
+
+        if not node:
+            context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
+
+        # assign the relationship rather than the id, so the info we return below isn't read off a stale parent_node
+        occurrence.event.parent_node = node
+        session.flush()
+
+        return event_community_info_to_pb(session, occurrence, context)
 
     def SendBlogPostNotification(
         self, request: editor_pb2.SendBlogPostNotificationReq, context: CouchersContext, session: Session

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -57,7 +57,7 @@ def load_community_geom(geojson: str, context: CouchersContext) -> BaseGeometry:
 
 
 def _get_event_occurrence(session: Session, occurrence_id: int, context: CouchersContext) -> EventOccurrence:
-    # deliberately unfiltered by moderation state or deletion: editors need to fix up any event
+    # unfiltered by moderation state and deletion: editors need to fix up any event
     occurrence = session.execute(
         select(EventOccurrence).where(EventOccurrence.id == occurrence_id)
     ).scalar_one_or_none()
@@ -327,7 +327,7 @@ class Editor(editor_pb2_grpc.EditorServicer):
         if not node:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "community_not_found")
 
-        # assign the relationship rather than the id, so the info we return below isn't read off a stale parent_node
+        # assign the relationship, not the id, or we read a stale parent_node below
         occurrence.event.parent_node = node
         session.flush()
 

--- a/app/backend/src/couchers/servicers/editor.py
+++ b/app/backend/src/couchers/servicers/editor.py
@@ -16,7 +16,7 @@ from couchers.db import get_parent_node_at_location, session_scope
 from couchers.helpers.clusters import CHILD_NODE_TYPE, create_cluster, create_node
 from couchers.jobs.enqueue import queue_job
 from couchers.materialized_views import LiteUser
-from couchers.models import EventCommunityInviteRequest, EventOccurrence, Node, NodeType, User, Volunteer
+from couchers.models import EventCommunityInviteRequest, EventOccurrence, Node, User, Volunteer
 from couchers.models.notifications import NotificationTopicAction
 from couchers.models.postal_verification import PostalVerificationAttempt
 from couchers.notifications.notify import notify
@@ -25,7 +25,11 @@ from couchers.proto import communities_pb2, editor_pb2, editor_pb2_grpc, notific
 from couchers.proto.internal import jobs_pb2
 from couchers.resources import get_static_badge_dict
 from couchers.servicers.communities import community_to_pb
-from couchers.servicers.events import generate_event_create_notifications, get_users_to_notify_for_new_event
+from couchers.servicers.events import (
+    generate_event_create_notifications,
+    get_users_to_notify_for_new_event,
+    is_community_too_large_for_event_notifications,
+)
 from couchers.servicers.postal_verification import postalverificationstatus2pb
 from couchers.servicers.public import format_volunteer_link
 from couchers.utils import (
@@ -69,7 +73,7 @@ def _event_community_candidate_to_pb(
     return editor_pb2.EventCommunityCandidate(
         community=community_to_pb(session, node, context),
         approx_users_to_notify=len(users_to_notify),
-        too_large_for_notifications=node.node_type.value <= NodeType.region.value,
+        too_large_for_notifications=is_community_too_large_for_event_notifications(node),
         notifies_by_proximity=node_id is None,
     )
 

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -328,9 +328,6 @@ def occurrences_next_page_token(occurrences: Sequence[EventOccurrence], page_siz
 
 
 def is_community_too_large_for_event_notifications(node: Node) -> bool:
-    """
-    Global, macroregion, and region communities are too big to notify about new events.
-    """
     return node.node_type.value <= NodeType.region.value
 
 
@@ -340,7 +337,7 @@ def get_users_to_notify_for_new_event(
     """
     Returns the users to notify, as well as the community id that is being notified (None if based on geo search)
 
-    Defaults to the event's current parent community; pass `node` to work out what would happen in a different one.
+    Defaults to the event's current parent community.
     """
     node = node or occurrence.event.parent_node
     # people already attending or organizing the event don't need an invite to it

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -350,7 +350,7 @@ def get_users_to_notify_for_new_event(
     cluster = node.official_cluster
     creator = aliased(User)
     if is_community_too_large_for_event_notifications(node):
-        logger.info("Global, macroregion, and region communities are too big for email notifications.")
+        logger.info(f"Community {node.id} is a {node.node_type} and too big for email notifications.")
         return [], node.id
     elif occurrence.creator_user in cluster.admins or cluster.is_leaf:
         members = (

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -327,6 +327,13 @@ def occurrences_next_page_token(occurrences: Sequence[EventOccurrence], page_siz
     return dt_id_to_page_token(next_occurrence.start_time, next_occurrence.id)
 
 
+def is_community_too_large_for_event_notifications(node: Node) -> bool:
+    """
+    Global, macroregion, and region communities are too big to notify about new events.
+    """
+    return node.node_type.value <= NodeType.region.value
+
+
 def get_users_to_notify_for_new_event(
     session: Session, occurrence: EventOccurrence, node: Node | None = None
 ) -> tuple[list[User], int | None]:
@@ -345,7 +352,7 @@ def get_users_to_notify_for_new_event(
 
     cluster = node.official_cluster
     creator = aliased(User)
-    if node.node_type.value <= NodeType.region.value:
+    if is_community_too_large_for_event_notifications(node):
         logger.info("Global, macroregion, and region communities are too big for email notifications.")
         return [], node.id
     elif occurrence.creator_user in cluster.admins or cluster.is_leaf:

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -327,10 +327,15 @@ def occurrences_next_page_token(occurrences: Sequence[EventOccurrence], page_siz
     return dt_id_to_page_token(next_occurrence.start_time, next_occurrence.id)
 
 
-def get_users_to_notify_for_new_event(session: Session, occurrence: EventOccurrence) -> tuple[list[User], int | None]:
+def get_users_to_notify_for_new_event(
+    session: Session, occurrence: EventOccurrence, node: Node | None = None
+) -> tuple[list[User], int | None]:
     """
     Returns the users to notify, as well as the community id that is being notified (None if based on geo search)
+
+    Defaults to the event's current parent community; pass `node` to work out what would happen in a different one.
     """
+    node = node or occurrence.event.parent_node
     # people already attending or organizing the event don't need an invite to it
     not_already_involved = User.id.not_in(
         select(EventOccurrenceAttendee.user_id)
@@ -338,11 +343,11 @@ def get_users_to_notify_for_new_event(session: Session, occurrence: EventOccurre
         .union(select(EventOrganizer.user_id).where(EventOrganizer.event_id == occurrence.event_id))
     )
 
-    cluster = occurrence.event.parent_node.official_cluster
+    cluster = node.official_cluster
     creator = aliased(User)
-    if occurrence.event.parent_node.node_type.value <= NodeType.region.value:
+    if node.node_type.value <= NodeType.region.value:
         logger.info("Global, macroregion, and region communities are too big for email notifications.")
-        return [], occurrence.event.parent_node_id
+        return [], node.id
     elif occurrence.creator_user in cluster.admins or cluster.is_leaf:
         members = (
             session.execute(
@@ -356,7 +361,7 @@ def get_users_to_notify_for_new_event(session: Session, occurrence: EventOccurre
             .scalars()
             .all()
         )
-        return list(members), occurrence.event.parent_node_id
+        return list(members), node.id
     else:
         max_radius = 20000  # m
         users = (

--- a/app/backend/src/tests/test_editor.py
+++ b/app/backend/src/tests/test_editor.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import grpc
 import pytest
 from google.protobuf import empty_pb2
@@ -8,12 +10,16 @@ from couchers.db import session_scope
 from couchers.materialized_views import refresh_materialized_views_rapid
 from couchers.models import (
     Cluster,
+    Event,
     Node,
     Volunteer,
 )
-from couchers.proto import editor_pb2
+from couchers.proto import editor_pb2, events_pb2
+from couchers.tasks import enforce_community_memberships
+from couchers.utils import datetime_to_iso8601_local, now
 from tests.fixtures.db import generate_user
-from tests.fixtures.sessions import real_editor_session
+from tests.fixtures.sessions import events_session, real_editor_session
+from tests.test_communities import create_1d_point, create_community
 
 
 @pytest.fixture(autouse=True)
@@ -794,3 +800,179 @@ def test_ListVolunteers_empty(db):
     with real_editor_session(editor_token) as api:
         res = api.ListVolunteers(editor_pb2.ListVolunteersReq(include_past=False))
         assert len(res.volunteers) == 0
+
+
+def _create_event_in_community(token: str, community_id: int, lat: float, lng: float) -> int:
+    with events_session(token) as api:
+        res = api.CreateEvent(
+            events_pb2.CreateEventReq(
+                title="Dummy Title",
+                content="Dummy content.",
+                parent_community_id=community_id,
+                location=events_pb2.EventLocation(address="Somewhere", lat=lat, lng=lng),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(now() + timedelta(hours=3)),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(now() + timedelta(hours=4)),
+            )
+        )
+        return int(res.event_id)
+
+
+@pytest.fixture
+def event_in_wrong_community(db):
+    """An event physically in "City" but parented to the far too large "Country" community."""
+    editor_user, editor_token = generate_user(is_editor=True)
+    creator, creator_token = generate_user(complete_profile=True, geom=create_1d_point(3), geom_radius=0.1)
+    member1, _ = generate_user(geom=create_1d_point(3), geom_radius=0.1)
+    member2, _ = generate_user(geom=create_1d_point(4), geom_radius=0.1)
+
+    with session_scope() as session:
+        w = create_community(session, 0, 100, "Global", [editor_user], [], None)
+        mr = create_community(session, 0, 100, "Macroregion", [editor_user], [], w)
+        country = create_community(session, 0, 50, "Country", [editor_user], [], mr)
+        city = create_community(session, 0, 10, "City", [creator], [member1, member2], country)
+        country_id = country.id
+        city_id = city.id
+
+    enforce_community_memberships()
+
+    event_id = _create_event_in_community(creator_token, country_id, lat=3, lng=1)
+
+    yield editor_token, creator_token, event_id, country_id, city_id
+
+
+def test_GetEventCommunityInfo(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with real_editor_session(editor_token) as api:
+        res = api.GetEventCommunityInfo(editor_pb2.GetEventCommunityInfoReq(event_id=event_id))
+
+    assert res.event_id == event_id
+    assert res.title == "Dummy Title"
+    assert res.address == "Somewhere"
+    assert res.occurrence_count == 1
+    assert not res.is_in_smallest_local_community
+
+    assert res.current.community.community_id == country_id
+    assert res.current.community.name == "Country"
+    # a region-level community never gets event broadcasts
+    assert res.current.too_large_for_notifications
+    assert res.current.approx_users_to_notify == 0
+
+    assert res.smallest_local.community.community_id == city_id
+    assert res.smallest_local.community.name == "City"
+    assert not res.smallest_local.too_large_for_notifications
+    assert not res.smallest_local.notifies_by_proximity
+    # the two other members of the city; the creator is an organizer so doesn't need an invite
+    assert res.smallest_local.approx_users_to_notify == 2
+
+
+def test_GetEventCommunityInfo_already_in_smallest_community(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    correctly_placed_event_id = _create_event_in_community(creator_token, city_id, lat=3, lng=1)
+
+    with real_editor_session(editor_token) as api:
+        res = api.GetEventCommunityInfo(editor_pb2.GetEventCommunityInfoReq(event_id=correctly_placed_event_id))
+
+    assert res.is_in_smallest_local_community
+    assert res.current.community.community_id == city_id
+    assert res.smallest_local.community.community_id == city_id
+
+
+def test_GetEventCommunityInfo_event_not_found(db):
+    _, editor_token = generate_user(is_editor=True)
+
+    with real_editor_session(editor_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.GetEventCommunityInfo(editor_pb2.GetEventCommunityInfoReq(event_id=42))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+        assert e.value.details() == "Event not found."
+
+
+def test_GetEventCommunityInfo_access_by_normal_user(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with real_editor_session(creator_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.GetEventCommunityInfo(editor_pb2.GetEventCommunityInfoReq(event_id=event_id))
+        assert e.value.code() == grpc.StatusCode.PERMISSION_DENIED
+
+
+def test_MoveEventToCommunity_smallest_local_community(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with real_editor_session(editor_token) as api:
+        res = api.MoveEventToCommunity(
+            editor_pb2.MoveEventToCommunityReq(event_id=event_id, smallest_local_community=True)
+        )
+
+    assert res.current.community.community_id == city_id
+    assert res.is_in_smallest_local_community
+    assert not res.current.too_large_for_notifications
+    assert res.current.approx_users_to_notify == 2
+
+    with session_scope() as session:
+        assert session.execute(select(Event.parent_node_id)).scalar_one() == city_id
+
+
+def test_MoveEventToCommunity_explicit_community(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with real_editor_session(editor_token) as api:
+        res = api.MoveEventToCommunity(editor_pb2.MoveEventToCommunityReq(event_id=event_id, community_id=city_id))
+        assert res.current.community.community_id == city_id
+
+        # and back again, editors aren't restricted to the smallest community
+        res = api.MoveEventToCommunity(editor_pb2.MoveEventToCommunityReq(event_id=event_id, community_id=country_id))
+        assert res.current.community.community_id == country_id
+        assert not res.is_in_smallest_local_community
+
+    with session_scope() as session:
+        assert session.execute(select(Event.parent_node_id)).scalar_one() == country_id
+
+
+def test_MoveEventToCommunity_moves_all_occurrences(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with events_session(creator_token) as api:
+        other_occurrence_id = api.ScheduleEvent(
+            events_pb2.ScheduleEventReq(
+                event_id=event_id,
+                content="Dummy content.",
+                location=events_pb2.EventLocation(address="Somewhere", lat=3, lng=1),
+                start_datetime_iso8601_local=datetime_to_iso8601_local(now() + timedelta(days=1)),
+                end_datetime_iso8601_local=datetime_to_iso8601_local(now() + timedelta(days=1, hours=1)),
+            )
+        ).event_id
+
+    with real_editor_session(editor_token) as api:
+        res = api.MoveEventToCommunity(
+            editor_pb2.MoveEventToCommunityReq(event_id=event_id, smallest_local_community=True)
+        )
+        assert res.occurrence_count == 2
+
+        res = api.GetEventCommunityInfo(editor_pb2.GetEventCommunityInfoReq(event_id=other_occurrence_id))
+        assert res.current.community.community_id == city_id
+
+
+def test_MoveEventToCommunity_no_target(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with real_editor_session(editor_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.MoveEventToCommunity(editor_pb2.MoveEventToCommunityReq(event_id=event_id))
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert (
+            e.value.details()
+            == "Specify either a community to move the event to, or recompute it from the event's location."
+        )
+
+
+def test_MoveEventToCommunity_community_not_found(event_in_wrong_community):
+    editor_token, creator_token, event_id, country_id, city_id = event_in_wrong_community
+
+    with real_editor_session(editor_token) as api:
+        with pytest.raises(grpc.RpcError) as e:
+            api.MoveEventToCommunity(editor_pb2.MoveEventToCommunityReq(event_id=event_id, community_id=42))
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+        assert e.value.details() == "Community not found."

--- a/app/backend/src/tests/test_editor.py
+++ b/app/backend/src/tests/test_editor.py
@@ -854,7 +854,6 @@ def test_GetEventCommunityInfo(event_in_wrong_community):
 
     assert res.current.community.community_id == country_id
     assert res.current.community.name == "Country"
-    # a region-level community never gets event broadcasts
     assert res.current.too_large_for_notifications
     assert res.current.approx_users_to_notify == 0
 

--- a/app/proto/editor.proto
+++ b/app/proto/editor.proto
@@ -23,6 +23,10 @@ service Editor {
 
   rpc DecideEventCommunityInviteRequest(DecideEventCommunityInviteRequestReq) returns (DecideEventCommunityInviteRequestRes) {}
 
+  rpc GetEventCommunityInfo(GetEventCommunityInfoReq) returns (EventCommunityInfo) {}
+
+  rpc MoveEventToCommunity(MoveEventToCommunityReq) returns (EventCommunityInfo) {}
+
   rpc SendBlogPostNotification(SendBlogPostNotificationReq) returns (google.protobuf.Empty) {}
 
   rpc MakeUserVolunteer(MakeUserVolunteerReq) returns (Volunteer) {}
@@ -110,6 +114,56 @@ message DecideEventCommunityInviteRequestReq {
 }
 
 message DecideEventCommunityInviteRequestRes {}
+
+message GetEventCommunityInfoReq {
+  // the event occurrence id, as used everywhere else in the events API
+  int64 event_id = 1;
+}
+
+message EventCommunityCandidate {
+  org.couchers.api.communities.Community community = 1;
+  // approximate number of users that would be notified if the event were broadcast in this community; note that
+  // this is unrelated to whether a broadcast is actually allowed, see too_large_for_notifications
+  uint32 approx_users_to_notify = 2;
+  // set if this community is a region or larger, in which case new event notifications are never sent out
+  bool too_large_for_notifications = 3;
+  // whether the notified users were picked by a radius search around the event rather than by community membership
+  bool notifies_by_proximity = 4;
+}
+
+message EventCommunityInfo {
+  // the event occurrence this was looked up by
+  int64 event_id = 1;
+  string title = 2;
+  string event_url = 3;
+  int64 creator_user_id = 4;
+  // the address of this occurrence; the smallest local community is computed from its coordinates
+  string address = 5;
+  // the number of occurrences of this event; the parent community is shared by all of them, so moving the event
+  // moves every occurrence
+  uint32 occurrence_count = 6;
+
+  // the community the event currently belongs to
+  EventCommunityCandidate current = 7;
+  // the smallest community containing this occurrence's location, i.e. where the event would land if created now;
+  // unset in the unlikely case that no community contains the location
+  EventCommunityCandidate smallest_local = 8;
+  // whether the event is already in the smallest community containing its location
+  bool is_in_smallest_local_community = 9;
+}
+
+message MoveEventToCommunityReq {
+  // the event occurrence id; note this moves the whole event, i.e. all its occurrences
+  int64 event_id = 1;
+
+  oneof new_parent_community {
+    // move the event into this community; this is intentionally not blocked when the community has events disabled,
+    // check small_community_features_enabled on the returned community
+    int64 community_id = 2;
+    // recompute the parent community as the smallest community containing this occurrence's location
+    bool smallest_local_community = 3;
+  }
+}
 
 message SendBlogPostNotificationReq {
   string url = 1;

--- a/app/proto/editor.proto
+++ b/app/proto/editor.proto
@@ -122,7 +122,7 @@ message GetEventCommunityInfoReq {
 message EventCommunityCandidate {
   org.couchers.api.communities.Community community = 1;
   uint32 approx_users_to_notify = 2;
-  // region or larger, so new event notifications are never sent out
+  // if set, a broadcast reaches nobody at all
   bool too_large_for_notifications = 3;
   // users were picked by a radius search around the event, not by community membership
   bool notifies_by_proximity = 4;

--- a/app/proto/editor.proto
+++ b/app/proto/editor.proto
@@ -116,51 +116,38 @@ message DecideEventCommunityInviteRequestReq {
 message DecideEventCommunityInviteRequestRes {}
 
 message GetEventCommunityInfoReq {
-  // the event occurrence id, as used everywhere else in the events API
   int64 event_id = 1;
 }
 
 message EventCommunityCandidate {
   org.couchers.api.communities.Community community = 1;
-  // approximate number of users that would be notified if the event were broadcast in this community; note that
-  // this is unrelated to whether a broadcast is actually allowed, see too_large_for_notifications
   uint32 approx_users_to_notify = 2;
-  // set if this community is a region or larger, in which case new event notifications are never sent out
+  // region or larger, so new event notifications are never sent out
   bool too_large_for_notifications = 3;
-  // whether the notified users were picked by a radius search around the event rather than by community membership
+  // users were picked by a radius search around the event, not by community membership
   bool notifies_by_proximity = 4;
 }
 
 message EventCommunityInfo {
-  // the event occurrence this was looked up by
   int64 event_id = 1;
   string title = 2;
   string event_url = 3;
   int64 creator_user_id = 4;
-  // the address of this occurrence; the smallest local community is computed from its coordinates
   string address = 5;
-  // the number of occurrences of this event; the parent community is shared by all of them, so moving the event
-  // moves every occurrence
   uint32 occurrence_count = 6;
 
-  // the community the event currently belongs to
   EventCommunityCandidate current = 7;
-  // the smallest community containing this occurrence's location, i.e. where the event would land if created now;
-  // unset in the unlikely case that no community contains the location
+  // smallest community containing this occurrence's location, i.e. where the event would land if created now
   EventCommunityCandidate smallest_local = 8;
-  // whether the event is already in the smallest community containing its location
   bool is_in_smallest_local_community = 9;
 }
 
 message MoveEventToCommunityReq {
-  // the event occurrence id; note this moves the whole event, i.e. all its occurrences
+  // moves the whole event, i.e. all its occurrences
   int64 event_id = 1;
 
   oneof new_parent_community {
-    // move the event into this community; this is intentionally not blocked when the community has events disabled,
-    // check small_community_features_enabled on the returned community
     int64 community_id = 2;
-    // recompute the parent community as the smallest community containing this occurrence's location
     bool smallest_local_community = 3;
   }
 }


### PR DESCRIPTION
Events are attached to a parent community when they're created, picked as the smallest community containing the event's location. That placement sometimes goes wrong — an event physically in a city ends up in the surrounding country community, where event broadcast notifications are never sent out — and nothing in the events API exposes or can change it: the `Event` message only reports the event's owner, and `TransferEvent` only reassigns ownership. This adds `GetEventCommunityInfo` and `MoveEventToCommunity` to the Editor service. The first reports the event's current community alongside the smallest community containing its location, each with the audience an event broadcast there would reach and whether that community is too large for broadcasts at all. The second moves the event, either into a named community or by recomputing the smallest local one.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._