### PR TITLE
Allow including the mod note text in the notification email

### DIFF
--- a/app/backend.dev.env
+++ b/app/backend.dev.env
@@ -35,6 +35,8 @@ SMS_SENDER_ID=invalid
 
 NOTIFICATION_EMAIL_SENDER=Couchers.org
 NOTIFICATION_EMAIL_ADDRESS=notify@couchers.org.invalid
+MODERATION_EMAIL_SENDER=Couchers.org Moderation
+MODERATION_EMAIL_ADDRESS=moderation@couchers.org.invalid
 NOTIFICATION_PREFIX='[DEV] '
 
 REPORTS_EMAIL_RECIPIENT=reports@couchers.org.invalid

--- a/app/backend/src/couchers/config.py
+++ b/app/backend/src/couchers/config.py
@@ -79,6 +79,10 @@ class Config:
     NOTIFICATION_EMAIL_SENDER: str
     # Sender email, e.g. "notify@couchers.org"
     NOTIFICATION_EMAIL_ADDRESS: str
+    # Sender name for moderation emails users can reply to
+    MODERATION_EMAIL_SENDER: str
+    # Sender email for moderation emails, a monitored mailbox users can reply to
+    MODERATION_EMAIL_ADDRESS: str
     # An optional prefix for email subject, e.g. [STAGING]
     NOTIFICATION_PREFIX: str = ""
     # Address to send emails about reported users

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -1662,21 +1662,21 @@ class HostReferenceReminderEmail(EmailBase):
 class ModeratorNoteEmail(EmailBase):
     """Sent to a user to notify them they have received a moderator note."""
 
-    # The note's markdown text, if the moderator chose to include it in the email.
-    note_content: str | None
+    # The note's text, only set if the moderator chose to include it in the email.
+    markdown_text: str | None
 
     @property
     def string_key_base(self) -> str:
         return "moderator_note"
 
     def get_preview_line(self, loc_context: LocalizationContext) -> str | None:
-        return markdown_to_plaintext(self.note_content) if self.note_content else None
+        return markdown_to_plaintext(self.markdown_text) if self.markdown_text else None
 
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        if self.note_content:
+        if self.markdown_text:
             builder.para(".purpose_with_note")
-            builder.quote(self.note_content, markdown=True)
+            builder.quote(self.markdown_text, markdown=True)
             builder.para(".acknowledge_request")
             builder.para(".reply_instructions")
         else:
@@ -1688,13 +1688,16 @@ class ModeratorNoteEmail(EmailBase):
 
     @classmethod
     def from_notification(cls, data: notification_data_pb2.ModNoteCreate, *, user_name: str) -> Self:
-        return cls(user_name=user_name, note_content=data.content or None)
+        return cls(user_name=user_name, markdown_text=data.markdown_text or None)
 
     @classmethod
     def test_instances(cls) -> list[Self]:
         return [
-            cls(user_name="Alice", note_content=None),
-            cls(user_name="Alice", note_content="Please **add** a profile photo so that your hosts can recognise you."),
+            cls(user_name="Alice", markdown_text=None),
+            cls(
+                user_name="Alice",
+                markdown_text="Please **add** a profile photo so that your hosts can recognise you.",
+            ),
         ]
 
 

--- a/app/backend/src/couchers/email/emails.py
+++ b/app/backend/src/couchers/email/emails.py
@@ -1662,21 +1662,40 @@ class HostReferenceReminderEmail(EmailBase):
 class ModeratorNoteEmail(EmailBase):
     """Sent to a user to notify them they have received a moderator note."""
 
+    # The note's markdown text, if the moderator chose to include it in the email.
+    note_content: str | None
+
     @property
     def string_key_base(self) -> str:
         return "moderator_note"
 
+    def get_preview_line(self, loc_context: LocalizationContext) -> str | None:
+        return markdown_to_plaintext(self.note_content) if self.note_content else None
+
     def get_body_blocks(self, loc_context: LocalizationContext) -> list[EmailBlock]:
         builder = self._body_builder(loc_context)
-        builder.para(".purpose")
+        if self.note_content:
+            builder.para(".purpose_with_note")
+            builder.quote(self.note_content, markdown=True)
+            builder.para(".acknowledge_request")
+            builder.para(".reply_instructions")
+        else:
+            builder.para(".purpose")
         # Users with moderator notes are "jailed": any URL will show the note before
         # letting them use the platform.
         builder.action(urls.dashboard_link(), ".view_action")
         return builder.build()
 
     @classmethod
+    def from_notification(cls, data: notification_data_pb2.ModNoteCreate, *, user_name: str) -> Self:
+        return cls(user_name=user_name, note_content=data.content or None)
+
+    @classmethod
     def test_instances(cls) -> list[Self]:
-        return [cls(user_name="Alice")]
+        return [
+            cls(user_name="Alice", note_content=None),
+            cls(user_name="Alice", note_content="Please **add** a profile photo so that your hosts can recognise you."),
+        ]
 
 
 @dataclass(kw_only=True, slots=True)

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -272,7 +272,7 @@
     "purpose": "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform.",
     "purpose_with_note": "You have received an important note from the moderators:",
     "acknowledge_request": "You must read and acknowledge this note before continuing to use the platform.",
-    "reply_instructions": "If you would like to respond, simply reply to this email and it will reach the moderation team.",
+    "reply_instructions": "You can respond to the moderation team by replying to this email.",
     "view_action": "View moderator note"
   },
   "new_blog_post": {

--- a/app/backend/src/couchers/email/locales/en.json
+++ b/app/backend/src/couchers/email/locales/en.json
@@ -270,6 +270,9 @@
   "moderator_note": {
     "subject": "You have received a moderator note",
     "purpose": "You have received an important note from the moderators. You must read and acknowledge it before continuing to use the platform.",
+    "purpose_with_note": "You have received an important note from the moderators:",
+    "acknowledge_request": "You must read and acknowledge this note before continuing to use the platform.",
+    "reply_instructions": "If you would like to respond, simply reply to this email and it will reach the moderation team.",
     "view_action": "View moderator note"
   },
   "new_blog_post": {

--- a/app/backend/src/couchers/i18n/admin_locales/en.json
+++ b/app/backend/src/couchers/i18n/admin_locales/en.json
@@ -18,6 +18,7 @@
     "invalid_started_volunteering_date": "Invalid start date for volunteering.",
     "invalid_stopped_volunteering_date": "Invalid end date for volunteering.",
     "missing_moderation_user_list_id": "Missing moderation user list id.",
+    "mod_note_notification_must_be_specified": "Whether and how to notify the user about the mod note must be specified.",
     "moderation_user_list_not_found": "Moderation user list not found.",
     "no_multipolygon": "GeoJson was not of type MultiPolygon.",
     "note_cant_be_empty": "The admin note cannot be empty.",

--- a/app/backend/src/couchers/models/notifications.py
+++ b/app/backend/src/couchers/models/notifications.py
@@ -156,7 +156,7 @@ class NotificationTopicAction(enum.Enum):
 
     onboarding__reminder = ("onboarding:reminder", dt_sec, False, empty_pb2.Empty)
 
-    modnote__create = ("modnote:create", dt_sec, True, empty_pb2.Empty)
+    modnote__create = ("modnote:create", dt_sec, True, nd.ModNoteCreate)
 
     verification__sv_fail = ("verification:sv_fail", dt_sec, True, nd.VerificationSVFail)
     verification__sv_success = ("verification:sv_success", dt_sec, True, empty_pb2.Empty)

--- a/app/backend/src/couchers/notifications/render_email.py
+++ b/app/backend/src/couchers/notifications/render_email.py
@@ -126,7 +126,7 @@ def get_notification_email(notification: Notification, *, user_name: str) -> Ema
         case NotificationTopicAction.general__new_blog_post:
             return emails.NewBlogPostEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.modnote__create:
-            return emails.ModeratorNoteEmail(user_name=user_name)
+            return emails.ModeratorNoteEmail.from_notification(data, user_name=user_name)
         case NotificationTopicAction.onboarding__reminder:
             return emails.OnboardingReminderEmail(user_name=user_name, initial=notification.key == "1")
         case NotificationTopicAction.password__change:
@@ -170,6 +170,9 @@ def get_notification_email(notification: Notification, *, user_name: str) -> Ema
 
 def get_email_sender(notification: Notification) -> Address:
     """Gets the address the email is sent from, which a notification can override to e.g. a monitored mailbox."""
+    if notification.topic_action == NotificationTopicAction.modnote__create:
+        # Moderator notes come from the moderation mailbox so that users can reply to them.
+        return Address(config.MODERATION_EMAIL_SENDER, addr_spec=config.MODERATION_EMAIL_ADDRESS)
     return Address(config.NOTIFICATION_EMAIL_SENDER, addr_spec=config.NOTIFICATION_EMAIL_ADDRESS)
 
 

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -717,7 +717,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
                 topic_action=NotificationTopicAction.modnote__create,
                 key="",
                 data=notification_data_pb2.ModNoteCreate(
-                    content=(
+                    markdown_text=(
                         request.content
                         if request.notification == admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY_WITH_CONTENT
                         else ""

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -126,6 +126,13 @@ nonvisibleuserstate2api = {
     NonvisibleUserState.deleted: admin_pb2.NONVISIBLE_USER_STATE_DELETED,
 }
 
+# Doubles as the set of accepted values: MOD_NOTE_NOTIFICATION_UNSPECIFIED is rejected.
+_MOD_NOTE_NOTIFY_LOG_LABELS = {
+    admin_pb2.MOD_NOTE_NOTIFICATION_NONE: "No",
+    admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY: "Yes",
+    admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY_WITH_CONTENT: "Yes, including the note text",
+}
+
 
 def log_admin_action(
     session: Session,
@@ -679,6 +686,10 @@ class Admin(admin_pb2_grpc.AdminServicer):
     def SendModNote(
         self, request: admin_pb2.SendModNoteReq, context: CouchersContext, session: Session
     ) -> admin_pb2.UserDetails:
+        if request.notification not in _MOD_NOTE_NOTIFY_LOG_LABELS:
+            context.abort_with_error_code(
+                grpc.StatusCode.INVALID_ARGUMENT, "admin:mod_note_notification_must_be_specified"
+            )
         user = session.execute(select(User).where(username_or_email_or_id(request.user))).scalar_one_or_none()
         if not user:
             context.abort_with_error_code(grpc.StatusCode.NOT_FOUND, "user_not_found")
@@ -691,21 +702,27 @@ class Admin(admin_pb2_grpc.AdminServicer):
             )
         )
         session.flush()
-        notify_user = "No" if request.do_not_notify else "Yes"
         log_admin_action(
             session,
             context,
             user,
             "send_mod_note",
-            note=f"Notify user: {notify_user}\n\n{request.content}",
+            note=f"Notify user: {_MOD_NOTE_NOTIFY_LOG_LABELS[request.notification]}\n\n{request.content}",
         )
 
-        if not request.do_not_notify:
+        if request.notification != admin_pb2.MOD_NOTE_NOTIFICATION_NONE:
             notify(
                 session,
                 user_id=user.id,
                 topic_action=NotificationTopicAction.modnote__create,
                 key="",
+                data=notification_data_pb2.ModNoteCreate(
+                    content=(
+                        request.content
+                        if request.notification == admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY_WITH_CONTENT
+                        else ""
+                    ),
+                ),
             )
 
         return _user_to_details(session, user)

--- a/app/backend/src/tests/conftest.py
+++ b/app/backend/src/tests/conftest.py
@@ -311,6 +311,8 @@ def testconfig():
     config.ENABLE_EMAIL = False
     config.NOTIFICATION_EMAIL_SENDER = "Couchers.org"
     config.NOTIFICATION_EMAIL_ADDRESS = "notify@couchers.org.invalid"
+    config.MODERATION_EMAIL_SENDER = "Couchers.org Moderation"
+    config.MODERATION_EMAIL_ADDRESS = "moderation@couchers.org.invalid"
     config.NOTIFICATION_PREFIX = "[TEST] "
     config.REPORTS_EMAIL_RECIPIENT = "reports@couchers.org.invalid"
     config.CONTRIBUTOR_FORM_EMAIL_RECIPIENT = "forms@couchers.org.invalid"

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1423,7 +1423,10 @@ def test_admin_actions_on_mutations(db, push_collector: PushCollector):
         # SendModNote with notify
         res = api.SendModNote(
             admin_pb2.SendModNoteReq(
-                user=normal_user.username, content="Please update your profile", internal_id="test1"
+                user=normal_user.username,
+                content="Please update your profile",
+                internal_id="test1",
+                notification=admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY,
             )
         )
         assert any(
@@ -1431,17 +1434,31 @@ def test_admin_actions_on_mutations(db, push_collector: PushCollector):
             for a in res.admin_actions
         )
 
-        # SendModNote with do_not_notify
+        # SendModNote without notifying
         res = api.SendModNote(
             admin_pb2.SendModNoteReq(
                 user=normal_user.username,
                 content="Silent note",
                 internal_id="test2",
-                do_not_notify=True,
+                notification=admin_pb2.MOD_NOTE_NOTIFICATION_NONE,
             )
         )
         assert any(
             a.action_type == "send_mod_note" and a.note == "Notify user: No\n\nSilent note" for a in res.admin_actions
+        )
+
+        # SendModNote including the note text in the email
+        res = api.SendModNote(
+            admin_pb2.SendModNoteReq(
+                user=normal_user.username,
+                content="Emailed note",
+                internal_id="test3",
+                notification=admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY_WITH_CONTENT,
+            )
+        )
+        assert any(
+            a.action_type == "send_mod_note" and a.note == "Notify user: Yes, including the note text\n\nEmailed note"
+            for a in res.admin_actions
         )
 
         # DeleteUser

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -373,7 +373,7 @@ def test_modnotes_notify_with_content(db, email_collector: EmailCollector, push_
     assert email.sender_email == "moderation@couchers.org.invalid"
     assert "Please remove your phone number." in email.plain
     assert "Please remove your phone number." in email.html
-    assert "reply to this email" in email.plain
+    assert "replying to this email" in email.plain
 
     # the note itself is never included in the push notification
     push = push_collector.pop_for_user(user.id, last=True)

--- a/app/backend/src/tests/test_jail.py
+++ b/app/backend/src/tests/test_jail.py
@@ -282,11 +282,15 @@ def test_modnotes(db, email_collector: EmailCollector, push_collector: PushColle
                 user=user.username,
                 content="# Important note\nThis is a sample mod note.",
                 internal_id="sample_note",
+                notification=admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY,
             )
         )
 
     email = email_collector.pop_for_recipient(user.email, last=True)
     assert email.subject == "[TEST] You have received a moderator note"
+    assert email.sender_name == "Couchers.org Moderation"
+    assert email.sender_email == "moderation@couchers.org.invalid"
+    assert "This is a sample mod note." not in email.plain
 
     push = push_collector.pop_for_user(user.id, last=True)
     assert push.content.title == "New moderator note"
@@ -348,6 +352,61 @@ def test_modnotes(db, email_collector: EmailCollector, push_collector: PushColle
         assert to_aware_datetime(note.acknowledged) > to_aware_datetime(note.created)
 
 
+def test_modnotes_notify_with_content(db, email_collector: EmailCollector, push_collector: PushCollector):
+    user, token = generate_user()
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_admin_session(super_token) as admin:
+        admin.SendModNote(
+            admin_pb2.SendModNoteReq(
+                user=user.username,
+                content="# Important note\nPlease remove your phone number.",
+                internal_id="sample_note",
+                notification=admin_pb2.MOD_NOTE_NOTIFICATION_NOTIFY_WITH_CONTENT,
+            )
+        )
+
+    email = email_collector.pop_for_recipient(user.email, last=True)
+    assert email.subject == "[TEST] You have received a moderator note"
+    # sent from the moderation mailbox so the user can reply to it
+    assert email.sender_name == "Couchers.org Moderation"
+    assert email.sender_email == "moderation@couchers.org.invalid"
+    assert "Please remove your phone number." in email.plain
+    assert "Please remove your phone number." in email.html
+    assert "reply to this email" in email.plain
+
+    # the note itself is never included in the push notification
+    push = push_collector.pop_for_user(user.id, last=True)
+    assert "phone number" not in push.content.body
+
+    with real_jail_session(token) as jail:
+        res = jail.JailInfo(empty_pb2.Empty())
+        assert res.jailed
+        assert res.has_pending_mod_notes
+
+
+def test_modnotes_notification_must_be_specified(db):
+    user, token = generate_user()
+    super_user, super_token = generate_user(is_superuser=True)
+
+    with real_admin_session(super_token) as admin:
+        with pytest.raises(grpc.RpcError) as e:
+            admin.SendModNote(
+                admin_pb2.SendModNoteReq(
+                    user=user.username,
+                    content="A note",
+                    internal_id="sample_note",
+                )
+            )
+        assert e.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+        assert e.value.details() == "Whether and how to notify the user about the mod note must be specified."
+
+    with real_jail_session(token) as jail:
+        res = jail.JailInfo(empty_pb2.Empty())
+        assert not res.jailed
+        assert not res.has_pending_mod_notes
+
+
 def test_modnotes_no_notify(db, email_collector: EmailCollector, push_collector: PushCollector):
     user, token = generate_user()
     super_user, super_token = generate_user(is_superuser=True)
@@ -368,7 +427,7 @@ def test_modnotes_no_notify(db, email_collector: EmailCollector, push_collector:
                 user=user.username,
                 content="# Important note\nThis is a sample mod note.",
                 internal_id="sample_note",
-                do_not_notify=True,
+                notification=admin_pb2.MOD_NOTE_NOTIFICATION_NONE,
             )
         )
 

--- a/app/proto/api/admin.proto
+++ b/app/proto/api/admin.proto
@@ -324,11 +324,10 @@ message SendModNoteReq {
   string content = 2; // CommonMark without images
   // this allows us to track what type of note it is without having to read it individually
   string internal_id = 3;
+  ModNoteNotification notification = 5;
 
   reserved 4;
   reserved "do_not_notify";
-
-  ModNoteNotification notification = 5;
 }
 
 message MarkUserNeedsLocationUpdateReq {

--- a/app/proto/api/admin.proto
+++ b/app/proto/api/admin.proto
@@ -309,13 +309,26 @@ message GetContentReportsForAuthorRes {
   repeated ContentReport content_reports = 1;
 }
 
+enum ModNoteNotification {
+  MOD_NOTE_NOTIFICATION_UNSPECIFIED = 0;
+  // don't notify the user: simply show them the note the next time they log on
+  MOD_NOTE_NOTIFICATION_NONE = 1;
+  // tell the user a note is waiting for them, without revealing what it says
+  MOD_NOTE_NOTIFICATION_NOTIFY = 2;
+  // tell the user and include the note text in the email, which they can reply to
+  MOD_NOTE_NOTIFICATION_NOTIFY_WITH_CONTENT = 3;
+}
+
 message SendModNoteReq {
   string user = 1;
   string content = 2; // CommonMark without images
   // this allows us to track what type of note it is without having to read it individually
   string internal_id = 3;
-  // whether to not notify the user about the note: simply show it to them the next time they log on
-  bool do_not_notify = 4;
+
+  reserved 4;
+  reserved "do_not_notify";
+
+  ModNoteNotification notification = 5;
 }
 
 message MarkUserNeedsLocationUpdateReq {

--- a/app/proto/api/notification_data.proto
+++ b/app/proto/api/notification_data.proto
@@ -268,6 +268,6 @@ message GeneralNewBlogPost {
 }
 
 message ModNoteCreate {
-  // the note's text, only set if the moderator chose to include it in the notification
-  string content = 1;
+  // the note's CommonMark text, only set if the moderator chose to include it in the notification
+  string markdown_text = 1;
 }

--- a/app/proto/api/notification_data.proto
+++ b/app/proto/api/notification_data.proto
@@ -266,3 +266,8 @@ message GeneralNewBlogPost {
   string title = 2;
   string blurb = 3;
 }
+
+message ModNoteCreate {
+  // the note's text, only set if the moderator chose to include it in the notification
+  string content = 1;
+}


### PR DESCRIPTION
Moderator notes are sent with the admin `SendModNote` RPC, which can also notify the user that a note is waiting for them. This replaces that RPC's `do_not_notify` boolean with a `ModNoteNotification` enum with three choices — don't notify, notify without revealing the note, or notify and include the note's text in the email — and makes the field required. Mod note emails now come from a separate moderation sender, configured with the new `MODERATION_EMAIL_SENDER` and `MODERATION_EMAIL_ADDRESS` settings, and when the text is included the email invites the user to reply to it. The note text is never included in the push notification.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._