### PR TITLE
Devops: Rework the code review bot around deterministic rules

### DIFF
--- a/.github/llm-bot/pr_review_bot.py
+++ b/.github/llm-bot/pr_review_bot.py
@@ -1,0 +1,405 @@
+"""
+PR review bot.
+
+Three subcommands, run in order by .github/workflows/code-review.yml:
+
+  gate         gather facts, apply the deterministic rules, approve outright or ask for a review
+  query-diff   work out which SQL the branch newly issues, for the review prompt
+  apply        turn the review's verdict into a review on the PR
+
+The split exists so that the model is never the thing that approves a pull request. `gate` decides whether an approval
+is permitted at all and records that in `auto_stamp_eligible`; the review can only ever spend that permission, never
+grant it. `apply` re-reads the gate's decision and refuses to approve without it, so a review that comes back with an
+enthusiastic verdict on a migration still gets posted as a comment.
+
+Python also owns the review body, because the body carries the marker that the next run's rebase detection reads. A
+64-character hash is not something to ask a model to copy accurately.
+
+The prompt's context and the review's verdict travel between the commands as files in the working directory, so all
+three have to run in one job. The gate's decision is the exception: it reaches `apply` as step outputs, because the
+review holds a Write tool and so can reach anything on disk. See `_set_outputs`.
+
+The pull request's own code is checked out read-only into `pr-head/` for the review to read, but nothing ever runs it:
+no install step touches it, and the review's Bash access is two `gh` subcommands. That matters because
+`pull_request_target` hands this job's PR-approving token to forks as well.
+"""
+
+import argparse
+import gzip
+import importlib.util
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from github import Auth, Github
+from github.PullRequest import PullRequest
+
+from pr_review_rules import (
+    Action,
+    ChangedFile,
+    Codeowners,
+    GateDecision,
+    PullRequestFacts,
+    gate,
+    marker,
+    may_approve,
+    parse_marker,
+    patch_fingerprint,
+)
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CODEOWNERS_PATH = REPO_ROOT / ".github" / "CODEOWNERS"
+QUERY_LOG_REPORT = REPO_ROOT / "app" / "scripts" / "query_log_report.py"
+
+CONTEXT_FILE = Path("pr-review-context.md")
+QUERIES_FILE = Path("pr-review-queries.md")
+VERDICT_FILE = Path("pr-review-verdict.json")
+
+PREVIEW_DOMAIN = os.environ.get("PREVIEW_DOMAIN", "preview.couchershq.org")
+BASELINE_REF = os.environ.get("BASELINE_REF", "develop")
+
+# GitLab publishes the merged query log under the short sha once the backend pipeline finishes, which is well after
+# GitHub fires this workflow. Wait for it, but never let it hold the review hostage.
+QUERY_LOG_TIMEOUT = int(os.environ.get("QUERY_LOG_TIMEOUT", "900"))
+QUERY_LOG_POLL_INTERVAL = 30
+GITLAB_SHORT_SHA_LENGTH = 8
+
+# How many newly-issued statements to put in front of the reviewer. Past this the branch has changed database access
+# broadly enough that the full report is the thing to read, not a list.
+MAX_QUERIES_SHOWN = 40
+
+BACKEND_PREFIXES = ("app/backend/", "app/proto/")
+
+
+# ============================================================================
+# GitHub plumbing
+# ============================================================================
+
+
+def _client() -> tuple[Github, PullRequest, str]:
+    repo_name = os.environ["REPOSITORY"]
+    github = Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"]))
+    pr = github.get_repo(repo_name).get_pull(int(os.environ["PR_NUMBER"]))
+    return github, pr, repo_name
+
+
+def _fetch_diff(repo_name: str, number: int) -> str | None:
+    """The PR's diff against its merge base, or None when GitHub declines to render it."""
+    response = requests.get(
+        f"https://api.github.com/repos/{repo_name}/pulls/{number}",
+        headers={
+            "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+            "Accept": "application/vnd.github.v3.diff",
+        },
+        timeout=60,
+    )
+    # 406 is GitHub refusing to render a diff that large. There is nothing to fingerprint and no point asking again.
+    if response.status_code == 406:
+        print("GitHub would not render the diff (too large), skipping the unchanged-diff rule")
+        return None
+    response.raise_for_status()
+    return response.text
+
+
+def _previous_verdict(pr: PullRequest) -> tuple[str, str] | None:
+    """The (fingerprint, verdict) of the most recent review this bot left, if it has left one."""
+    for review in reversed(list(pr.get_reviews())):
+        found = parse_marker(review.body or "")
+        if found:
+            return found
+    return None
+
+
+def _author_teams(github: Github, repo_name: str, login: str, codeowners: Codeowners) -> frozenset[str]:
+    """Team slugs (`org/team`) the author belongs to, so CODEOWNERS team entries resolve to a person.
+
+    Skipped entirely when CODEOWNERS names no teams, which is the case today and saves an org-scoped API call that
+    the bot's token is not otherwise required to be able to make.
+    """
+    if not any("/" in owner for _, owners in codeowners.rules for owner in owners):
+        return frozenset()
+    org_name = repo_name.split("/")[0]
+    org = github.get_organization(org_name)
+    user = org.get_named_user(login)
+    return frozenset(f"{org_name}/{team.slug}".lower() for team in org.get_teams() if team.has_in_members(user))
+
+
+def _set_outputs(**outputs: Any) -> None:
+    """Publish the gate's decision as step outputs.
+
+    These, and not a file, are how the decision reaches `apply`. A step's outputs are captured when it ends, so
+    nothing that runs afterwards can alter them — including the review, which holds a Write tool and would otherwise
+    be able to grant itself the approval permission it is supposed to be unable to grant.
+    """
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        print(f"(no GITHUB_OUTPUT set) outputs: {outputs}")
+        return
+    with open(path, "a") as f:
+        for key, value in outputs.items():
+            f.write(f"{key}={str(value).lower() if isinstance(value, bool) else value}\n")
+
+
+# ============================================================================
+# gate
+# ============================================================================
+
+
+def _write_context(pr: PullRequest, facts: PullRequestFacts, decision: GateDecision) -> None:
+    """Write the deterministic findings out for the review prompt to read."""
+    lines = [
+        "# Deterministic facts about this pull request",
+        "",
+        "These were established before any model looked at the PR. Treat them as given.",
+        "",
+        f"- Title: {pr.title}",
+        f"- Author: @{facts.author}",
+        f"- Files changed: {len(facts.files)}",
+        f"- Lines changed: {facts.changed_lines}",
+        f"- Auto-approval permitted if the review is clean: {'yes' if decision.auto_stamp_eligible else 'no'}",
+    ]
+    if decision.stamp_blockers:
+        lines += ["", "Auto-approval is ruled out because:", ""]
+        lines += [f"- {blocker}" for blocker in decision.stamp_blockers]
+    lines += ["", "## Changed files", ""]
+    lines += [f"- `{f.path}` (+{f.additions}/-{f.deletions})" for f in facts.files]
+    CONTEXT_FILE.write_text("\n".join(lines) + "\n")
+
+
+def cmd_gate() -> None:
+    github, pr, repo_name = _client()
+    diff = _fetch_diff(repo_name, pr.number)
+    codeowners = Codeowners.parse(CODEOWNERS_PATH.read_text()) if CODEOWNERS_PATH.exists() else Codeowners()
+
+    facts = PullRequestFacts(
+        author=pr.user.login,
+        draft=pr.draft,
+        files=[ChangedFile(f.filename, f.additions, f.deletions) for f in pr.get_files()],
+        fingerprint=patch_fingerprint(diff) if diff is not None else None,
+        author_teams=_author_teams(github, repo_name, pr.user.login, codeowners),
+        codeowners=codeowners,
+        previous=_previous_verdict(pr),
+    )
+    decision = gate(facts)
+
+    print(f"action={decision.action.value} ({decision.reason})")
+    for blocker in decision.stamp_blockers:
+        print(f"  no stamp: {blocker}")
+
+    if decision.action == Action.APPROVE_UNCHANGED:
+        # The fingerprint is unchanged by definition here, so carrying it forward keeps the chain intact across any
+        # number of successive rebases.
+        _approve(
+            pr,
+            "### Code review bot\n\nNo code changes since the last review — rebase or merge only, so the previous "
+            "approval still stands.",
+            facts.fingerprint or "",
+        )
+    elif decision.action == Action.REVIEW:
+        _write_context(pr, facts, decision)
+
+    _set_outputs(
+        action=decision.action.value,
+        backend_touched=any(p.startswith(BACKEND_PREFIXES) for p in facts.paths),
+        auto_stamp_eligible=decision.auto_stamp_eligible,
+        fingerprint=facts.fingerprint or "",
+        # JSON so this stays on one line, which is all GITHUB_OUTPUT takes without a heredoc.
+        stamp_blockers=json.dumps(list(decision.stamp_blockers)),
+    )
+
+
+# ============================================================================
+# query-diff
+# ============================================================================
+
+
+def _load_query_log_report() -> Any:
+    """Import app/scripts/query_log_report.py so the bot diffs query logs exactly the way CI does."""
+    spec = importlib.util.spec_from_file_location("query_log_report", QUERY_LOG_REPORT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {QUERY_LOG_REPORT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fetch_query_log(url: str) -> dict[str, Any] | None:
+    """Read a published query log, or None if the pipeline has not put one there."""
+    response = requests.get(url, timeout=60)
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    payload = response.content
+    if payload[:2] == b"\x1f\x8b":
+        payload = gzip.decompress(payload)
+    return json.loads(payload)
+
+
+def _await_query_log(sha: str) -> dict[str, Any] | None:
+    """Poll for this commit's query log until the GitLab pipeline publishes it, or the deadline passes."""
+    url = f"https://{sha[:GITLAB_SHORT_SHA_LENGTH]}--test-artifacts.{PREVIEW_DOMAIN}/queries/data.json.gz"
+    deadline = time.monotonic() + QUERY_LOG_TIMEOUT
+    while True:
+        log = _fetch_query_log(url)
+        if log is not None:
+            return log
+        if time.monotonic() >= deadline:
+            print(f"gave up waiting for {url}")
+            return None
+        print(f"{url} not published yet, retrying in {QUERY_LOG_POLL_INTERVAL}s")
+        time.sleep(QUERY_LOG_POLL_INTERVAL)
+
+
+def _render_queries(current: dict[str, Any], report: dict[str, Any]) -> str:
+    lines = [
+        "# SQL this branch changes",
+        "",
+        "Recorded by the backend test suite and diffed against develop's published log. A shape is one statement with "
+        "its bound parameters replaced by `?`. The inlined version below each one comes from a truncated test "
+        "database, so read its values as a template rather than as representative data.",
+        "",
+    ]
+
+    if not report["has_baseline"]:
+        lines += ["Develop has published no query log to compare against, so nothing can be diffed.", ""]
+        return "\n".join(lines)
+
+    added, removed = report["added_shapes"], report["removed_shapes"]
+    lines += [f"**{len(added)} new query shapes, {len(removed)} no longer issued.**", ""]
+
+    if not added and not removed:
+        lines += ["No change to the SQL the test suite issues.", ""]
+        return "\n".join(lines)
+
+    for shape_id in added[:MAX_QUERIES_SHOWN]:
+        shape = current["shapes"][shape_id]
+        lines += [
+            f"## New, first seen in `{shape['first_seen_in']}`",
+            "",
+            "```sql",
+            shape["sql"],
+            "```",
+            "",
+            "<details><summary>with values inlined</summary>",
+            "",
+            "```sql",
+            shape["example"],
+            "```",
+            "",
+            "</details>",
+            "",
+        ]
+    if len(added) > MAX_QUERIES_SHOWN:
+        lines += [f"_{len(added) - MAX_QUERIES_SHOWN} further new shapes omitted._", ""]
+
+    if removed:
+        lines += ["## No longer issued", ""]
+        for shape in removed[:MAX_QUERIES_SHOWN]:
+            lines += ["```sql", shape["sql"], "```", ""]
+
+    changed_tests = [t for t, v in report["tests"].items() if v["status"] == "changed"]
+    if changed_tests:
+        lines += ["## Tests whose query pattern changed", ""]
+        lines += [f"- `{t}`" for t in changed_tests[:MAX_QUERIES_SHOWN]]
+        lines += [""]
+    return "\n".join(lines)
+
+
+def cmd_query_diff() -> None:
+    _, pr, _ = _client()
+    current = _await_query_log(pr.head.sha)
+    if current is None:
+        QUERIES_FILE.write_text(
+            "# SQL this branch changes\n\nThe query log for this commit was not published in time, so no SQL diff is "
+            "available. Review any new or modified queries from the PR diff directly.\n"
+        )
+        return
+
+    baseline = _fetch_query_log(f"https://{BASELINE_REF}--test-artifacts.{PREVIEW_DOMAIN}/queries/data.json.gz")
+    report = _load_query_log_report().diff(current, baseline)
+    QUERIES_FILE.write_text(_render_queries(current, report))
+    print(f"wrote {QUERIES_FILE}: {len(report['added_shapes'])} new shapes")
+
+
+# ============================================================================
+# apply
+# ============================================================================
+
+
+def _approve(pr: PullRequest, body: str, fingerprint: str) -> None:
+    pr.create_review(body=f"{body}\n\n{marker(fingerprint, 'approve')}", event="APPROVE")
+    print(f"approved #{pr.number}")
+
+
+def _comment(pr: PullRequest, body: str, fingerprint: str) -> None:
+    # Deliberately COMMENT rather than REQUEST_CHANGES: the bot should be able to say a change looks wrong without
+    # taking the merge button away from the people who can tell whether it is.
+    pr.create_review(body=f"{body}\n\n{marker(fingerprint, 'comment')}", event="COMMENT")
+    print(f"commented on #{pr.number}")
+
+
+def _render_review(verdict: dict[str, Any], approved: bool, blockers: list[str]) -> str:
+    lines = ["### Code review bot", "", str(verdict.get("summary", "")).strip(), ""]
+
+    findings = verdict.get("findings") or []
+    if findings:
+        lines += ["#### Findings", ""]
+        for finding in findings:
+            severity = str(finding.get("severity", "note")).upper()
+            where = f" (`{finding['file']}`)" if finding.get("file") else ""
+            lines.append(f"- **{severity}**{where}: {str(finding.get('description', '')).strip()}")
+        lines.append("")
+
+    if approved:
+        lines += ["Approved: a code owner made a small change with nothing outstanding against it.", ""]
+    elif verdict.get("verdict") == "approve" and blockers:
+        lines += ["The review found nothing outstanding, but this PR cannot be approved automatically:", ""]
+        lines += [f"- {blocker}" for blocker in blockers]
+        lines += ["", "It needs a human reviewer.", ""]
+    return "\n".join(lines).strip()
+
+
+def cmd_apply() -> None:
+    _, pr, _ = _client()
+    # From the gate's step outputs, not from a file: the review cannot reach these. See _set_outputs.
+    fingerprint = os.environ.get("FINGERPRINT", "")
+    eligible = os.environ["AUTO_STAMP_ELIGIBLE"] == "true"
+    blockers = json.loads(os.environ.get("STAMP_BLOCKERS") or "[]")
+
+    if not VERDICT_FILE.exists():
+        print(f"{VERDICT_FILE} missing, the review did not finish; leaving the PR alone")
+        return
+
+    verdict = json.loads(VERDICT_FILE.read_text())
+    print(f"verdict={verdict.get('verdict')} eligible={eligible} architectural={verdict.get('architectural_change')}")
+
+    approved = may_approve(verdict, eligible)
+    body = _render_review(verdict, approved, blockers)
+
+    if not fingerprint:
+        # Without a fingerprint the next run cannot tell a rebase from a real change, so it will just review again.
+        print("no fingerprint available, this review will not be reusable after a rebase")
+
+    if approved:
+        _approve(pr, body, fingerprint)
+    else:
+        _comment(pr, body, fingerprint)
+
+
+# ============================================================================
+# Main Entry Point
+# ============================================================================
+
+COMMANDS = {"gate": cmd_gate, "query-diff": cmd_query_diff, "apply": cmd_apply}
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=COMMANDS)
+    COMMANDS[parser.parse_args().command]()

--- a/.github/llm-bot/pr_review_rules.py
+++ b/.github/llm-bot/pr_review_rules.py
@@ -1,0 +1,294 @@
+"""
+Deterministic rules for the PR review bot.
+
+Everything in here is pure: no network, no GitHub, no LLM. The bot gathers facts about a pull request, feeds them to
+`gate()`, and gets back a decision about whether to skip the PR, approve it outright, or spend an LLM review on it.
+Keeping the rules pure is what makes them testable, and the auto-approve paths are exactly the ones that should not
+depend on a model's mood.
+
+The gate answers two separate questions:
+
+  what to do now      skip / approve unchanged / run a review
+  what may follow     whether an approval is even permitted once the review comes back
+
+The second is `auto_stamp_eligible`. A review can never approve a PR the gate did not already mark eligible, so
+widening what the bot will stamp is a change to this file, not to a prompt.
+"""
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+# Authors whose PRs are machine-generated and reviewed by their own workflow.
+SKIP_AUTHORS = {"CouchersBot", "couchersbot", "couchersbot[bot]", "weblate"}
+
+# Paths where a change is never small enough to stamp on size alone, either because it is hard to reverse once
+# merged (migrations, proto field numbers), because it decides who can do what (auth, crypto, visibility), or
+# because it changes what CI itself does and so could disable the checks the stamp leans on.
+SENSITIVE_PATTERNS = (
+    "/app/backend/src/couchers/migrations/",
+    "/app/proto/",
+    "/app/backend/proto/",
+    "/app/backend/src/couchers/models/",
+    "/app/backend/src/couchers/crypto.py",
+    "/app/backend/src/couchers/sql.py",
+    "/app/backend/src/couchers/servicers/auth.py",
+    "/app/backend/src/couchers/interceptors.py",
+    "/app/deployment/",
+    "/.github/",
+    "/.gitlab-ci.yml",
+    "/app/.gitlab-ci.yml",
+    "**/pyproject.toml",
+    "**/uv.lock",
+    "**/package.json",
+    "**/yarn.lock",
+)
+
+# A stamp is for a change a reviewer would skim, not read. Past this, a human looks.
+MAX_STAMP_FILES = 10
+MAX_STAMP_LINES = 150
+
+# Marker left in the bot's own comment so a later run can recognise its previous verdict. The fingerprint is what
+# rebase detection compares against.
+MARKER_RE = re.compile(r"<!--\s*code-review-bot\s+fingerprint=(?P<fingerprint>[0-9a-f]{64})\s+verdict=(?P<verdict>\w+)\s*-->")
+
+
+def marker(fingerprint: str, verdict: str) -> str:
+    return f"<!-- code-review-bot fingerprint={fingerprint} verdict={verdict} -->"
+
+
+def parse_marker(body: str) -> tuple[str, str] | None:
+    """Pull (fingerprint, verdict) back out of a previous bot comment, or None if this isn't one."""
+    match = MARKER_RE.search(body or "")
+    return (match["fingerprint"], match["verdict"]) if match else None
+
+
+# ============================================================================
+# Patch fingerprinting
+# ============================================================================
+
+_INDEX_RE = re.compile(r"^index [0-9a-f]+\.\.[0-9a-f]+.*$")
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@")
+
+
+def normalise_patch(patch: str) -> str:
+    """Strip the parts of a diff that a rebase moves but a code change does not.
+
+    GitHub serves a PR's diff against the merge base, so rebasing onto a newer develop, or merging develop in, leaves
+    the diff identical as long as no line actually changed. Two things still shift: blob hashes on the `index` lines,
+    and the line numbers in hunk headers. Both are dropped here.
+
+    The text after a hunk header (the enclosing function git guesses at) is deliberately kept, as is every context
+    line. Those do change when develop edits the surrounding code, which makes the fingerprint conservative: it can
+    say "this differs" about a rebase that touched nothing, and the PR then gets a normal review. It cannot say
+    "unchanged" about a diff whose content moved, which is the direction that matters.
+    """
+    lines = []
+    for line in patch.splitlines():
+        if _INDEX_RE.match(line):
+            continue
+        lines.append(_HUNK_RE.sub("@@", line))
+    return "\n".join(lines)
+
+
+def patch_fingerprint(patch: str) -> str:
+    return hashlib.sha256(normalise_patch(patch).encode()).hexdigest()
+
+
+# ============================================================================
+# CODEOWNERS
+# ============================================================================
+
+
+def _translate(body: str) -> str:
+    """Convert the glob part of a CODEOWNERS pattern to a regex, gitignore-style."""
+    out = []
+    i = 0
+    while i < len(body):
+        if body.startswith("**/", i):
+            out.append("(?:.*/)?")
+            i += 3
+        elif body.startswith("**", i):
+            out.append(".*")
+            i += 2
+        elif body[i] == "*":
+            out.append("[^/]*")
+            i += 1
+        elif body[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(body[i]))
+            i += 1
+    return "".join(out)
+
+
+def compile_pattern(pattern: str) -> re.Pattern[str]:
+    """Compile one CODEOWNERS path pattern against repo-root-relative paths (no leading slash).
+
+    A separator at the start or middle anchors the pattern to the repo root; otherwise it may match at any depth. A
+    trailing separator makes it a directory, matching everything beneath it.
+    """
+    directory = pattern.endswith("/")
+    anchored = pattern.startswith("/") or "/" in pattern.rstrip("/")
+    body = pattern.strip("/")
+    prefix = "" if anchored else "(?:.*/)?"
+    suffix = "/.*$" if directory else "$"
+    return re.compile(f"^{prefix}{_translate(body)}{suffix}")
+
+
+@dataclass(frozen=True)
+class Codeowners:
+    """The CODEOWNERS file, as rules in file order."""
+
+    rules: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = ()
+
+    @classmethod
+    def parse(cls, text: str) -> "Codeowners":
+        rules = []
+        for raw in text.splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            pattern, *owners = line.split()
+            if not owners:
+                continue
+            rules.append((compile_pattern(pattern), frozenset(o.lstrip("@").lower() for o in owners)))
+        return cls(tuple(rules))
+
+    def owners_for(self, path: str) -> frozenset[str]:
+        """Owners of one path. Only the last matching rule counts, which is how GitHub reads the file."""
+        owners: frozenset[str] = frozenset()
+        for pattern, rule_owners in self.rules:
+            if pattern.match(path):
+                owners = rule_owners
+        return owners
+
+    def owns_all(self, login: str, teams: frozenset[str], paths: list[str]) -> bool:
+        """Whether `login` (or one of their `teams`, as `org/team` slugs) owns every one of `paths`.
+
+        Every path, not any: a PR that reaches outside what its author owns is not one to stamp.
+        """
+        if not paths:
+            return False
+        identities = {login.lower()} | {t.lower() for t in teams}
+        return all(self.owners_for(path) & identities for path in paths)
+
+
+# ============================================================================
+# Facts and decisions
+# ============================================================================
+
+
+class Action(str, Enum):
+    SKIP = "skip"
+    APPROVE_UNCHANGED = "approve_unchanged"
+    REVIEW = "review"
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    path: str
+    additions: int = 0
+    deletions: int = 0
+
+
+@dataclass(frozen=True)
+class PullRequestFacts:
+    author: str
+    draft: bool
+    files: list[ChangedFile]
+    fingerprint: str | None
+    author_teams: frozenset[str] = frozenset()
+    codeowners: Codeowners = field(default_factory=Codeowners)
+    # (fingerprint, verdict) from the bot's most recent review of this PR, if it has one.
+    previous: tuple[str, str] | None = None
+
+    @property
+    def paths(self) -> list[str]:
+        return [f.path for f in self.files]
+
+    @property
+    def changed_lines(self) -> int:
+        return sum(f.additions + f.deletions for f in self.files)
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    action: Action
+    reason: str
+    auto_stamp_eligible: bool = False
+    # Why a stamp is off the table, for the PR comment. Empty when eligible.
+    stamp_blockers: tuple[str, ...] = ()
+
+
+def sensitive_paths(paths: list[str]) -> list[str]:
+    patterns = [compile_pattern(p) for p in SENSITIVE_PATTERNS]
+    return [p for p in paths if any(pattern.match(p) for pattern in patterns)]
+
+
+def stamp_blockers(facts: PullRequestFacts) -> tuple[str, ...]:
+    """Every deterministic reason this PR may not be auto-approved. Empty means a clean review is allowed to stamp."""
+    blockers = []
+    if not facts.codeowners.owns_all(facts.author, facts.author_teams, facts.paths):
+        blockers.append(f"@{facts.author} is not a code owner of every changed path")
+    sensitive = sensitive_paths(facts.paths)
+    if sensitive:
+        shown = ", ".join(f"`{p}`" for p in sensitive[:5])
+        more = f" (+{len(sensitive) - 5} more)" if len(sensitive) > 5 else ""
+        blockers.append(f"touches paths that always need a human: {shown}{more}")
+    if len(facts.files) > MAX_STAMP_FILES:
+        blockers.append(f"{len(facts.files)} files changed, over the {MAX_STAMP_FILES} file limit")
+    if facts.changed_lines > MAX_STAMP_LINES:
+        blockers.append(f"{facts.changed_lines} lines changed, over the {MAX_STAMP_LINES} line limit")
+    return tuple(blockers)
+
+
+def may_approve(verdict: dict, auto_stamp_eligible: bool) -> bool:
+    """Whether a review's verdict may be turned into an approval.
+
+    Every condition can only subtract. `auto_stamp_eligible` comes from the gate and is the permission; the verdict
+    can decline to use it but can never supply it. The severity check is redundant against a review that follows its
+    instructions and belt-and-braces against one that says "approve" while listing something serious, which is the
+    failure mode with the worst consequences here.
+    """
+    if not auto_stamp_eligible or verdict.get("verdict") != "approve":
+        return False
+    if verdict.get("architectural_change", True):
+        return False
+    severities = {str(f.get("severity", "")).lower() for f in verdict.get("findings") or []}
+    return not severities & {"high", "medium"}
+
+
+def gate(facts: PullRequestFacts) -> GateDecision:
+    """Decide what to do with a pull request before any model has looked at it."""
+    if facts.draft:
+        return GateDecision(Action.SKIP, "pull request is a draft")
+
+    if facts.author in SKIP_AUTHORS:
+        return GateDecision(Action.SKIP, f"@{facts.author} is an automation account")
+
+    if not facts.files:
+        return GateDecision(Action.SKIP, "no files changed")
+
+    # A rebase, or a merge of develop, leaves the diff against the merge base untouched. Nothing about the previous
+    # review has been invalidated, so repeat it rather than paying for it again. GitHub dismisses approvals on push
+    # when a branch is configured to, so re-approving here is what actually unblocks the merge.
+    if facts.previous and facts.fingerprint and facts.previous[0] == facts.fingerprint:
+        previous_verdict = facts.previous[1]
+        if previous_verdict == "approve":
+            return GateDecision(Action.APPROVE_UNCHANGED, "no code changes since the last review (rebase or merge only)")
+        return GateDecision(Action.SKIP, f"no code changes since the last review, which said `{previous_verdict}`")
+
+    blockers = stamp_blockers(facts)
+    return GateDecision(
+        Action.REVIEW,
+        "changed since the last review" if facts.previous else "not yet reviewed",
+        auto_stamp_eligible=not blockers,
+        stamp_blockers=blockers,
+    )

--- a/.github/llm-bot/pyproject.toml
+++ b/.github/llm-bot/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
     "pygithub>=2.8.1",
     "requests>=2.32.5",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/.github/llm-bot/test_pr_review_rules.py
+++ b/.github/llm-bot/test_pr_review_rules.py
@@ -1,0 +1,271 @@
+"""Tests for the PR review bot's deterministic rules. These decide what gets approved without a human, so they are
+worth pinning down: everything the model contributes is downstream of them."""
+
+import pytest
+
+from pr_review_rules import (
+    Action,
+    ChangedFile,
+    Codeowners,
+    PullRequestFacts,
+    compile_pattern,
+    gate,
+    marker,
+    may_approve,
+    normalise_patch,
+    parse_marker,
+    patch_fingerprint,
+    sensitive_paths,
+    stamp_blockers,
+)
+
+# The real file, so the tests fail if its semantics are ever misread.
+COUCHERS_CODEOWNERS = """
+# Only the last matching line's owners are added to the PR
+* @aapeliv
+/app/**/locales/*.json @tristanlabelle # Watch Weblate integrations
+/app/web/ @nabramow
+/docs/ @aapeliv @nabramow
+"""
+
+PATCH = """diff --git a/app/backend/src/couchers/servicers/api.py b/app/backend/src/couchers/servicers/api.py
+index 1111111..2222222 100644
+--- a/app/backend/src/couchers/servicers/api.py
++++ b/app/backend/src/couchers/servicers/api.py
+@@ -120,7 +120,7 @@ class API(api_pb2_grpc.APIServicer):
+     def Ping(self, request, context, session):
+-        return api_pb2.PingRes(user_id=context.user_id)
++        return api_pb2.PingRes(user_id=context.user_id, unseen=0)
+"""
+
+
+def facts(**kwargs) -> PullRequestFacts:
+    defaults = dict(
+        author="aapeliv",
+        draft=False,
+        files=[ChangedFile("app/backend/src/couchers/servicers/api.py", 3, 1)],
+        fingerprint="a" * 64,
+        codeowners=Codeowners.parse(COUCHERS_CODEOWNERS),
+    )
+    return PullRequestFacts(**{**defaults, **kwargs})
+
+
+# ============================================================================
+# Patch fingerprinting
+# ============================================================================
+
+
+def test_rebase_does_not_change_the_fingerprint():
+    """A rebase moves blob hashes and hunk line numbers without touching a line of code."""
+    rebased = PATCH.replace("index 1111111..2222222", "index 3333333..4444444").replace(
+        "@@ -120,7 +120,7 @@", "@@ -137,7 +137,7 @@"
+    )
+    assert patch_fingerprint(rebased) == patch_fingerprint(PATCH)
+
+
+def test_changing_a_line_changes_the_fingerprint():
+    assert patch_fingerprint(PATCH.replace("unseen=0", "unseen=1")) != patch_fingerprint(PATCH)
+
+
+def test_changing_a_context_line_changes_the_fingerprint():
+    """Conservative by design: develop editing the surrounding code costs a re-review, it does not skip one."""
+    moved = PATCH.replace("    def Ping(self, request, context, session):", "    def Ping(self, request, context):")
+    assert patch_fingerprint(moved) != patch_fingerprint(PATCH)
+
+
+def test_normalise_keeps_the_hunk_heading():
+    normalised = normalise_patch(PATCH)
+    assert "@@ class API(api_pb2_grpc.APIServicer):" in normalised
+    assert "index 1111111" not in normalised
+
+
+def test_marker_round_trips():
+    assert parse_marker(f"some review text\n\n{marker('b' * 64, 'approve')}") == ("b" * 64, "approve")
+
+
+def test_a_comment_without_a_marker_is_not_ours():
+    assert parse_marker("Looks good to me!") is None
+
+
+# ============================================================================
+# CODEOWNERS
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("pattern", "path", "matches"),
+    [
+        ("*", "app/backend/src/couchers/models/user.py", True),
+        ("/app/web/", "app/web/features/profile/Profile.tsx", True),
+        ("/app/web/", "app/backend/x.py", False),
+        ("/app/web/", "app/web", False),
+        ("/app/**/locales/*.json", "app/web/features/auth/locales/en.json", True),
+        ("/app/**/locales/*.json", "app/web/features/auth/locales/nested/en.json", False),
+        ("/docs/", "docs/query-log.md", True),
+        ("app/backend/**", "app/backend/src/couchers/sql.py", True),
+        ("app/backend/**", "app/web/src/x.ts", False),
+        ("**/uv.lock", "app/backend/uv.lock", True),
+        ("**/uv.lock", "uv.lock", True),
+    ],
+)
+def test_pattern_matching(pattern, path, matches):
+    assert bool(compile_pattern(pattern).match(path)) is matches
+
+
+def test_only_the_last_matching_rule_counts():
+    owners = Codeowners.parse(COUCHERS_CODEOWNERS)
+    assert owners.owners_for("app/backend/src/couchers/sql.py") == {"aapeliv"}
+    # `/app/web/` comes after `*`, so aapeliv is not an owner of web files.
+    assert owners.owners_for("app/web/features/profile/Profile.tsx") == {"nabramow"}
+    assert owners.owners_for("docs/query-log.md") == {"aapeliv", "nabramow"}
+    assert owners.owners_for("app/web/features/auth/locales/en.json") == {"nabramow"}
+
+
+def test_comments_and_blank_lines_are_ignored():
+    assert len(Codeowners.parse(COUCHERS_CODEOWNERS).rules) == 4
+
+
+def test_owns_all_needs_every_path():
+    owners = Codeowners.parse(COUCHERS_CODEOWNERS)
+    assert owners.owns_all("aapeliv", frozenset(), ["app/backend/a.py", "docs/b.md"])
+    assert not owners.owns_all("aapeliv", frozenset(), ["app/backend/a.py", "app/web/b.tsx"])
+    assert not owners.owns_all("aapeliv", frozenset(), [])
+
+
+def test_team_membership_resolves_ownership():
+    owners = Codeowners.parse("/app/backend/ @Couchers-org/backend")
+    assert owners.owns_all("someone", frozenset({"couchers-org/backend"}), ["app/backend/a.py"])
+    assert not owners.owns_all("someone", frozenset(), ["app/backend/a.py"])
+
+
+# ============================================================================
+# Stamp eligibility
+# ============================================================================
+
+
+def test_sensitive_paths_are_found():
+    assert sensitive_paths(["app/backend/src/couchers/migrations/versions/0123_x.py"])
+    assert sensitive_paths(["app/proto/api.proto"])
+    assert sensitive_paths(["app/backend/src/couchers/models/user.py"])
+    assert sensitive_paths([".github/workflows/code-review.yml"])
+    assert sensitive_paths(["app/web/yarn.lock"])
+    assert not sensitive_paths(["app/backend/src/couchers/servicers/api.py"])
+
+
+def test_a_small_owned_change_may_be_stamped():
+    assert stamp_blockers(facts()) == ()
+
+
+def test_a_migration_may_never_be_stamped():
+    blockers = stamp_blockers(facts(files=[ChangedFile("app/backend/src/couchers/migrations/versions/0123_x.py", 8, 0)]))
+    assert any("always need a human" in b for b in blockers)
+
+
+def test_a_non_owner_may_not_be_stamped():
+    blockers = stamp_blockers(facts(author="someone-else"))
+    assert any("not a code owner" in b for b in blockers)
+
+
+def test_a_large_change_may_not_be_stamped():
+    blockers = stamp_blockers(facts(files=[ChangedFile("app/backend/src/couchers/servicers/api.py", 400, 20)]))
+    assert any("over the" in b and "line limit" in b for b in blockers)
+
+
+def test_many_files_may_not_be_stamped():
+    blockers = stamp_blockers(facts(files=[ChangedFile(f"app/backend/src/couchers/servicers/s{i}.py", 1, 1) for i in range(20)]))
+    assert any("file limit" in b for b in blockers)
+
+
+# ============================================================================
+# The gate
+# ============================================================================
+
+
+def test_drafts_are_left_alone():
+    assert gate(facts(draft=True)).action == Action.SKIP
+
+
+def test_automation_accounts_are_left_alone():
+    assert gate(facts(author="CouchersBot")).action == Action.SKIP
+
+
+def test_an_empty_pull_request_is_left_alone():
+    assert gate(facts(files=[])).action == Action.SKIP
+
+
+def test_an_unchanged_diff_repeats_a_previous_approval():
+    """The rebase case: GitHub dismissed the approval on push, but nothing about the code changed."""
+    decision = gate(facts(fingerprint="c" * 64, previous=("c" * 64, "approve")))
+    assert decision.action == Action.APPROVE_UNCHANGED
+
+
+def test_an_unchanged_diff_does_not_manufacture_an_approval():
+    """A rebase must not upgrade a previous review that was not an approval."""
+    decision = gate(facts(fingerprint="c" * 64, previous=("c" * 64, "comment")))
+    assert decision.action == Action.SKIP
+
+
+def test_a_changed_diff_is_reviewed_again():
+    assert gate(facts(fingerprint="c" * 64, previous=("d" * 64, "approve"))).action == Action.REVIEW
+
+
+def test_an_unfingerprintable_diff_is_reviewed():
+    """No fingerprint means no way to tell a rebase from a rewrite, so the PR gets reviewed."""
+    assert gate(facts(fingerprint=None, previous=("c" * 64, "approve"))).action == Action.REVIEW
+
+
+def test_a_codeowner_making_a_small_change_is_eligible_for_a_stamp():
+    decision = gate(facts())
+    assert decision.action == Action.REVIEW
+    assert decision.auto_stamp_eligible
+
+
+def test_a_contributor_is_reviewed_but_not_eligible():
+    decision = gate(facts(author="new-contributor"))
+    assert decision.action == Action.REVIEW
+    assert not decision.auto_stamp_eligible
+    assert decision.stamp_blockers
+
+
+# ============================================================================
+# Approval authority
+# ============================================================================
+
+CLEAN = {"verdict": "approve", "architectural_change": False, "summary": "Fine.", "findings": []}
+
+
+def test_a_clean_verdict_on_an_eligible_pr_approves():
+    assert may_approve(CLEAN, auto_stamp_eligible=True)
+
+
+def test_the_review_cannot_approve_what_the_gate_did_not_permit():
+    """The whole point of the split: a glowing verdict on a migration is still not an approval."""
+    assert not may_approve(CLEAN, auto_stamp_eligible=False)
+
+
+def test_an_architectural_change_is_not_approved():
+    assert not may_approve({**CLEAN, "architectural_change": True}, auto_stamp_eligible=True)
+
+
+def test_a_missing_architectural_flag_is_read_as_architectural():
+    assert not may_approve({"verdict": "approve", "findings": []}, auto_stamp_eligible=True)
+
+
+@pytest.mark.parametrize("severity", ["high", "medium", "HIGH", "Medium"])
+def test_a_serious_finding_overrides_an_approve_verdict(severity):
+    """Belt and braces: the verdict says approve but contradicts itself."""
+    verdict = {**CLEAN, "findings": [{"severity": severity, "description": "off by one"}]}
+    assert not may_approve(verdict, auto_stamp_eligible=True)
+
+
+def test_a_low_severity_suggestion_does_not_block_approval():
+    verdict = {**CLEAN, "findings": [{"severity": "low", "description": "could be tidier"}]}
+    assert may_approve(verdict, auto_stamp_eligible=True)
+
+
+def test_a_comment_verdict_is_not_an_approval():
+    assert not may_approve({**CLEAN, "verdict": "comment"}, auto_stamp_eligible=True)
+
+
+def test_an_empty_verdict_is_not_an_approval():
+    assert not may_approve({}, auto_stamp_eligible=True)

--- a/.github/llm-bot/uv.lock
+++ b/.github/llm-bot/uv.lock
@@ -224,6 +224,11 @@ dependencies = [
     { name = "requests" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "a5", specifier = ">=0.0.16" },
@@ -232,6 +237,9 @@ requires-dist = [
     { name = "pygithub", specifier = ">=2.8.1" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "h11"
@@ -277,6 +285,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -347,6 +364,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/51/a2/f4023c1e0c868a6a5854955b3374f17153388aed95e835af114a17eac95b/openai-2.7.1.tar.gz", hash = "sha256:df4d4a3622b2df3475ead8eb0fbb3c27fd1c070fa2e55d778ca4f40e0186c726", size = 595933, upload-time = "2025-11-04T06:07:23.069Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/74/6bfc3adc81f6c2cea4439f2a734c40e3a420703bbcdc539890096a732bbd/openai-2.7.1-py3-none-any.whl", hash = "sha256:2f2530354d94c59c614645a4662b9dab0a5b881c5cd767a8587398feac0c9021", size = 1008780, upload-time = "2025-11-04T06:07:20.818Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -443,6 +478,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -491,6 +535,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/2c/ee0b373a1861f66a7ca8bdb999331525615061320dd628527a50ba8e8a60/pynacl-1.6.0-cp38-abi3-win32.whl", hash = "sha256:dcdeb41c22ff3c66eef5e63049abf7639e0db4edee57ba70531fc1b6b133185d", size = 226461, upload-time = "2025-09-10T23:39:11.894Z" },
     { url = "https://files.pythonhosted.org/packages/75/f7/41b6c0b9dd9970173b6acc026bab7b4c187e4e5beef2756d419ad65482da/pynacl-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:cf831615cc16ba324240de79d925eacae8265b7691412ac6b24221db157f6bd1", size = 238802, upload-time = "2025-09-10T23:39:08.966Z" },
     { url = "https://files.pythonhosted.org/packages/8e/0f/462326910c6172fa2c6ed07922b22ffc8e77432b3affffd9e18f444dbfbb/pynacl-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:84709cea8f888e618c21ed9a0efdb1a59cc63141c403db8bf56c469b71ad56f2", size = 183846, upload-time = "2025-09-10T23:39:10.552Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,36 +1,191 @@
-name: Claude Auto Review
+name: Code Review Bot
+
+# Deterministic rules decide what happens to a PR; the model only ever supplies an opinion for those rules to act on.
+# See .github/llm-bot/pr_review_bot.py for why the two are kept apart.
+#
+# This runs on pull_request_target, so it holds a token that can approve pull requests even when the PR comes from a
+# fork. The PR's code is checked out, read-only, into pr-head/ so the review can read changed files in full rather
+# than squinting at diff hunks. Nothing ever executes it: no install step runs against it, and the review's Bash
+# access is restricted to two `gh` subcommands. Do not add a step that runs anything out of pr-head/, and do not
+# widen allowedTools to a general Bash, or a fork gains the token that approves its own pull request.
+#
+# pull_request_target also means this file is always read from the base branch, so a PR cannot edit the workflow that
+# reviews it. `.github/**` is in the bot's sensitive-path list besides, so such a PR can never be auto-approved.
+
 on:
   pull_request_target:
-    types: [review_requested]
+    types: [opened, synchronize, ready_for_review]
+
+concurrency:
+  group: code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review:
-    if: github.event.requested_reviewer.login == 'couchersbot'
     runs-on: ubuntu-latest
+    # Generous, because the SQL step waits for GitLab to publish this commit's query log.
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
+      - name: Check out the base branch
+        uses: actions/checkout@v5
 
-      - uses: anthropics/claude-code-action@v1
+      # Read-only copy of the PR's own code, for the review to read. Never executed; see the note at the top.
+      - name: Check out the pull request's code
+        uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-head
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: ".github/llm-bot/.python-version"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install dependencies
+        run: uv sync --locked --all-extras --dev
+        working-directory: .github/llm-bot
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      # Applies the deterministic rules. Approves rebase-only pushes itself and stops there; otherwise it writes
+      # pr-review-context.md for the review to read and reports whether an approval is permitted at all.
+      - name: Gate
+        id: gate
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: uv run --project .github/llm-bot .github/llm-bot/pr_review_bot.py gate
+
+      - name: Diff the SQL the branch issues
+        if: steps.gate.outputs.action == 'review' && steps.gate.outputs.backend_touched == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: uv run --project .github/llm-bot .github/llm-bot/pr_review_bot.py query-diff
+
+      - name: Review
+        if: steps.gate.outputs.action == 'review'
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true # ✨ Enables tracking comments
+          additional_permissions: |
+            pull-requests: write
           prompt: |
+            You are the code review bot for Couchers.org, a non-profit couch surfing platform.
+
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            ## Where the code is
 
-            Provide detailed feedback using inline comments for specific issues.
+            There are two checkouts, and confusing them will make you review the wrong thing:
 
+            - The working directory is the BASE branch, without the PR's changes. Read files here for surrounding
+              context: models, callers, existing conventions.
+            - `pr-head/` is the same repository at the PR's head commit, so `pr-head/app/backend/...` is a changed
+              file as the PR leaves it. Read files here to see a change in full rather than as diff hunks.
+
+            Get the change itself with `gh pr diff ${{ github.event.pull_request.number }}`. Both checkouts are
+            shallow, so `git diff` and `git log` will tell you nothing useful.
+
+            When you report a finding or post an inline comment, name the path WITHOUT the `pr-head/` prefix — that
+            prefix is an artefact of this checkout and means nothing to anyone reading the PR.
+
+            ## Context prepared for you
+
+            Read both of these first:
+
+            - `pr-review-context.md` — deterministic facts about the PR, already established. Do not re-derive them.
+            - `pr-review-queries.md` — the SQL this branch newly issues, if the PR touches the backend. Absent when it
+              does not.
+
+            The repository's CLAUDE.md describes this project's conventions. Follow it when judging whether code fits.
+
+            ## What to review
+
+            1. **Correctness.** Bugs, unhandled cases, mistakes in logic, misuse of an API, races, N+1 queries,
+               anything that will behave differently from what the change plainly intends.
+
+            2. **New SQL, carefully.** This is the part worth spending real effort on. For every new query shape in
+               `pr-review-queries.md`, and for every query you can see in the diff, work out what it actually does:
+               read the models it touches under `app/backend/src/couchers/models/` and check the joins, the filter
+               conditions, and the columns. Specifically:
+               - Does the query answer the question the calling code believes it answers?
+               - Are joins on the right columns, and is the cardinality what the caller expects? A join that fans out
+                 silently turns one row into many.
+               - Are deleted, banned and blocked users filtered out? This project requires `users_visible(context)`,
+                 `users_column_visible(context, column)` or `users_visible_to_each_other(...)` from `couchers.sql`,
+                 and never `User.is_visible` directly in a query.
+               - Is anything issued inside a loop that should have been one query?
+               - Are new queries hitting indexed columns, on tables that are large in production?
+               - Does a new query shape appear in many more tests than the change would suggest? That usually means a
+                 shared helper or fixture started issuing it.
+               If `pr-review-queries.md` says the log was not published in time, say so in your summary rather than
+               guessing, and review the queries visible in the diff.
+
+            3. **Whether the change is architectural.** Set `architectural_change` to true if the PR introduces a new
+               abstraction, changes a data model or an interface between components, changes how a subsystem is wired
+               together, alters authentication, authorisation or visibility rules, or would make a reviewer want to
+               discuss the approach rather than the code. Small, local, self-evident changes are not architectural.
+               When you are unsure, true is the safe answer.
+
+            Do not comment on formatting or style; linters and formatters already run in CI. Do not restate what the
+            diff does. Only raise things you would raise with a colleague.
+
+            ## Output
+
+            Post inline comments on specific problematic lines with
+            `mcp__github_inline_comment__create_inline_comment`. Keep them concrete and actionable.
+
+            Then write your verdict to `pr-review-verdict.json` in the current directory, exactly this shape:
+
+            ```json
+            {
+              "verdict": "approve",
+              "architectural_change": false,
+              "summary": "One to three sentences on what the PR does and how it looks. Markdown.",
+              "findings": [
+                {"severity": "high", "file": "app/backend/src/couchers/servicers/x.py", "description": "..."}
+              ]
+            }
+            ```
+
+            - `verdict` is `"approve"` only when you found nothing of `high` or `medium` severity and
+              `architectural_change` is false. Otherwise it is `"comment"`.
+            - `findings` lists only real problems, most serious first. An empty list is the expected result for a
+              clean PR — do not pad it.
+            - Severity is `high` for something that is wrong and will cause incorrect behaviour or data loss, `medium`
+              for something likely wrong or risky, `low` for a suggestion.
+
+            Writing this file is the last thing you do, and it is required. Something else decides what to do with
+            your verdict: you are not approving anything yourself, and you should not run `gh pr review`.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model opus
+            --allowedTools "Read,Glob,Grep,Write,Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"
+
+      # Turns the verdict into a review. Approves only where the gate already said an approval was permitted, which
+      # arrives as step outputs rather than as a file, so the review step cannot have tampered with it.
+      - name: Apply the verdict
+        if: steps.gate.outputs.action == 'review'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTO_STAMP_ELIGIBLE: ${{ steps.gate.outputs.auto_stamp_eligible }}
+          FINGERPRINT: ${{ steps.gate.outputs.fingerprint }}
+          STAMP_BLOCKERS: ${{ steps.gate.outputs.stamp_blockers }}
+        run: uv run --project .github/llm-bot .github/llm-bot/pr_review_bot.py apply


### PR DESCRIPTION
The code review bot has until now fired only when `couchersbot` was added as a reviewer, and did nothing beyond asking a model for inline comments. This reworks it to run on every push to a pull request, with deterministic Python rules — not the model — deciding what happens: drafts and automation authors are skipped, a push that only rebases or merges `develop` re-uses the previous verdict instead of paying for another review, and whether an approval is permitted at all is settled from CODEOWNERS ownership, a sensitive-path list and size limits before the model is invoked, so a review can spend that permission but never grant it. Backend PRs additionally get a diff of the SQL the branch newly issues, built from the query log the GitLab pipeline publishes, so new queries can be reviewed against the models they touch.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._
