### PR TITLE
Frontend/bugtool: Improve bug reporting copy

### DIFF
--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -92,7 +92,7 @@
       "warning_message": "The information you provide in this form, as well as diagnostic information including the page you are on, your browser and your username will be recorded for our team to review.",
       "title_label": "Report title",
       "problem_label": "How did you encounter the problem?",
-      "problem_helper": "Describe the steps you took, which pages you navigated to, what you clicked on, etc.",
+      "problem_helper": "Describe the steps you took: which pages you were on, what you clicked on, etc.",
       "expect_label": "What happened? What should have happened?",
       "expect_helper": "Describe the problem you saw as a result of your steps, including any error messages, and what you expected to happen instead.",
       "success_message2": "Thank you for reporting this problem and making Couchers better! A report was sent to the developers. You can refer to this problem using ID: <id/>."

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -89,13 +89,13 @@
     "label": "Report a problem",
     "bug": {
       "button_label": "Report a technical problem",
-      "warning_message": "Please note that this information, as well as diagnostic information including which page you are on, what browser you are using, and your username will be saved to a public list of bugs.",
+      "warning_message": "The information you provide in this form, as well as diagnostic information including the page you are on, your browser and your username will be recorded for our team to review.",
       "title_label": "Report title",
-      "problem_label": "What did you do to trigger the bug?",
-      "problem_helper": "Brief description of the problem and how to reproduce it",
+      "problem_label": "How did you encounter the problem?",
+      "problem_helper": "Describe the steps you took, which pages you navigated to, what you clicked on, etc.",
       "expect_label": "What happened? What should have happened?",
-      "expect_helper": "Brief description of what you expected to happen instead",
-      "success_message2": "Thank you for reporting that bug and making Couchers better, a report was sent to the developers! The bug ID is <id/>."
+      "expect_helper": "Describe the problem you saw as a result of your steps, including any error messages, and what you expected to happen instead.",
+      "success_message2": "Thank you for reporting this problem and making Couchers better! A report was sent to the developers. You can refer to this problem using ID: <id/>."
     },
     "content": {
       "button_label": "Report inappropriate content or behaviour",


### PR DESCRIPTION
Too many of our bug reports have little and unactionable information. We might be able to improve this with better instructions. Also fixes some issues with the copy.

- The list of bugs is not public anymore.
- Use "problem" consistently, avoid "bug".
- Avoid implying that the user caused the bug ("what did you do").
- Don't ask for a "brief" description. The more the better. Suggest what information to include.
- Clarify that the first field is for the steps, and the second field for the result.
- Update reference to bug id now that it's not a link anymore

## Testing
Vercel preview.

<img width="720" height="788" alt="image" src="https://github.com/user-attachments/assets/bce2f033-5ae6-40ca-a099-8ef602b4ade8" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me