### PR TITLE
Backend: Fix Edge push notifications rejected by WNS

### DIFF
--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -17,7 +17,7 @@ from couchers.models import (
 )
 from couchers.models.notifications import DeviceType
 from couchers.notifications.expo_api import send_expo_push_notification
-from couchers.notifications.web_push_api import send_web_push, wns_headers
+from couchers.notifications.web_push_api import debug_response_headers, send_web_push
 from couchers.proto.internal import jobs_pb2
 from couchers.utils import not_none, now
 
@@ -117,7 +117,7 @@ def _send_web_push(
     if resp.status_code in [200, 201, 202]:
         return PushDeliveryResult(status_code=resp.status_code, response=resp.text)
 
-    headers = wns_headers(resp)
+    headers = debug_response_headers(resp)
 
     if resp.status_code in [404, 410]:
         raise PermanentSubscriptionFailure(

--- a/app/backend/src/couchers/notifications/send_raw_push_notification.py
+++ b/app/backend/src/couchers/notifications/send_raw_push_notification.py
@@ -2,6 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 
+import sentry_sdk
 from sqlalchemy import select
 from sqlalchemy.sql import func
 
@@ -16,7 +17,7 @@ from couchers.models import (
 )
 from couchers.models.notifications import DeviceType
 from couchers.notifications.expo_api import send_expo_push_notification
-from couchers.notifications.web_push_api import send_web_push
+from couchers.notifications.web_push_api import send_web_push, wns_headers
 from couchers.proto.internal import jobs_pb2
 from couchers.utils import not_none, now
 
@@ -34,10 +35,18 @@ class PushNotificationError(Exception):
     Transient errors should raise this base class - they will be retried.
     """
 
-    def __init__(self, message: str, *, status_code: int | None = None, response: str | None = None):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        response: str | None = None,
+        response_headers: dict[str, str] | None = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
         self.response = response
+        self.response_headers = response_headers
 
 
 class PermanentSubscriptionFailure(PushNotificationError):
@@ -108,18 +117,31 @@ def _send_web_push(
     if resp.status_code in [200, 201, 202]:
         return PushDeliveryResult(status_code=resp.status_code, response=resp.text)
 
+    headers = wns_headers(resp)
+
     if resp.status_code in [404, 410]:
         raise PermanentSubscriptionFailure(
             f"Subscription gone (HTTP {resp.status_code})",
             status_code=resp.status_code,
             response=resp.text,
+            response_headers=headers,
+        )
+
+    if resp.status_code == 400:
+        # the push service rejected the request itself, so re-sending it won't help
+        raise PermanentMessageFailure(
+            f"Web push rejected as a bad request (HTTP {resp.status_code}): {headers}",
+            status_code=resp.status_code,
+            response=resp.text,
+            response_headers=headers,
         )
 
     # Other errors are transient - will retry
     raise PushNotificationError(
-        f"Web push failed (HTTP {resp.status_code})",
+        f"Web push failed (HTTP {resp.status_code}): {headers}",
         status_code=resp.status_code,
         response=resp.text,
+        response_headers=headers,
     )
 
 
@@ -246,6 +268,19 @@ def send_raw_push_notification_v2(payload: jobs_pb2.SendRawPushNotificationPaylo
 
         except PermanentMessageFailure as e:
             logger.warning(f"Permanent message failure for sub {sub.id}: {e}")
+            # this notification is dropped and never retried, so it won't reach Sentry any other way
+            with sentry_sdk.new_scope() as scope:
+                scope.set_tag("context", "push")
+                scope.set_context(
+                    "push_response",
+                    {
+                        "platform": sub.platform.name,
+                        "status_code": e.status_code,
+                        "response": e.response,
+                        "response_headers": e.response_headers,
+                    },
+                )
+                sentry_sdk.capture_exception(e)
             session.add(
                 PushNotificationDeliveryAttempt(
                     push_notification_subscription_id=sub.id,

--- a/app/backend/src/couchers/notifications/web_push_api.py
+++ b/app/backend/src/couchers/notifications/web_push_api.py
@@ -54,7 +54,8 @@ def send_web_push(
         "authorization": generate_vapid_authorization(endpoint, vapid_sub, vapid_private_key),
         "content-encoding": "aes128gcm",
         "ttl": str(ttl),
-        # WNS (Edge) 400s with "Ttl value conflicts with X-WNS-Cache-Policy" unless this matches the ttl
+        # WNS (Windows Notification Service, the push backend for Edge) 400s with
+        # "Ttl value conflicts with X-WNS-Cache-Policy" unless this matches the ttl
         "x-wns-cache-policy": "no-cache" if ttl == 0 else "cache",
     }
 
@@ -73,8 +74,11 @@ def send_web_push(
     )
 
 
-def wns_headers(resp: requests.Response) -> dict[str, str] | None:
-    """WNS reports why it rejected a push in x-wns-* headers and leaves the body empty."""
+def debug_response_headers(resp: requests.Response) -> dict[str, str] | None:
+    """Pick out the response headers worth reporting when a push fails.
+
+    WNS reports why it rejected a push in x-wns-* headers and leaves the body empty.
+    """
     headers = {k: v for k, v in resp.headers.items() if k.lower().startswith("x-wns-")}
     return headers or None
 

--- a/app/backend/src/couchers/notifications/web_push_api.py
+++ b/app/backend/src/couchers/notifications/web_push_api.py
@@ -54,6 +54,8 @@ def send_web_push(
         "authorization": generate_vapid_authorization(endpoint, vapid_sub, vapid_private_key),
         "content-encoding": "aes128gcm",
         "ttl": str(ttl),
+        # WNS (Edge) 400s with "Ttl value conflicts with X-WNS-Cache-Policy" unless this matches the ttl
+        "x-wns-cache-policy": "no-cache" if ttl == 0 else "cache",
     }
 
     encrypted = http_ece.encrypt(
@@ -69,6 +71,12 @@ def send_web_push(
         data=encrypted,
         headers=headers,
     )
+
+
+def wns_headers(resp: requests.Response) -> dict[str, str] | None:
+    """WNS reports why it rejected a push in x-wns-* headers and leaves the body empty."""
+    headers = {k: v for k, v in resp.headers.items() if k.lower().startswith("x-wns-")}
+    return headers or None
 
 
 def decode_key(value: str) -> bytes:

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -1002,7 +1002,7 @@ def test_check_expo_push_receipts_success(db):
         assert sub.disabled_at == DATETIME_INFINITY
 
 
-def test_check_expo_push_receipts_device_not_registered(db):
+def test_check_expo_push_receipts_device_not_registered(db, frozen_timewarp):
     """Test batch receipt checking with DeviceNotRegistered error disables subscription."""
     user, token = generate_user()
 
@@ -1027,7 +1027,7 @@ def test_check_expo_push_receipts_device_not_registered(db):
         session.add(attempt)
         session.flush()
         # Make the attempt old enough to be checked
-        attempt.time = now() - timedelta(minutes=15)
+        attempt.time = now() - timedelta(minutes=20)
         attempt_id = attempt.id
         sub_id = sub.id
 
@@ -1058,8 +1058,7 @@ def test_check_expo_push_receipts_device_not_registered(db):
         sub = session.execute(
             select(PushNotificationSubscription).where(PushNotificationSubscription.id == sub_id)
         ).scalar_one()
-        # not compared against now(): postgres sets this from its own clock, which can lead ours
-        assert sub.disabled_at < DATETIME_INFINITY
+        assert sub.disabled_at == now()
 
 
 def test_check_expo_push_receipts_not_found(db):
@@ -2077,7 +2076,7 @@ def test_web_push_transient_error_is_retried(db, status_code):
 
 
 @pytest.mark.parametrize("status_code", [404, 410])
-def test_web_push_gone_disables_subscription(db, status_code):
+def test_web_push_gone_disables_subscription(db, frozen_timewarp, status_code):
     user, _ = generate_user()
     sub_id = _make_web_push_sub(user.id)
 
@@ -2102,8 +2101,7 @@ def test_web_push_gone_disables_subscription(db, status_code):
         sub = session.execute(
             select(PushNotificationSubscription).where(PushNotificationSubscription.id == sub_id)
         ).scalar_one()
-        # not compared against now(): postgres sets this from its own clock, which can lead ours
-        assert sub.disabled_at < DATETIME_INFINITY
+        assert sub.disabled_at == now()
 
 
 @pytest.mark.parametrize(("ttl", "expected"), [(0, "no-cache"), (3600, "cache")])

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -34,7 +34,9 @@ from couchers.models import (
 from couchers.notifications.background import handle_notification
 from couchers.notifications.expo_api import get_expo_push_receipts
 from couchers.notifications.notify import notify
+from couchers.notifications.send_raw_push_notification import PushNotificationError, send_raw_push_notification_v2
 from couchers.notifications.settings import get_topic_actions_by_delivery_type, reset_preference
+from couchers.notifications.web_push_api import decode_key, send_web_push
 from couchers.proto import (
     api_pb2,
     auth_pb2,
@@ -1056,7 +1058,8 @@ def test_check_expo_push_receipts_device_not_registered(db):
         sub = session.execute(
             select(PushNotificationSubscription).where(PushNotificationSubscription.id == sub_id)
         ).scalar_one()
-        assert sub.disabled_at <= now()
+        # not compared against now(): postgres sets this from its own clock, which can lead ours
+        assert sub.disabled_at < DATETIME_INFINITY
 
 
 def test_check_expo_push_receipts_not_found(db):
@@ -1993,3 +1996,194 @@ def test_handle_notification_multiple_delivery_types(
                 assert delivery.delivered is not None
             elif delivery.delivery_type == NotificationDeliveryType.digest:
                 assert delivery.delivered is None
+
+
+# a real uncompressed P-256 point, so the aes128gcm encryption in send_web_push actually runs
+_P256DH_KEY = decode_key("BK7Rp8og3eFJPqm0ofR8F-l2mtNCCCWYo6f_5kSs8jPEFiKetnZHNOglvC6IrgU9vHmgFHlG7gHGtB1HM599sy0")
+
+
+def _make_web_push_sub(user_id: int) -> int:
+    with session_scope() as session:
+        sub = PushNotificationSubscription(
+            user_id=user_id,
+            platform=PushNotificationPlatform.web_push,
+            endpoint="https://updates.push.services.mozilla.com/wpush/v2/sometoken",
+            auth_key=b"0123456789abcdef",
+            p256dh_key=b"0123456789abcdef0123456789abcdef",
+            full_subscription_info="{}",
+            user_agent="Mozilla/5.0",
+        )
+        session.add(sub)
+        session.flush()
+        return sub.id
+
+
+def test_web_push_bad_request_is_permanent_message_failure(db):
+    """A rejected request won't be accepted on a retry, so don't retry it."""
+    user, _ = generate_user()
+    sub_id = _make_web_push_sub(user.id)
+
+    with patch("couchers.notifications.send_raw_push_notification.send_web_push") as mock_send:
+        mock_send.return_value = Mock(status_code=400, text="bad request", headers={})
+        send_raw_push_notification_v2(
+            jobs_pb2.SendRawPushNotificationPayloadV2(
+                push_notification_subscription_id=sub_id,
+                title="title",
+                body="body",
+            )
+        )
+
+    with session_scope() as session:
+        attempt = session.execute(
+            select(PushNotificationDeliveryAttempt).where(
+                PushNotificationDeliveryAttempt.push_notification_subscription_id == sub_id
+            )
+        ).scalar_one()
+        assert attempt.outcome == PushNotificationDeliveryOutcome.permanent_message_failure
+        assert attempt.status_code == 400
+
+        # the subscription itself is still fine
+        sub = session.execute(
+            select(PushNotificationSubscription).where(PushNotificationSubscription.id == sub_id)
+        ).scalar_one()
+        assert sub.disabled_at == DATETIME_INFINITY
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 413, 429, 500, 502, 503])
+def test_web_push_transient_error_is_retried(db, status_code):
+    """Anything we don't recognise as permanent stays retryable."""
+    user, _ = generate_user()
+    sub_id = _make_web_push_sub(user.id)
+
+    with patch("couchers.notifications.send_raw_push_notification.send_web_push") as mock_send:
+        mock_send.return_value = Mock(status_code=status_code, text="try again later", headers={})
+        with pytest.raises(PushNotificationError):
+            send_raw_push_notification_v2(
+                jobs_pb2.SendRawPushNotificationPayloadV2(
+                    push_notification_subscription_id=sub_id,
+                    title="title",
+                    body="body",
+                )
+            )
+
+    with session_scope() as session:
+        attempt = session.execute(
+            select(PushNotificationDeliveryAttempt).where(
+                PushNotificationDeliveryAttempt.push_notification_subscription_id == sub_id
+            )
+        ).scalar_one()
+        assert attempt.outcome == PushNotificationDeliveryOutcome.transient_failure
+        assert attempt.status_code == status_code
+
+
+@pytest.mark.parametrize("status_code", [404, 410])
+def test_web_push_gone_disables_subscription(db, status_code):
+    user, _ = generate_user()
+    sub_id = _make_web_push_sub(user.id)
+
+    with patch("couchers.notifications.send_raw_push_notification.send_web_push") as mock_send:
+        mock_send.return_value = Mock(status_code=status_code, text="gone", headers={})
+        send_raw_push_notification_v2(
+            jobs_pb2.SendRawPushNotificationPayloadV2(
+                push_notification_subscription_id=sub_id,
+                title="title",
+                body="body",
+            )
+        )
+
+    with session_scope() as session:
+        attempt = session.execute(
+            select(PushNotificationDeliveryAttempt).where(
+                PushNotificationDeliveryAttempt.push_notification_subscription_id == sub_id
+            )
+        ).scalar_one()
+        assert attempt.outcome == PushNotificationDeliveryOutcome.permanent_subscription_failure
+
+        sub = session.execute(
+            select(PushNotificationSubscription).where(PushNotificationSubscription.id == sub_id)
+        ).scalar_one()
+        # not compared against now(): postgres sets this from its own clock, which can lead ours
+        assert sub.disabled_at < DATETIME_INFINITY
+
+
+@pytest.mark.parametrize(("ttl", "expected"), [(0, "no-cache"), (3600, "cache")])
+def test_web_push_sends_wns_cache_policy(testconfig, ttl, expected):
+    """WNS rejects a push whose cache policy doesn't match its ttl."""
+    with patch("couchers.notifications.web_push_api.requests.post") as mock_post:
+        send_web_push(
+            b"data",
+            "https://wns2-par02p.notify.windows.com/w/?token=abc",
+            b"0123456789abcdef",
+            _P256DH_KEY,
+            "mailto:testing@couchers.org.invalid",
+            config.PUSH_NOTIFICATIONS_VAPID_PRIVATE_KEY,
+            ttl=ttl,
+        )
+
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers["ttl"] == str(ttl)
+    assert headers["x-wns-cache-policy"] == expected
+
+
+def test_web_push_bad_request_reports_wns_error_to_sentry(db):
+    """WNS explains a rejection in headers with an empty body, and the drop is silent otherwise."""
+    user, _ = generate_user()
+    sub_id = _make_web_push_sub(user.id)
+
+    with (
+        patch("couchers.notifications.send_raw_push_notification.send_web_push") as mock_send,
+        patch("couchers.notifications.send_raw_push_notification.sentry_sdk") as mock_sentry,
+    ):
+        mock_send.return_value = Mock(
+            status_code=400,
+            text="",
+            headers={
+                "X-WNS-Error-Description": "Ttl value conflicts with X-WNS-Cache-Policy.",
+                "X-WNS-Status": "dropped",
+                "Content-Length": "0",
+            },
+        )
+        send_raw_push_notification_v2(
+            jobs_pb2.SendRawPushNotificationPayloadV2(
+                push_notification_subscription_id=sub_id,
+                title="title",
+                body="body",
+            )
+        )
+
+    reported = mock_sentry.capture_exception.call_args[0][0]
+    assert reported.response_headers["X-WNS-Error-Description"] == "Ttl value conflicts with X-WNS-Cache-Policy."
+    # unrelated headers aren't worth reporting
+    assert "Content-Length" not in reported.response_headers
+    # the message carries them too, so they show up in the Sentry issue itself
+    assert "Ttl value conflicts" in str(reported)
+
+    scope = mock_sentry.new_scope.return_value.__enter__.return_value
+    context = scope.set_context.call_args[0][1]
+    assert context["status_code"] == 400
+    assert context["response_headers"]["X-WNS-Status"] == "dropped"
+
+
+def test_web_push_success_records_body_verbatim(db):
+    """response holds the body exactly as received, never a wrapper around it."""
+    user, _ = generate_user()
+    sub_id = _make_web_push_sub(user.id)
+
+    with patch("couchers.notifications.send_raw_push_notification.send_web_push") as mock_send:
+        mock_send.return_value = Mock(status_code=201, text="ok", headers={"X-WNS-Status": "received"})
+        send_raw_push_notification_v2(
+            jobs_pb2.SendRawPushNotificationPayloadV2(
+                push_notification_subscription_id=sub_id,
+                title="title",
+                body="body",
+            )
+        )
+
+    with session_scope() as session:
+        attempt = session.execute(
+            select(PushNotificationDeliveryAttempt).where(
+                PushNotificationDeliveryAttempt.push_notification_subscription_id == sub_id
+            )
+        ).scalar_one()
+        assert attempt.outcome == PushNotificationDeliveryOutcome.success
+        assert attempt.response == "ok"

--- a/app/backend/src/tests/test_notifications.py
+++ b/app/backend/src/tests/test_notifications.py
@@ -2108,7 +2108,7 @@ def test_web_push_gone_disables_subscription(db, status_code):
 
 @pytest.mark.parametrize(("ttl", "expected"), [(0, "no-cache"), (3600, "cache")])
 def test_web_push_sends_wns_cache_policy(testconfig, ttl, expected):
-    """WNS rejects a push whose cache policy doesn't match its ttl."""
+    """WNS (Windows Notification Service, Edge's push backend) rejects a mismatched cache policy and ttl."""
     with patch("couchers.notifications.web_push_api.requests.post") as mock_post:
         send_web_push(
             b"data",


### PR DESCRIPTION
Push notifications to Edge go via WNS, which requires an `X-WNS-Cache-Policy` header consistent with the request's TTL and otherwise rejects the push with HTTP 400 and `Ttl value conflicts with X-WNS-Cache-Policy`. We never sent that header, so every push using the default TTL of 0 failed for Edge users — which is the confirmation push sent the moment they enable notifications, and the one behind the test button in notification settings. Their real notifications, which go out with a TTL of an hour, were unaffected, so notifications appeared broken to exactly the users who had just turned them on. This sends the header. WNS reports the reason in `x-wns-*` response headers rather than in the body, so those headers now travel on the exception and are reported to Sentry along with the failing push; a permanent message failure is otherwise only logged at warning level and left no trace. Finally, a 400 is no longer treated as transient: a push service that rejects the request won't accept it on a retry, so it is recorded as a permanent message failure rather than exhausting all five attempts. Other unrecognised statuses stay retryable.

## Testing
Enabling web push in Edge on Windows should now show the "thanks for enabling push notifications" confirmation, as should the test button in notification settings.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._