### PR TITLE
Frontend: Clarify 501(c)(3) when asking for donation

### DIFF
--- a/app/web/features/profile/locales/en.json
+++ b/app/web/features/profile/locales/en.json
@@ -190,7 +190,7 @@
     "thank_you_header": "Thank you for leaving a reference!",
     "thank_you_references_available": "When hosting or surfing, references become visible when both people have submitted their references, or after 2 weeks, whichever comes sooner.",
     "thank_you_support": "Most of all, thanks for being on Couchers and a part of our community!",
-    "thank_you_donation_prompt": "Consider <donateLink>making a donation</donateLink>! Couchers.org is a 501(c)(3) non-profit organization and we need donations to keep our servers running.",
+    "thank_you_donation_prompt": "Consider <donateLink>making a donation</donateLink>! Couchers, Inc. is a U.S. 501(c)(3) non-profit organization and we need donations to keep our servers running.",
     "was_appropriate_required": "To help us keep our community safe, this question is required.",
     "rating_required": "Please move the slider and rate your experience.",
     "rating_negative": "Negative",


### PR DESCRIPTION
Tweaks a string to clarify `501(c)(3)` is a U.S. concept, and fix the organization name.

## Testing
N/A

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me