### PR TITLE
Backend/push: Specify group name in message notifications

### DIFF
--- a/app/backend/src/couchers/notifications/locales/en.json
+++ b/app/backend/src/couchers/notifications/locales/en.json
@@ -85,7 +85,12 @@
   },
   "chat": {
     "message": {
-      "event_description": "Someone sends you a message"
+      "event_description": "Someone sends you a message",
+      "push_group": {
+        "title": "{{user}} • {{group}}",
+        "ios_title": "{{user}}",
+        "ios_subtitle": "{{group}}"
+      }
     },
     "missed_messages": {
       "event_description": "You miss messages in a chat",

--- a/app/backend/src/couchers/notifications/render_push.py
+++ b/app/backend/src/couchers/notifications/render_push.py
@@ -269,7 +269,17 @@ def _render_birthdate__change(
 def _render_chat__message(
     data: notification_data_pb2.ChatMessage, loc_context: LocalizationContext
 ) -> PushNotificationContent:
-    # All strings are dynamic, no need to use _get_content
+    if data.group_chat_title:
+        # Group chat message: title/subtitle specifies user and group
+        return _get_content(
+            "chat.message.push_group",
+            loc_context,
+            body=data.text,
+            substitutions={"user": data.author.name, "group": data.group_chat_title},
+            icon_user=data.author,
+            action_url=urls.chat_link(chat_id=data.group_chat_id),
+        )
+    # Direct message: all strings are dynamic, no need to use _get_content
     return PushNotificationContent(
         title=data.author.name,
         ios_title=data.author.name,

--- a/app/backend/src/tests/test_conversations.py
+++ b/app/backend/src/tests/test_conversations.py
@@ -732,6 +732,10 @@ def test_send_message(db, moderator: Moderator, push_collector: PushCollector, e
     # user2 gets email and push notifications
     push = push_collector.pop_for_user(user2.id, last=True)
     assert push.topic_action == NotificationTopicAction.chat__message.display
+    assert user1.name in push.content.title
+    assert group_chat_title in push.content.title
+    assert push.content.ios_title == user1.name
+    assert push.content.ios_subtitle == group_chat_title
     assert message1 in push.content.body
 
     email = email_collector.pop_for_recipient(user2.email, last=True)


### PR DESCRIPTION
For direct message we only need to specify the sender, but for group messages it's useful to include the group name. Currently it doesn't:

<img width="1000" height="377" alt="image" src="https://github.com/user-attachments/assets/9e667911-d15d-4036-b888-f46783c8d155" />

Fixes #9124

## Testing
Updated backend tests.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me