### PR TITLE
backend/jobs: Only report permanently failed jobs to Sentry

### DIFF
--- a/app/backend/src/couchers/jobs/worker.py
+++ b/app/backend/src/couchers/jobs/worker.py
@@ -89,18 +89,17 @@ def process_job() -> bool:
             logger.info(f"Job #{job.id} complete on try number {job.try_count}")
         except Exception as e:
             finished = perf_counter_ns()
-            # not sentry_sdk.set_tag: that writes to the thread's isolation scope, where the tags stick to
-            # every later report from this thread
-            with sentry_sdk.new_scope() as scope:
-                scope.set_tag("context", "job")
-                scope.set_tag("job", job.job_type)
-                logger.exception(e)
-                sentry_sdk.capture_exception(e)
+            logger.exception(e)
 
             if job.try_count >= job.max_tries:
                 # if we already tried max_tries times, it's permanently failed
                 job.state = BackgroundJobState.failed
                 logger.info(f"Job #{job.id} failed on try number {job.try_count}")
+                # a new scope keeps these tags on this report only, not on every later one from this thread
+                with sentry_sdk.new_scope() as scope:
+                    scope.set_tag("context", "job")
+                    scope.set_tag("job", job.job_type)
+                    sentry_sdk.capture_exception(e)
             else:
                 job.state = BackgroundJobState.error
                 # exponential backoff


### PR DESCRIPTION
Background jobs are retried with exponential backoff up to `max_tries`, five by default. The worker reported the exception to Sentry on every failed attempt rather than only once a job had run out of retries, so transient failures that later succeeded — throttled email sends, temporary web push delivery errors — still filed events. The capture now happens only when a job is marked permanently failed. Every attempt is still logged and still recorded in the background jobs duration metric, so the per-attempt error rate remains visible.

**Backend checklist**
- [ ] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._