### PR TITLE
Frontend/i18n: Localize press coverage dates

### DIFF
--- a/app/web/features/press/PressCoverage.test.tsx
+++ b/app/web/features/press/PressCoverage.test.tsx
@@ -1,6 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import { localizeDateOnly } from "i18n/datetimes";
-import { Temporal } from "temporal-polyfill";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
 
@@ -35,14 +33,17 @@ describe("PressCoverage", () => {
     });
   });
 
-  it("article dates are localized and have correct datetime attributes", () => {
+  it("article dates have correct datetime attributes", () => {
     render(<PressCoverage />, { wrapper });
 
-    const dates = ["2025-04-01", "2022-10-06", "2021-09-15"];
+    const dates = [
+      { text: "April 1, 2025", dateTime: "2025-04-01" },
+      { text: "October 6, 2022", dateTime: "2022-10-06" },
+      { text: "September 15, 2021", dateTime: "2021-09-15" },
+    ];
 
-    dates.forEach((date) => {
-      const text = localizeDateOnly(Temporal.PlainDate.from(date), i18n.language);
-      expect(screen.getByText(text)).toHaveAttribute("datetime", date);
+    dates.forEach(({ text, dateTime }) => {
+      expect(screen.getByText(text)).toHaveAttribute("datetime", dateTime);
     });
   });
 });

--- a/app/web/features/press/PressCoverage.test.tsx
+++ b/app/web/features/press/PressCoverage.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from "@testing-library/react";
+import { localizeDateOnly } from "i18n/datetimes";
+import { Temporal } from "temporal-polyfill";
 import wrapper from "test/hookWrapper";
 import i18n from "test/i18n";
 
@@ -33,17 +35,14 @@ describe("PressCoverage", () => {
     });
   });
 
-  it("article dates have correct datetime attributes", () => {
+  it("article dates are localized and have correct datetime attributes", () => {
     render(<PressCoverage />, { wrapper });
 
-    const dates = [
-      { text: "April 1, 2025", dateTime: "2025-04-01" },
-      { text: "October 6, 2022", dateTime: "2022-10-06" },
-      { text: "September 15, 2021", dateTime: "2021-09-15" },
-    ];
+    const dates = ["2025-04-01", "2022-10-06", "2021-09-15"];
 
-    dates.forEach(({ text, dateTime }) => {
-      expect(screen.getByText(text)).toHaveAttribute("datetime", dateTime);
+    dates.forEach((date) => {
+      const text = localizeDateOnly(Temporal.PlainDate.from(date), i18n.language);
+      expect(screen.getByText(text)).toHaveAttribute("datetime", date);
     });
   });
 });

--- a/app/web/features/press/PressCoverage.tsx
+++ b/app/web/features/press/PressCoverage.tsx
@@ -1,6 +1,8 @@
 import { Box, Card, Link, styled, Typography } from "@mui/material";
 import { useTranslation } from "i18n";
+import { localizeDateOnly } from "i18n/datetimes";
 import { PRESS } from "i18n/namespaces";
+import { Temporal } from "temporal-polyfill";
 
 import SectionHeading from "./SectionHeading";
 import SectionWrapper from "./SectionWrapper";
@@ -22,8 +24,7 @@ const articlesData = [
     altText: "Travel Noir",
     bgColor: "#001d2e",
     padding: "1rem",
-    publishedDate: "April 1, 2025",
-    dateTime: "2025-04-01",
+    date: "2025-04-01",
     headline: "Couchsurfing vs. house sitting: how to stay for free around the world",
     href: "https://travelnoire.com/couchsurfing-house-sitting-travel",
   },
@@ -32,8 +33,7 @@ const articlesData = [
     altText: "Adventure Uncovered",
     bgColor: "#1d1d1d",
     padding: "1rem",
-    publishedDate: "October 6, 2022",
-    dateTime: "2022-10-06",
+    date: "2022-10-06",
     headline: "The couchsurfing crossroads",
     href: "https://adventureuncovered.com/stories/the-couchsurfing-crossroads/",
   },
@@ -42,8 +42,7 @@ const articlesData = [
     altText: "Input",
     bgColor: undefined,
     padding: undefined,
-    publishedDate: "September 15, 2021",
-    dateTime: "2021-09-15",
+    date: "2021-09-15",
     headline: "Paradise lost: The rise and ruin of Couchsurfing.com",
     href: "https://www.inverse.com/input/features/rise-and-ruin-of-couchsurfing",
   },
@@ -99,13 +98,16 @@ const StyledLink = styled(Link)(({ theme }) => ({
 }));
 
 export default function PressCoverage() {
-  const { t } = useTranslation([PRESS]);
+  const {
+    t,
+    i18n: { language: locale },
+  } = useTranslation([PRESS]);
 
   return (
     <SectionWrapper>
       <SectionHeading>{t("press_coverage_subheading")}</SectionHeading>
       <StyledContainer>
-        {articlesData.map(({ imgPath, altText, bgColor, padding, publishedDate, dateTime, headline, href }) => (
+        {articlesData.map(({ imgPath, altText, bgColor, padding, date, headline, href }) => (
           <StyledCard key={altText}>
             <Box
               sx={{
@@ -114,8 +116,8 @@ export default function PressCoverage() {
             >
               <StyledImage src={imgPath} alt={altText} loading="lazy" bgColor={bgColor} padding={padding} />
             </Box>
-            <Typography component="time" dateTime={dateTime}>
-              {publishedDate}
+            <Typography component="time" dateTime={date}>
+              {localizeDateOnly(Temporal.PlainDate.from(date), locale)}
             </Typography>
             <Typography
               sx={{

--- a/app/web/features/press/PressCoverage.tsx
+++ b/app/web/features/press/PressCoverage.tsx
@@ -13,8 +13,7 @@ const articlesData = [
     altText: "Travel Massive",
     bgColor: "#fff",
     padding: "0.5rem",
-    publishedDate: "August 28, 2026",
-    dateTime: "2026-08-28",
+    date: "2026-08-28",
     headline:
       "Couchers is a free couch surfing platform connecting travelers and locals in 180+ countries around the world",
     href: "https://www.travelmassive.com/posts/couchers-is-a-free-couch-surfing-platform-connecting-travelers-and-locals-in-180-countries-around-the-world-371378167",


### PR DESCRIPTION
Removes the hardcoded US-English `publishedDate` strings from `PressCoverage.tsx`, in favor of localizing the `date` ISO string (renamed from `dateTime`)..

Fixes #9671

## Testing
Updated tests & ran locally.

<img width="2403" height="622" alt="image" src="https://github.com/user-attachments/assets/b99e7309-4fac-4283-9617-7b683be9b4a7" />

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
