### PR TITLE
Ignore the repo-root tmp/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ pyrightconfig.json
 !/.claude/tools/**
 !/.claude/skills/
 !/.claude/skills/**
+/tmp/


### PR DESCRIPTION
The root `.gitignore` already covers local scratch paths such as `/private/` so they don't show up as untracked noise. This adds `/tmp/` alongside them, keeping a scratch directory created at the repo root out of `git status`.

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._