### PR TITLE
Backend to allow changing email during signup

### DIFF
--- a/app/backend/src/couchers/i18n/locales/en.json
+++ b/app/backend/src/couchers/i18n/locales/en.json
@@ -217,6 +217,8 @@
     "signup_flow_email_taken": "That email address is already associated with an account. Please log in instead!",
     "signup_flow_feedback_filled": "Feedback information already filled in.",
     "signup_flow_motivations_filled": "You've already told us about why you are signing up.",
+    "signup_flow_email_verified": "You have already verified your email.",
+    "signup_flow_invalid_request": "Invalid signup request, you cannot recover your signup and continue signing up simultaneously.",
     "sms_disabled": "SMS verification is currently disabled.",
     "strong_verification_already_verified": "You already have strong verification.",
     "strong_verification_attempt_not_found": "Strong verification attempt not found.",

--- a/app/backend/src/couchers/metrics.py
+++ b/app/backend/src/couchers/metrics.py
@@ -690,6 +690,11 @@ signup_time_histogram: Histogram = Histogram(
     buckets=(30, 60, 90, 120, 180, 240, 300, 360, 420, 480, 540, 600, 900, 1200, 1800, 3600, 7200, _INF),
 )
 
+signup_email_changes_counter: Counter = Counter(
+    "couchers_signup_email_changes_total",
+    "Number of times email is changed during signup",
+)
+
 logins_counter: Counter = Counter(
     "couchers_logins_total",
     "Number of logins",

--- a/app/backend/src/couchers/migrations/versions/0189_backend_to_allow_changing_email_during_.py
+++ b/app/backend/src/couchers/migrations/versions/0189_backend_to_allow_changing_email_during_.py
@@ -1,0 +1,24 @@
+"""Backend to allow changing email during signup
+
+Revision ID: 0189
+Revises: 0188
+Create Date: 2026-09-12 15:53:44.262937
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0189"
+down_revision = "0188"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("signup_flows", sa.Column("email_changed_count", sa.Integer(), server_default="0", nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column("signup_flows", "email_changed_count")

--- a/app/backend/src/couchers/models/rest.py
+++ b/app/backend/src/couchers/models/rest.py
@@ -187,6 +187,8 @@ class SignupFlow(Base, kw_only=True):
     email_token: Mapped[str | None] = mapped_column(String, unique=True, default=None)
     email_token_expiry: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
 
+    email_changed_count: Mapped[int] = mapped_column(Integer, server_default="0", init=False)
+
     ## Basic
     name: Mapped[str] = mapped_column(String)
     # TODO: unique across both tables

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -365,9 +365,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                         grpc.StatusCode.INVALID_ARGUMENT,
                         "invalid_email",
                     )
-                existing_user = session.execute(
-                    select(User).where(User.email == new_email)
-                ).scalar_one_or_none()
+                existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
                 if existing_user:
                     if not existing_user.is_visible:
                         context.abort_with_error_code(
@@ -399,7 +397,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
             # send verification email if needed
             if not flow.email_sent or request.resend_verification_email:
-                send_signup_email(context, session, flow)                
+                send_signup_email(context, session, flow)
 
             session.flush()
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -813,6 +813,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
             avatar_url=avatar_upload.thumbnail_url if avatar_upload else None,
             url=urls.invite_code_link(code=request.code),
         )
+
     def SignupFlowChangeEmail(
         self, request: auth_pb2.ChangeSignupEmailReq, context: CouchersContext, session: Session
     ) -> auth_pb2.SignupFlowRes:
@@ -831,7 +832,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 grpc.StatusCode.FAILED_PRECONDITION,
                 "signup_flow_email_taken",
             )
-            
+
         new_email = request.new_email
 
         if not is_valid_email(new_email):
@@ -840,9 +841,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 "invalid_email",
             )
 
-        existing_user = session.execute(
-            select(User).where(User.email == new_email)
-        ).scalar_one_or_none()
+        existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
 
         if existing_user:
             if not existing_user.is_visible:
@@ -874,7 +873,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 SignupFlow.flow_token == flow.flow_token,
             )
         ).scalar_one_or_none()
-                
+
         if not existing_same_signup:
             # change signup email and invalidate the old verification token.
             flow.email = new_email

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -24,6 +24,7 @@ from couchers.metrics import (
     password_reset_initiations_counter,
     signup_account_filled_counter,
     signup_completions_counter,
+    signup_email_changes_counter,
     signup_email_verified_counter,
     signup_guidelines_accepted_counter,
     signup_initiations_counter,
@@ -195,6 +196,24 @@ class Auth(auth_pb2_grpc.AuthServicer):
     def SignupFlow(
         self, request: auth_pb2.SignupFlowReq, context: CouchersContext, session: Session
     ) -> auth_pb2.SignupFlowRes:
+        # this is a bit ugly, probably one RPC for this mega-mutation of signup flows is not ideal
+        has_signup_step = (
+            request.HasField("basic")
+            or request.HasField("account")
+            or request.HasField("feedback")
+            or request.HasField("motivations")
+            or request.HasField("accept_community_guidelines")
+        )
+        has_recovery_step = request.HasField("change_email") or request.resend_verification_email
+
+        # if we have the token then we ignore all the other stuff, so better just error to the client
+        if request.email_token and (has_signup_step or has_recovery_step):
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_invalid_request")
+
+        # just for safety
+        if has_signup_step and has_recovery_step:
+            context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_invalid_request")
+
         if request.email_token:
             # the email token can either be for verification or just to find an existing signup
             flow = session.execute(
@@ -285,19 +304,6 @@ class Auth(auth_pb2_grpc.AuthServicer):
 
             # we've found and/or created a new flow, now sort out other parts
 
-            # this is a bit ugly, probably one RPC for this mega-mutation of signup flows is not ideal
-            has_signup_step = (
-                request.HasField("basic")
-                or request.HasField("account")
-                or request.HasField("feedback")
-                or request.HasField("motivations")
-                or request.HasField("accept_community_guidelines")
-            )
-            has_recovery_step = request.HasField("change_email") or request.resend_verification_email
-
-            if has_signup_step and has_recovery_step:
-                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_invalid_request")
-
             if request.HasField("account"):
                 if flow.account_is_filled:
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_account_filled")
@@ -376,15 +382,19 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_verified")
                 # can't resend verification at the same time
                 if request.resend_verification_email:
-                    context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_invalid_request")
+                    context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_invalid_request")
+
+                # this will error if the email is not different from the current one
                 _check_email_is_available_and_valid(request.change_email.new_email)
-                if flow.email != request.change_email.new_email:
-                    flow.email = request.change_email.new_email
-                    flow.email_verified = False
-                    flow.email_sent = False
-                    flow.email_token = None
-                    flow.email_token_expiry = None
-                    flow.email_changed_count += 1
+
+                flow.email = request.change_email.new_email
+                flow.email_verified = False
+                flow.email_sent = False
+                flow.email_token = None
+                flow.email_token_expiry = None
+                flow.email_changed_count += 1
+                signup_email_changes_counter.inc()
+
                 session.flush()
 
             # send verification email if needed

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -813,12 +813,8 @@ class Auth(auth_pb2_grpc.AuthServicer):
             avatar_url=avatar_upload.thumbnail_url if avatar_upload else None,
             url=urls.invite_code_link(code=request.code),
         )
-
     def SignupFlowChangeEmail(
-        self,
-        request: auth_pb2.ChangeSignupEmailReq,
-        context: CouchersContext,
-        session: Session,
+        self, request: auth_pb2.ChangeSignupEmailReq, context: CouchersContext, session: Session
     ) -> auth_pb2.SignupFlowRes:
         flow = session.execute(
             select(SignupFlow).where(SignupFlow.flow_token == request.flow_token)
@@ -830,7 +826,13 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 "invalid_token",
             )
 
-        new_email = request.new_email.strip().lower()
+        if flow.email_verified:
+            context.abort_with_error_code(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "signup_flow_email_taken",
+            )
+            
+        new_email = request.new_email
 
         if not is_valid_email(new_email):
             context.abort_with_error_code(
@@ -838,7 +840,9 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 "invalid_email",
             )
 
-        existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
+        existing_user = session.execute(
+            select(User).where(User.email == new_email)
+        ).scalar_one_or_none()
 
         if existing_user:
             if not existing_user.is_visible:
@@ -851,25 +855,32 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 grpc.StatusCode.FAILED_PRECONDITION,
                 "signup_flow_email_taken",
             )
-        existing_signup = session.execute(
+        existing_different_signup = session.execute(
             select(SignupFlow).where(
                 SignupFlow.email == new_email,
-                SignupFlow.id != flow.id,
+                SignupFlow.flow_token != flow.flow_token,
             )
         ).scalar_one_or_none()
 
-        if existing_signup:
+        if existing_different_signup:
             context.abort_with_error_code(
                 grpc.StatusCode.FAILED_PRECONDITION,
                 "signup_flow_email_taken",
             )
 
-        flow.email = new_email
-
-        # Invalidate the old verification token.
-        flow.email_token = None
-        flow.email_token_expiry = None
-        flow.email_sent = False
+        existing_same_signup = session.execute(
+            select(SignupFlow).where(
+                SignupFlow.email == new_email,
+                SignupFlow.flow_token == flow.flow_token,
+            )
+        ).scalar_one_or_none()
+                
+        if not existing_same_signup:
+            # change signup email and invalidate the old verification token.
+            flow.email = new_email
+            flow.email_token = None
+            flow.email_token_expiry = None
+            flow.email_sent = False
 
         send_signup_email(context, session, flow)
 

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -353,7 +353,6 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     signup_guidelines_accepted_counter.inc()
                 flow.accepted_community_guidelines = GUIDELINES_VERSION
                 session.flush()
-
             # send verification email if needed
             if not flow.email_sent or request.resend_verification_email:
                 send_signup_email(context, session, flow)
@@ -813,4 +812,74 @@ class Auth(auth_pb2_grpc.AuthServicer):
             username=user.username,
             avatar_url=avatar_upload.thumbnail_url if avatar_upload else None,
             url=urls.invite_code_link(code=request.code),
+        )
+
+    def SignupFlowChangeEmail(
+        self,
+        request: auth_pb2.ChangeSignupEmailReq,
+        context: CouchersContext,
+        session: Session,
+    ) -> auth_pb2.SignupFlowRes:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == request.flow_token)
+        ).scalar_one_or_none()
+
+        if not flow:
+            context.abort_with_error_code(
+                grpc.StatusCode.NOT_FOUND,
+                "invalid_token",
+            )
+
+        new_email = request.new_email.strip().lower()
+
+        if not is_valid_email(new_email):
+            context.abort_with_error_code(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "invalid_email",
+            )
+
+        existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
+
+        if existing_user:
+            if not existing_user.is_visible:
+                context.abort_with_error_code(
+                    grpc.StatusCode.FAILED_PRECONDITION,
+                    "signup_email_cannot_be_used",
+                )
+
+            context.abort_with_error_code(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "signup_flow_email_taken",
+            )
+        existing_signup = session.execute(
+            select(SignupFlow).where(
+                SignupFlow.email == new_email,
+                SignupFlow.id != flow.id,
+            )
+        ).scalar_one_or_none()
+
+        if existing_signup:
+            context.abort_with_error_code(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "signup_flow_email_taken",
+            )
+
+        flow.email = new_email
+
+        # Invalidate the old verification token.
+        flow.email_token = None
+        flow.email_token_expiry = None
+        flow.email_sent = False
+
+        send_signup_email(context, session, flow)
+
+        session.flush()
+
+        return auth_pb2.SignupFlowRes(
+            flow_token=flow.flow_token,
+            need_account=not flow.account_is_filled,
+            need_feedback=False,
+            need_verify_email=True,
+            need_accept_community_guidelines=(flow.accepted_community_guidelines < GUIDELINES_VERSION),
+            need_motivations=not flow.filled_motivations,
         )

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -219,14 +219,10 @@ class Auth(auth_pb2_grpc.AuthServicer):
                 if not flow:
                     context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "invalid_token")
         else:
-            if not request.flow_token:
-                # fresh signup
-                if not request.HasField("basic"):
-                    context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_basic_needed")
+
+            def _check_email_is_available_and_valid(new_email: str) -> None:
                 # TODO: unique across both tables
-                existing_user = session.execute(
-                    select(User).where(User.email == request.basic.email)
-                ).scalar_one_or_none()
+                existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
                 if existing_user:
                     if not existing_user.is_visible:
                         context.abort_with_error_code(
@@ -234,7 +230,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
                         )
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_taken")
                 existing_flow = session.execute(
-                    select(SignupFlow).where(SignupFlow.email == request.basic.email)
+                    select(SignupFlow).where(SignupFlow.email == new_email)
                 ).scalar_one_or_none()
                 if existing_flow:
                     send_signup_email(context, session, existing_flow)
@@ -243,8 +239,14 @@ class Auth(auth_pb2_grpc.AuthServicer):
                         grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_started_signup"
                     )
 
-                if not is_valid_email(request.basic.email):
+                if not is_valid_email(new_email):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_email")
+
+            if not request.flow_token:
+                # fresh signup
+                if not request.HasField("basic"):
+                    context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_basic_needed")
+                _check_email_is_available_and_valid(request.basic.email)
                 if not is_valid_name(request.basic.name):
                     context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "invalid_name")
 
@@ -282,6 +284,20 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_basic_filled")
 
             # we've found and/or created a new flow, now sort out other parts
+
+            # this is a bit ugly, probably one RPC for this mega-mutation of signup flows is not ideal
+            has_signup_step = (
+                request.HasField("basic")
+                or request.HasField("account")
+                or request.HasField("feedback")
+                or request.HasField("motivations")
+                or request.HasField("accept_community_guidelines")
+            )
+            has_recovery_step = request.HasField("change_email") or request.resend_verification_email
+
+            if has_signup_step and has_recovery_step:
+                context.abort_with_error_code(grpc.StatusCode.INVALID_ARGUMENT, "signup_flow_invalid_request")
+
             if request.HasField("account"):
                 if flow.account_is_filled:
                     context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_account_filled")
@@ -353,46 +369,22 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     signup_guidelines_accepted_counter.inc()
                 flow.accepted_community_guidelines = GUIDELINES_VERSION
                 session.flush()
+
             if request.HasField("change_email"):
+                # can't change after verifying
                 if flow.email_verified:
-                    context.abort_with_error_code(
-                        grpc.StatusCode.FAILED_PRECONDITION,
-                        "signup_flow_email_taken",
-                    )
-                new_email = request.change_email.new_email
-                if not is_valid_email(new_email):
-                    context.abort_with_error_code(
-                        grpc.StatusCode.INVALID_ARGUMENT,
-                        "invalid_email",
-                    )
-                existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
-                if existing_user:
-                    if not existing_user.is_visible:
-                        context.abort_with_error_code(
-                            grpc.StatusCode.FAILED_PRECONDITION,
-                            "signup_email_cannot_be_used",
-                        )
-                    context.abort_with_error_code(
-                        grpc.StatusCode.FAILED_PRECONDITION,
-                        "signup_flow_email_taken",
-                    )
-                existing_signup = session.execute(
-                    select(SignupFlow).where(
-                        SignupFlow.email == new_email,
-                        SignupFlow.flow_token != flow.flow_token,
-                    )
-                ).scalar_one_or_none()
-                if existing_signup:
-                    context.abort_with_error_code(
-                        grpc.StatusCode.FAILED_PRECONDITION,
-                        "signup_flow_email_taken",
-                    )
-                if flow.email != new_email:
-                    flow.email = new_email
+                    context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_email_verified")
+                # can't resend verification at the same time
+                if request.resend_verification_email:
+                    context.abort_with_error_code(grpc.StatusCode.FAILED_PRECONDITION, "signup_flow_invalid_request")
+                _check_email_is_available_and_valid(request.change_email.new_email)
+                if flow.email != request.change_email.new_email:
+                    flow.email = request.change_email.new_email
+                    flow.email_verified = False
+                    flow.email_sent = False
                     flow.email_token = None
                     flow.email_token_expiry = None
-                    flow.email_sent = False
-                send_signup_email(context, session, flow)
+                    flow.email_changed_count += 1
                 session.flush()
 
             # send verification email if needed

--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -353,9 +353,53 @@ class Auth(auth_pb2_grpc.AuthServicer):
                     signup_guidelines_accepted_counter.inc()
                 flow.accepted_community_guidelines = GUIDELINES_VERSION
                 session.flush()
+            if request.HasField("change_email"):
+                if flow.email_verified:
+                    context.abort_with_error_code(
+                        grpc.StatusCode.FAILED_PRECONDITION,
+                        "signup_flow_email_taken",
+                    )
+                new_email = request.change_email.new_email
+                if not is_valid_email(new_email):
+                    context.abort_with_error_code(
+                        grpc.StatusCode.INVALID_ARGUMENT,
+                        "invalid_email",
+                    )
+                existing_user = session.execute(
+                    select(User).where(User.email == new_email)
+                ).scalar_one_or_none()
+                if existing_user:
+                    if not existing_user.is_visible:
+                        context.abort_with_error_code(
+                            grpc.StatusCode.FAILED_PRECONDITION,
+                            "signup_email_cannot_be_used",
+                        )
+                    context.abort_with_error_code(
+                        grpc.StatusCode.FAILED_PRECONDITION,
+                        "signup_flow_email_taken",
+                    )
+                existing_signup = session.execute(
+                    select(SignupFlow).where(
+                        SignupFlow.email == new_email,
+                        SignupFlow.flow_token != flow.flow_token,
+                    )
+                ).scalar_one_or_none()
+                if existing_signup:
+                    context.abort_with_error_code(
+                        grpc.StatusCode.FAILED_PRECONDITION,
+                        "signup_flow_email_taken",
+                    )
+                if flow.email != new_email:
+                    flow.email = new_email
+                    flow.email_token = None
+                    flow.email_token_expiry = None
+                    flow.email_sent = False
+                send_signup_email(context, session, flow)
+                session.flush()
+
             # send verification email if needed
             if not flow.email_sent or request.resend_verification_email:
-                send_signup_email(context, session, flow)
+                send_signup_email(context, session, flow)                
 
             session.flush()
 
@@ -812,84 +856,4 @@ class Auth(auth_pb2_grpc.AuthServicer):
             username=user.username,
             avatar_url=avatar_upload.thumbnail_url if avatar_upload else None,
             url=urls.invite_code_link(code=request.code),
-        )
-
-    def SignupFlowChangeEmail(
-        self, request: auth_pb2.ChangeSignupEmailReq, context: CouchersContext, session: Session
-    ) -> auth_pb2.SignupFlowRes:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == request.flow_token)
-        ).scalar_one_or_none()
-
-        if not flow:
-            context.abort_with_error_code(
-                grpc.StatusCode.NOT_FOUND,
-                "invalid_token",
-            )
-
-        if flow.email_verified:
-            context.abort_with_error_code(
-                grpc.StatusCode.FAILED_PRECONDITION,
-                "signup_flow_email_taken",
-            )
-
-        new_email = request.new_email
-
-        if not is_valid_email(new_email):
-            context.abort_with_error_code(
-                grpc.StatusCode.INVALID_ARGUMENT,
-                "invalid_email",
-            )
-
-        existing_user = session.execute(select(User).where(User.email == new_email)).scalar_one_or_none()
-
-        if existing_user:
-            if not existing_user.is_visible:
-                context.abort_with_error_code(
-                    grpc.StatusCode.FAILED_PRECONDITION,
-                    "signup_email_cannot_be_used",
-                )
-
-            context.abort_with_error_code(
-                grpc.StatusCode.FAILED_PRECONDITION,
-                "signup_flow_email_taken",
-            )
-        existing_different_signup = session.execute(
-            select(SignupFlow).where(
-                SignupFlow.email == new_email,
-                SignupFlow.flow_token != flow.flow_token,
-            )
-        ).scalar_one_or_none()
-
-        if existing_different_signup:
-            context.abort_with_error_code(
-                grpc.StatusCode.FAILED_PRECONDITION,
-                "signup_flow_email_taken",
-            )
-
-        existing_same_signup = session.execute(
-            select(SignupFlow).where(
-                SignupFlow.email == new_email,
-                SignupFlow.flow_token == flow.flow_token,
-            )
-        ).scalar_one_or_none()
-
-        if not existing_same_signup:
-            # change signup email and invalidate the old verification token.
-            flow.email = new_email
-            flow.email_token = None
-            flow.email_token_expiry = None
-            flow.email_sent = False
-
-        send_signup_email(context, session, flow)
-
-        session.flush()
-
-        return auth_pb2.SignupFlowRes(
-            flow_token=flow.flow_token,
-            need_account=not flow.account_is_filled,
-            need_feedback=False,
-            need_verify_email=True,
-            need_accept_community_guidelines=(flow.accepted_community_guidelines < GUIDELINES_VERSION),
-            need_motivations=not flow.filled_motivations,
         )

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -428,7 +428,7 @@ def test_basic_login(db):
 
 def test_login_part_signed_up_verified_email(db):
     """
-    If you try to log in but didn't finish singing up, we send you a new email and ask you to finish signing up.
+    If you try to log in but didn't finish signing up, we send you a new email and ask you to finish signing up.
     """
     with auth_api_session() as (auth_api, metadata_interceptor):
         res = auth_api.SignupFlow(
@@ -930,6 +930,206 @@ def test_signup_resend_email(db, email_collector: EmailCollector):
 
     assert not res.flow_token
     assert res.HasField("auth_res")
+
+def test_signup_change_email(db, email_collector: EmailCollector):
+    old_email = f"{random_hex(12)}@couchers.org.invalid"
+    new_email = f"{random_hex(12)}@couchers.org.invalid"
+
+    # Start a signup with the old email.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                basic=auth_pb2.SignupBasic(
+                    name="testing",
+                    email=old_email,
+                )
+            )
+        )
+
+    flow_token = res.flow_token
+    assert flow_token
+
+    # Get the original verification token.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        old_email_token = flow.email_token
+        assert flow.email == old_email
+        assert old_email_token
+
+    # Consume the initial email so we can specifically check the new email below.
+    email_collector.pop_for_recipient(old_email, last=True)
+
+    # Change the signup email.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlowChangeEmail(
+            auth_pb2.ChangeSignupEmailReq(
+                flow_token=flow_token,
+                new_email=new_email,
+            )
+        )
+
+    assert res.flow_token == flow_token
+    assert res.need_verify_email
+
+    # The signup should now have the new email and a new verification token.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        assert flow.email == new_email
+        assert flow.email != old_email
+
+        new_email_token = flow.email_token
+        assert new_email_token
+        assert new_email_token != old_email_token
+
+    # The old token should no longer be usable.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    email_token=old_email_token,
+                )
+            )
+
+        assert e.value.code() == grpc.StatusCode.NOT_FOUND
+
+    # The new email should receive a verification link containing the new token.
+    email = email_collector.pop_for_recipient(new_email, last=True)
+
+    assert email.recipient == new_email
+    assert new_email_token in email.plain
+    assert new_email_token in email.html
+    assert old_email_token not in email.plain
+    assert old_email_token not in email.html
+   
+def test_signup_change_email_after_email_verified(db):
+    old_email = f"{random_hex(12)}@couchers.org.invalid"
+    new_email = f"{random_hex(12)}@couchers.org.invalid"
+
+    # Start a signup.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                basic=auth_pb2.SignupBasic(
+                    name="testing",
+                    email=old_email,
+                )
+            )
+        )
+
+    flow_token = res.flow_token
+    assert flow_token
+
+    # Get the verification token.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        email_token = flow.email_token
+        assert email_token
+        assert not flow.email_verified
+
+    # Verify the original email.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                email_token=email_token,
+            )
+        )
+
+    # The email should now be verified.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        assert flow.email_verified
+
+    # Once the email has been verified, changing the signup email should fail.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlowChangeEmail(
+                auth_pb2.ChangeSignupEmailReq(
+                    flow_token=flow_token,
+                    new_email=new_email,
+                )
+            )
+
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert e.value.details() == "That email address is already associated with an account. Please log in instead!"
+
+    # Make sure the signup email wasn't changed.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        assert flow.email == old_email
+        assert flow.email_verified
+
+def test_signup_change_email_same_email_resends_existing_token(db, email_collector: EmailCollector):
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                basic=auth_pb2.SignupBasic(
+                    name="testing",
+                    email=testing_email,
+                )
+            )
+        )
+
+    flow_token = res.flow_token
+    assert flow_token
+
+    # Get the original email token.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        original_email_token = flow.email_token
+        assert original_email_token
+        assert flow.email == testing_email
+
+    # Clear the original email so we can inspect the one sent by
+    # SignupFlowChangeEmail.
+    email_collector.pop_for_recipient(testing_email, last=True)
+
+    # Ask to change the signup email to the same email.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlowChangeEmail(
+            auth_pb2.ChangeSignupEmailReq(
+                flow_token=flow_token,
+                new_email=testing_email,
+            )
+        )
+
+    assert res.flow_token == flow_token
+    assert res.need_verify_email
+
+    # The email should have been resent.
+    email = email_collector.pop_for_recipient(testing_email, last=True)
+    assert email.recipient == testing_email
+    assert original_email_token in email.plain
+    assert original_email_token in email.html
+
+    # The signup flow should still have the same token.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_token == original_email_token
+        assert not flow.email_verified
 
 
 def test_successful_authenticate(db):

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -1,5 +1,5 @@
 import http.cookies
-from typing import cast
+from typing import Any, cast
 from unittest.mock import DEFAULT, patch
 
 import grpc
@@ -983,6 +983,7 @@ def test_signup_change_email(db, email_collector: EmailCollector):
         new_email_token = flow.email_token
         assert new_email_token
         assert new_email_token != old_email_token
+        assert flow.email_changed_count == 1
 
     # The old token should no longer be usable.
     with auth_api_session() as (auth_api, metadata_interceptor):
@@ -1085,7 +1086,7 @@ def test_signup_change_email_after_email_verified(db):
 
         assert flow.email_verified
 
-    # Try changing to an invalid email.
+    # Changing the email is no longer allowed.
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
             auth_api.SignupFlow(
@@ -1097,7 +1098,7 @@ def test_signup_change_email_after_email_verified(db):
                 )
             )
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
-    assert e.value.details() == "That email address is already associated with an account. Please log in instead!"
+    assert e.value.details() == "You have already verified your email."
 
     # Make sure the signup email wasn't changed.
     with session_scope() as session:
@@ -1107,59 +1108,348 @@ def test_signup_change_email_after_email_verified(db):
         assert flow.email_verified
 
 
-def test_signup_change_email_same_email_resends_existing_token(db, email_collector: EmailCollector):
-    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+_INVALID_SIGNUP_REQUEST = (
+    "Invalid signup request, you cannot recover your signup and continue signing up simultaneously."
+)
 
+# a sample value for every field that mutates a signup flow
+_SIGNUP_FLOW_FIELDS: dict[str, Any] = {
+    "basic": auth_pb2.SignupBasic(name="testing", email="other@couchers.org.invalid"),
+    "account": auth_pb2.SignupAccount(username="frodo"),
+    "feedback": auth_pb2.ContributorForm(),
+    "motivations": auth_pb2.SignupMotivations(motivations=["surfing"]),
+    "accept_community_guidelines": wrappers_pb2.BoolValue(value=True),
+    "change_email": auth_pb2.ChangeSignupEmail(new_email="other@couchers.org.invalid"),
+    "resend_verification_email": True,
+}
+_SIGNUP_STEP_FIELDS = ["basic", "account", "feedback", "motivations", "accept_community_guidelines"]
+_RECOVERY_STEP_FIELDS = ["change_email", "resend_verification_email"]
+
+
+def _start_signup_flow(email: str) -> str:
     with auth_api_session() as (auth_api, metadata_interceptor):
-        res = auth_api.SignupFlow(
-            auth_pb2.SignupFlowReq(
-                basic=auth_pb2.SignupBasic(
-                    name="testing",
-                    email=testing_email,
-                )
-            )
-        )
+        res = auth_api.SignupFlow(auth_pb2.SignupFlowReq(basic=auth_pb2.SignupBasic(name="testing", email=email)))
+    assert res.flow_token
+    return cast(str, res.flow_token)
 
-    flow_token = res.flow_token
-    assert flow_token
 
-    # Get the original email token.
+def test_signup_change_email_same_email(db, email_collector: EmailCollector):
+    """Changing to the email the flow already has is rejected, but the existing link is resent."""
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    flow_token = _start_signup_flow(testing_email)
+
     with session_scope() as session:
         flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         original_email_token = flow.email_token
         assert original_email_token
-        assert flow.email == testing_email
 
-    # Clear the original email so we can inspect the one sent by
-    # SignupFlowChangeEmail.
+    # Consume the initial email so we can specifically check the one sent below.
     email_collector.pop_for_recipient(testing_email, last=True)
 
-    # Ask to change the signup email to the same email.
     with auth_api_session() as (auth_api, metadata_interceptor):
-        res = auth_api.SignupFlow(
-            auth_pb2.SignupFlowReq(
-                flow_token=flow_token,
-                change_email=auth_pb2.ChangeSignupEmail(new_email=testing_email),
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    change_email=auth_pb2.ChangeSignupEmail(new_email=testing_email),
+                )
             )
-        )
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert e.value.details() == "Please check your email for a link to continue signing up."
 
-    assert res.flow_token == flow_token
-    assert res.need_verify_email
-
-    # The email should have been resent.
+    # The existing verification link is resent.
     email = email_collector.pop_for_recipient(testing_email, last=True)
     assert email.recipient == testing_email
     assert original_email_token in email.plain
     assert original_email_token in email.html
 
-    # The signup flow should still have the same token.
     with session_scope() as session:
         flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         assert flow.email == testing_email
         assert flow.email_token == original_email_token
         assert not flow.email_verified
+        assert flow.email_changed_count == 0
+
+
+def test_signup_change_email_to_existing_user_email(db):
+    user, _ = generate_user()
+
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    flow_token = _start_signup_flow(testing_email)
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    change_email=auth_pb2.ChangeSignupEmail(new_email=user.email),
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert e.value.details() == "That email address is already associated with an account. Please log in instead!"
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_changed_count == 0
+
+
+@pytest.mark.parametrize("invisible_column", ["banned_at", "deleted_at"])
+def test_signup_change_email_to_invisible_user_email(db, invisible_column):
+    user, _ = generate_user()
+
+    with session_scope() as session:
+        session.execute(update(User).where(User.id == user.id).values(**{invisible_column: func.now()}))
+
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    flow_token = _start_signup_flow(testing_email)
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    change_email=auth_pb2.ChangeSignupEmail(new_email=user.email),
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert e.value.details() == "You cannot sign up with that email address."
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_changed_count == 0
+
+
+def test_signup_change_email_to_other_flow_email(db, email_collector: EmailCollector):
+    """Changing to an email that another signup already uses nudges that other signup instead."""
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    other_email = f"{random_hex(12)}@couchers.org.invalid"
+
+    flow_token = _start_signup_flow(testing_email)
+    other_flow_token = _start_signup_flow(other_email)
+
+    with session_scope() as session:
+        other_flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == other_flow_token)).scalar_one()
+
+        other_email_token = other_flow.email_token
+        assert other_email_token
+
+    email_collector.pop_for_recipient(other_email, last=True)
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    change_email=auth_pb2.ChangeSignupEmail(new_email=other_email),
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
+    assert e.value.details() == "Please check your email for a link to continue signing up."
+
+    # The other signup gets its own link resent, this one is untouched.
+    email = email_collector.pop_for_recipient(other_email, last=True)
+    assert other_email_token in email.plain
+    assert other_email_token in email.html
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_changed_count == 0
+
+
+def test_signup_change_email_without_flow_token(db):
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    change_email=auth_pb2.ChangeSignupEmail(new_email=f"{random_hex(12)}@couchers.org.invalid"),
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert e.value.details() == "Account details needed to sign up."
+
+
+def test_signup_change_email_and_resend_verification_email(db, email_collector: EmailCollector):
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    new_email = f"{random_hex(12)}@couchers.org.invalid"
+    flow_token = _start_signup_flow(testing_email)
+
+    email_collector.pop_for_recipient(testing_email, last=True)
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    change_email=auth_pb2.ChangeSignupEmail(new_email=new_email),
+                    resend_verification_email=True,
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert e.value.details() == _INVALID_SIGNUP_REQUEST
+
+    assert email_collector.count() == 0
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_changed_count == 0
+
+
+@pytest.mark.parametrize("field", list(_SIGNUP_FLOW_FIELDS))
+def test_signup_email_token_with_other_fields(db, field):
+    """The email token makes the rest of the request be ignored, so sending both is rejected."""
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    flow_token = _start_signup_flow(testing_email)
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        email_token = flow.email_token
+        assert email_token
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token, **{field: _SIGNUP_FLOW_FIELDS[field]}))
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert e.value.details() == _INVALID_SIGNUP_REQUEST
+
+    # the token wasn't consumed
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_token == email_token
+        assert not flow.email_verified
+
+
+@pytest.mark.parametrize("recovery_field", _RECOVERY_STEP_FIELDS)
+@pytest.mark.parametrize("signup_field", _SIGNUP_STEP_FIELDS)
+def test_signup_flow_signup_step_with_recovery_step(db, signup_field, recovery_field):
+    """Continuing a signup and recovering it in the same request is rejected."""
+    testing_email = f"{random_hex(12)}@couchers.org.invalid"
+    flow_token = _start_signup_flow(testing_email)
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
+                    flow_token=flow_token,
+                    **{
+                        signup_field: _SIGNUP_FLOW_FIELDS[signup_field],
+                        recovery_field: _SIGNUP_FLOW_FIELDS[recovery_field],
+                    },
+                )
+            )
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert e.value.details() == _INVALID_SIGNUP_REQUEST
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == testing_email
+        assert flow.email_changed_count == 0
+        assert not flow.account_is_filled
+
+
+def test_signup_change_email_repeatedly(db):
+    with patch.multiple("couchers.servicers.auth", signup_email_changes_counter=DEFAULT) as counters:
+        flow_token = _start_signup_flow(f"{random_hex(12)}@couchers.org.invalid")
+
+        for _ in range(3):
+            new_email = f"{random_hex(12)}@couchers.org.invalid"
+            with auth_api_session() as (auth_api, metadata_interceptor):
+                res = auth_api.SignupFlow(
+                    auth_pb2.SignupFlowReq(
+                        flow_token=flow_token,
+                        change_email=auth_pb2.ChangeSignupEmail(new_email=new_email),
+                    )
+                )
+            assert res.flow_token == flow_token
+            assert res.need_verify_email
+
+        assert counters["signup_email_changes_counter"].inc.call_count == 3
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        assert flow.email == new_email
+        assert flow.email_changed_count == 3
+
+
+def test_signup_change_email_then_complete(db, email_collector: EmailCollector):
+    old_email = f"{random_hex(12)}@couchers.org.invalid"
+    new_email = f"{random_hex(12)}@couchers.org.invalid"
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                basic=auth_pb2.SignupBasic(name="testing", email=old_email),
+                account=auth_pb2.SignupAccount(
+                    username="frodo",
+                    password="a very insecure password",
+                    birthdate="1970-01-01",
+                    gender="Bot",
+                    hosting_status=api_pb2.HOSTING_STATUS_CAN_HOST,
+                    city="New York City",
+                    lat=40.7331,
+                    lng=-73.9778,
+                    radius=500,
+                    accept_tos=True,
+                ),
+                feedback=auth_pb2.ContributorForm(),
+                accept_community_guidelines=wrappers_pb2.BoolValue(value=True),
+                motivations=auth_pb2.SignupMotivations(motivations=["surfing"]),
+            )
+        )
+
+    flow_token = res.flow_token
+    assert flow_token
+    assert res.need_verify_email
+
+    email_collector.pop_for_recipient(old_email, last=True)
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                flow_token=flow_token,
+                change_email=auth_pb2.ChangeSignupEmail(new_email=new_email),
+            )
+        )
+
+    # the flow is otherwise complete, so it must not finish until the new email is verified
+    assert res.flow_token == flow_token
+    assert res.need_verify_email
+    assert not res.HasField("auth_res")
+
+    with session_scope() as session:
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
+
+        email_token = flow.email_token
+        assert email_token
+
+    email = email_collector.pop_for_recipient(new_email, last=True)
+    assert email_token in email.plain
+    assert email_token in email.html
+
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(auth_pb2.SignupFlowReq(email_token=email_token))
+
+    assert not res.flow_token
+    assert res.HasField("auth_res")
+
+    with session_scope() as session:
+        user = session.execute(select(User).where(User.username == "frodo")).scalar_one()
+
+        assert user.email == new_email
 
 
 def test_successful_authenticate(db):

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -963,10 +963,12 @@ def test_signup_change_email(db, email_collector: EmailCollector):
 
     # Change the signup email.
     with auth_api_session() as (auth_api, metadata_interceptor):
-        res = auth_api.SignupFlowChangeEmail(
-            auth_pb2.ChangeSignupEmailReq(
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
                 flow_token=flow_token,
-                new_email=new_email,
+                change_email=auth_pb2.ChangeSignupEmail(
+                    new_email = new_email
+                ),
             )
         )
 
@@ -1026,12 +1028,14 @@ def test_signup_change_new_invalid_email(db, invalid_email):
     # Try changing to an invalid email.
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
-            auth_api.SignupFlowChangeEmail(
-                auth_pb2.ChangeSignupEmailReq(
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
-                    new_email=invalid_email,
+                    change_email=auth_pb2.ChangeSignupEmail(
+                        new_email=invalid_email,
+                    ),
                 )
-            )
+    )
 
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     assert e.value.details() == "Invalid email."
@@ -1083,16 +1087,17 @@ def test_signup_change_email_after_email_verified(db):
 
         assert flow.email_verified
 
-    # Once the email has been verified, changing the signup email should fail.
+    # Try changing to an invalid email.
     with auth_api_session() as (auth_api, metadata_interceptor):
         with pytest.raises(grpc.RpcError) as e:
-            auth_api.SignupFlowChangeEmail(
-                auth_pb2.ChangeSignupEmailReq(
+            auth_api.SignupFlow(
+                auth_pb2.SignupFlowReq(
                     flow_token=flow_token,
-                    new_email=new_email,
+                    change_email=auth_pb2.ChangeSignupEmail(
+                        new_email=new_email,
+                    ),
                 )
-            )
-
+    )
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
     assert e.value.details() == "That email address is already associated with an account. Please log in instead!"
 
@@ -1134,10 +1139,12 @@ def test_signup_change_email_same_email_resends_existing_token(db, email_collect
 
     # Ask to change the signup email to the same email.
     with auth_api_session() as (auth_api, metadata_interceptor):
-        res = auth_api.SignupFlowChangeEmail(
-            auth_pb2.ChangeSignupEmailReq(
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
                 flow_token=flow_token,
-                new_email=testing_email,
+                change_email=auth_pb2.ChangeSignupEmail(
+                    new_email = testing_email
+                ),
             )
         )
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -1007,6 +1007,46 @@ def test_signup_change_email(db, email_collector: EmailCollector):
     assert old_email_token not in email.plain
     assert old_email_token not in email.html
    
+@pytest.mark.parametrize("invalid_email", ["bad email", "a@b","a@b.", "@ab.cd", "a@b.c"])
+def test_signup_change_new_invalid_email(db, invalid_email):
+    old_email = f"{random_hex(12)}@couchers.org.invalid"
+
+    # Create a signup with a valid email first.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        res = auth_api.SignupFlow(
+            auth_pb2.SignupFlowReq(
+                basic=auth_pb2.SignupBasic(
+                    name="frodo",
+                    email=old_email,
+                )
+            )
+        )
+
+    flow_token = res.flow_token
+    assert flow_token
+
+    # Try changing to an invalid email.
+    with auth_api_session() as (auth_api, metadata_interceptor):
+        with pytest.raises(grpc.RpcError) as e:
+            auth_api.SignupFlowChangeEmail(
+                auth_pb2.ChangeSignupEmailReq(
+                    flow_token=flow_token,
+                    new_email=invalid_email,
+                )
+            )
+
+    assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+    assert e.value.details() == "Invalid email."
+
+    # Make sure the original email wasn't changed.
+    with session_scope() as session:
+        flow = session.execute(
+            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
+        ).scalar_one()
+
+        assert flow.email == old_email
+
+
 def test_signup_change_email_after_email_verified(db):
     old_email = f"{random_hex(12)}@couchers.org.invalid"
     new_email = f"{random_hex(12)}@couchers.org.invalid"

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -966,9 +966,7 @@ def test_signup_change_email(db, email_collector: EmailCollector):
         res = auth_api.SignupFlow(
             auth_pb2.SignupFlowReq(
                 flow_token=flow_token,
-                change_email=auth_pb2.ChangeSignupEmail(
-                    new_email = new_email
-                ),
+                change_email=auth_pb2.ChangeSignupEmail(new_email=new_email),
             )
         )
 
@@ -1035,7 +1033,7 @@ def test_signup_change_new_invalid_email(db, invalid_email):
                         new_email=invalid_email,
                     ),
                 )
-    )
+            )
 
     assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
     assert e.value.details() == "Invalid email."
@@ -1097,7 +1095,7 @@ def test_signup_change_email_after_email_verified(db):
                         new_email=new_email,
                     ),
                 )
-    )
+            )
     assert e.value.code() == grpc.StatusCode.FAILED_PRECONDITION
     assert e.value.details() == "That email address is already associated with an account. Please log in instead!"
 
@@ -1142,9 +1140,7 @@ def test_signup_change_email_same_email_resends_existing_token(db, email_collect
         res = auth_api.SignupFlow(
             auth_pb2.SignupFlowReq(
                 flow_token=flow_token,
-                change_email=auth_pb2.ChangeSignupEmail(
-                    new_email = testing_email
-                ),
+                change_email=auth_pb2.ChangeSignupEmail(new_email=testing_email),
             )
         )
 

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -931,6 +931,7 @@ def test_signup_resend_email(db, email_collector: EmailCollector):
     assert not res.flow_token
     assert res.HasField("auth_res")
 
+
 def test_signup_change_email(db, email_collector: EmailCollector):
     old_email = f"{random_hex(12)}@couchers.org.invalid"
     new_email = f"{random_hex(12)}@couchers.org.invalid"
@@ -951,9 +952,7 @@ def test_signup_change_email(db, email_collector: EmailCollector):
 
     # Get the original verification token.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         old_email_token = flow.email_token
         assert flow.email == old_email
@@ -976,9 +975,7 @@ def test_signup_change_email(db, email_collector: EmailCollector):
 
     # The signup should now have the new email and a new verification token.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         assert flow.email == new_email
         assert flow.email != old_email
@@ -1006,8 +1003,9 @@ def test_signup_change_email(db, email_collector: EmailCollector):
     assert new_email_token in email.html
     assert old_email_token not in email.plain
     assert old_email_token not in email.html
-   
-@pytest.mark.parametrize("invalid_email", ["bad email", "a@b","a@b.", "@ab.cd", "a@b.c"])
+
+
+@pytest.mark.parametrize("invalid_email", ["bad email", "a@b", "a@b.", "@ab.cd", "a@b.c"])
 def test_signup_change_new_invalid_email(db, invalid_email):
     old_email = f"{random_hex(12)}@couchers.org.invalid"
 
@@ -1040,9 +1038,7 @@ def test_signup_change_new_invalid_email(db, invalid_email):
 
     # Make sure the original email wasn't changed.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         assert flow.email == old_email
 
@@ -1067,9 +1063,7 @@ def test_signup_change_email_after_email_verified(db):
 
     # Get the verification token.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         email_token = flow.email_token
         assert email_token
@@ -1085,9 +1079,7 @@ def test_signup_change_email_after_email_verified(db):
 
     # The email should now be verified.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         assert flow.email_verified
 
@@ -1106,12 +1098,11 @@ def test_signup_change_email_after_email_verified(db):
 
     # Make sure the signup email wasn't changed.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         assert flow.email == old_email
         assert flow.email_verified
+
 
 def test_signup_change_email_same_email_resends_existing_token(db, email_collector: EmailCollector):
     testing_email = f"{random_hex(12)}@couchers.org.invalid"
@@ -1131,9 +1122,7 @@ def test_signup_change_email_same_email_resends_existing_token(db, email_collect
 
     # Get the original email token.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         original_email_token = flow.email_token
         assert original_email_token
@@ -1163,9 +1152,7 @@ def test_signup_change_email_same_email_resends_existing_token(db, email_collect
 
     # The signup flow should still have the same token.
     with session_scope() as session:
-        flow = session.execute(
-            select(SignupFlow).where(SignupFlow.flow_token == flow_token)
-        ).scalar_one()
+        flow = session.execute(select(SignupFlow).where(SignupFlow.flow_token == flow_token)).scalar_one()
 
         assert flow.email == testing_email
         assert flow.email_token == original_email_token

--- a/app/proto/api/auth.proto
+++ b/app/proto/api/auth.proto
@@ -49,10 +49,6 @@ service Auth {
     // * Once the flow completes, the user is logged in and the signup flow is destroyed
   }
 
-  rpc SignupFlowChangeEmail(ChangeSignupEmailReq) returns (SignupFlowRes) {
-    // Change the email address of an incomplete signup flow.
-  }
-
   rpc UsernameValid(UsernameValidReq) returns (UsernameValidRes) {
     // Check whether the username is valid and available
   }
@@ -127,6 +123,8 @@ message SignupFlowReq {
   google.protobuf.BoolValue accept_community_guidelines = 6;
 
   bool resend_verification_email = 7;
+
+  ChangeSignupEmail change_email = 9;
 }
 
 message SignupFlowRes {
@@ -182,6 +180,9 @@ message SignupMotivations {
   repeated string motivations = 2;
 }
 
+message ChangeSignupEmail {
+  string new_email = 1; 
+}
 message UsernameValidReq {
   string username = 1;
 }
@@ -288,9 +289,4 @@ message GetInviteCodeInfoRes {
   string username = 2;
   string avatar_url = 3;
   string url = 4;
-}
-
-message ChangeSignupEmailReq {
-  string flow_token = 1;
-  string new_email = 2;
 }

--- a/app/proto/api/auth.proto
+++ b/app/proto/api/auth.proto
@@ -49,6 +49,10 @@ service Auth {
     // * Once the flow completes, the user is logged in and the signup flow is destroyed
   }
 
+  rpc SignupFlowChangeEmail(ChangeSignupEmailReq) returns (SignupFlowRes) {
+    // Change the email address of an incomplete signup flow.
+  }
+
   rpc UsernameValid(UsernameValidReq) returns (UsernameValidRes) {
     // Check whether the username is valid and available
   }
@@ -284,4 +288,9 @@ message GetInviteCodeInfoRes {
   string username = 2;
   string avatar_url = 3;
   string url = 4;
+}
+
+message ChangeSignupEmailReq {
+  string flow_token = 1;
+  string new_email = 2;
 }

--- a/app/proto/api/auth.proto
+++ b/app/proto/api/auth.proto
@@ -116,6 +116,7 @@ message SignupFlowReq {
   SignupAccount account = 3;
   ContributorForm feedback = 4;
   SignupMotivations motivations = 8;
+  ChangeSignupEmail change_email = 9;
 
   // email token is reused for both verifying a signup's email, but also for continuing a signup
   string email_token = 5 [ (is_token) = true ];
@@ -123,8 +124,6 @@ message SignupFlowReq {
   google.protobuf.BoolValue accept_community_guidelines = 6;
 
   bool resend_verification_email = 7;
-
-  ChangeSignupEmail change_email = 9;
 }
 
 message SignupFlowRes {
@@ -181,8 +180,9 @@ message SignupMotivations {
 }
 
 message ChangeSignupEmail {
-  string new_email = 1; 
+  string new_email = 1;
 }
+
 message UsernameValidReq {
   string username = 1;
 }

--- a/app/proto/api/auth.proto
+++ b/app/proto/api/auth.proto
@@ -112,18 +112,18 @@ message SignupFlowReq {
   // required if basic is empty, otherwise the backend generates a new signup
   string flow_token = 1 [ (is_token) = true ];
 
+  // email token is reused for both verifying a signup's email, but also for continuing a signup
+  string email_token = 5 [ (is_token) = true ];
+
   SignupBasic basic = 2;
   SignupAccount account = 3;
   ContributorForm feedback = 4;
   SignupMotivations motivations = 8;
-  ChangeSignupEmail change_email = 9;
-
-  // email token is reused for both verifying a signup's email, but also for continuing a signup
-  string email_token = 5 [ (is_token) = true ];
 
   google.protobuf.BoolValue accept_community_guidelines = 6;
 
   bool resend_verification_email = 7;
+  ChangeSignupEmail change_email = 9;
 }
 
 message SignupFlowRes {


### PR DESCRIPTION
Implements the backend changes to close #9092. Frontend changes are here: https://github.com/Couchers-org/couchers/pull/9626. This PR choose option 3 from [this comment](https://github.com/Couchers-org/couchers/issues/9092#issuecomment-4985326942) and lets users change their email at the email verification step. BE changes are necessary here because otherwise, when the user goes to make a new SignupFlow with their correct email address, the desired username is blocked by the old SignupFlow. 

I tried to follow the path of our current "ChangeEmailV2" functions, which allow a logged-in user to change the account email address, but for changing signup emails I put the code in auth.py (with the other signup functions) instead of account.py where ChangeEmailV2 lives (with the other logged-in-user functions.) This new functionality also differs from ChangeEmailV2 in that passwords are not involved in changing signup emails, and we don't notify the old_email since it was never verified to begin with. Since we're changing the email in SignupFlow, this invalidates the old email_token and releases the old email to any future Signup

**One question for reviewers:** do we want to limit the number of times a SignupFlow can change its email address? That's not happening in the current PR but I think if we add another element to SignupFlow in auth.proto we can do that. 

## Testing
I added a few tests to `test_auth.py` to check the backend functionality added by this PR.  To run the backend tests, I took the following steps:

First I merged the frontend and backend branches into a local branch, reviewers can run:

```
# Make sure you're in the Couchers repository
cd couchers
git fetch origin
git switch -c review/signup-email-change origin/develop
git merge --no-edit origin/backend/bugfix/signup-email-change-backend
git merge --no-edit origin/web/bugfix/signup-email-change-frontend
```

Then, a couple steps from the [frontend guide](https://github.com/Couchers-org/couchers/blob/develop/app/web/readme.md): In one terminal, start the local backend:

```
## terminal 1
cd app
docker run --rm -w /app -v $(pwd):/app registry.gitlab.com/couchers/grpc ./generate_protos.sh
docker compose up
```

In a second terminal, start the local frontend:

```
## terminal 2
cd app/web
# use local development config
cp .env.localdev .env.development
# run the frontend (follow Quick Start for prep)
yarn start
```

To run the backend tests, I opened a third terminal and ran:
```
## terminal 3
cd app/backend
docker compose exec backend pytest src/tests/test_auth.py
```

Frontend tests are described in [the other PR](https://github.com/Couchers-org/couchers/pull/9626).

**Backend checklist**
- [X] Added tests for any new code or added a regression test if fixing a bug
- [X] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [X] There are no console warnings when running the app
- [X] Added tests where relevant
- [X] Clicked around my changes running locally and it works
- [X] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
