### PR TITLE
Backend: Only send logs to Sentry at CRITICAL and above

### DIFF
--- a/app/backend/src/app.py
+++ b/app/backend/src/app.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
 
 import sentry_sdk
 from sentry_sdk.integrations import excepthook
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sqlalchemy.sql import text
 
 from couchers.config import config
@@ -99,6 +100,9 @@ def common_init() -> None:
             # The global excepthook picks up already handled gRPC errors (e.g. grpc.StatusCode.NOT_FOUND)
             disabled_integrations=[
                 excepthook.ExcepthookIntegration(),
+            ],
+            integrations=[
+                LoggingIntegration(event_level=logging.CRITICAL),
             ],
         )
 

--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -90,7 +90,7 @@ def process_job() -> bool:
         except Exception as e:
             finished = perf_counter_ns()
             # not sentry_sdk.set_tag: that writes to the thread's isolation scope, where the tags stick to
-            # every later report from this thread. logger.exception is in here so its event is tagged too
+            # every later report from this thread
             with sentry_sdk.new_scope() as scope:
                 scope.set_tag("context", "job")
                 scope.set_tag("job", job.job_type)

--- a/app/backend/src/couchers/servicers/events.py
+++ b/app/backend/src/couchers/servicers/events.py
@@ -42,6 +42,7 @@ from couchers.notifications.notify import notify
 from couchers.proto import events_pb2, events_pb2_grpc, notification_data_pb2
 from couchers.proto.google.api import httpbody_pb2
 from couchers.proto.internal import jobs_pb2
+from couchers.sentry import report_message
 from couchers.servicers.api import user_model_to_pb
 from couchers.servicers.blocking import is_not_visible
 from couchers.servicers.threads import thread_to_pb
@@ -392,7 +393,7 @@ def generate_event_create_notifications(payload: jobs_pb2.GenerateEventCreateNot
         inviting_user = session.execute(select(User).where(User.id == payload.inviting_user_id)).scalar_one_or_none()
 
         if not inviting_user:
-            logger.error(f"Inviting user {payload.inviting_user_id} is gone while trying to send event notification?")
+            report_message(f"Inviting user {payload.inviting_user_id} is gone while trying to send event notification?")
             return
 
         for user in users:


### PR DESCRIPTION
Backend errors reach Sentry partly through the SDK's logging integration, which by default turns every `logger.error` call into a Sentry issue, so routine and expected failures — a GeoIP lookup that didn't resolve, an Expo push request that failed — land there alongside real problems. This raises the integration's event level to `CRITICAL`, so what reaches Sentry from logging is `logger.critical` (the supervisor losing a child process, an unhandled exception in the jobs worker) plus everything reported explicitly, and it converts the one `logger.error` that did want reporting — the inviting user being gone while sending event creation notifications — into an explicit Sentry report.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._