### PR TITLE
Backend/emails: Default to enabling translations

### DIFF
--- a/app/backend/src/couchers/email/queuing.py
+++ b/app/backend/src/couchers/email/queuing.py
@@ -48,7 +48,7 @@ def queue_userless_email(
     """
 
     loc_context = context.localization
-    if not context.get_boolean_value("notification_translations_enabled", default=False):
+    if not context.get_boolean_value("notification_translations_enabled", default=True):
         loc_context = LocalizationContext(locale="en", timezone=loc_context.timezone)
 
     footer = EmailFooter(timezone_name=loc_context.localized_timezone, copyright_year=now().year, unsubscribe_info=None)

--- a/app/backend/src/couchers/notifications/background.py
+++ b/app/backend/src/couchers/notifications/background.py
@@ -42,7 +42,7 @@ def _send_email_notification(session: Session, user: User, notification: Notific
     context = make_background_user_context(user.id)
 
     loc_context = LocalizationContext.from_user(user)
-    if not context.get_boolean_value("notification_translations_enabled", default=False):
+    if not context.get_boolean_value("notification_translations_enabled", default=True):
         loc_context = LocalizationContext(locale="en", timezone=loc_context.timezone)
 
     payload = get_send_email_payload(


### PR DESCRIPTION
@c-kreuz reported still getting untranslated emails. It seems like the feature flag might be off, and I think at this point many translations include email strings so we want to use it more as a kill flag than as an experiment (if we even need the feature flag), so it makes sense to default to enabled.

## Testing
N/A

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me