### PR TITLE
Add Vercel config for web preview deployments

### DIFF
--- a/app/web/.env.vercel
+++ b/app/web/.env.vercel
@@ -1,0 +1,12 @@
+ASSET_PREFIX=""
+NEXT_PUBLIC_COUCHERS_ENV=preview
+NEXT_PUBLIC_BASE_URL="https://next.couchershq.org"
+NEXT_PUBLIC_API_BASE_URL="https://dev-api.couchershq.org"
+NEXT_PUBLIC_MEDIA_BASE_URL="https://dev-user-media.couchershq.org"
+NEXT_PUBLIC_CONSOLE_BASE_URL="https://next-console.couchershq.org"
+NEXT_PUBLIC_NOMINATIM_URL="https://nominatim.openstreetmap.org/"
+NEXT_PUBLIC_STRIPE_KEY="pk_test_51KEzByIfR5z29g5khFE5samD8XKOGLcCrM1lhCkfOomGPUFAEYOw8uAqI2Nkv33wYdPM2FgTQNTC07IiNfHY1kLJ00Jqm8Ppai"
+NEXT_PUBLIC_GEOCODE_EARTH_KEY="ge-7c3c82e121bd5782"
+NEXT_PUBLIC_GLOBAL_MESSAGE_URL="https://gm.couchershq.org/next.json"
+NEXT_PUBLIC_GROWTHBOOK_API_HOST="https://next-static.couchershq.org"
+NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY="express.json"

--- a/app/web/vercel.json
+++ b/app/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "cp .env.vercel env && rm .env.* && mv env .env.local && cat ci-build-protos.sh | sh -e && next build"
+}


### PR DESCRIPTION
In https://github.com/Couchers-org/couchers/pull/9680 we discovered that there's a bunch of vercel config that maintainers don't have access to.

Turns out we can pull them into the repo, so this is an attempt to import it here to the code as SOT.

IIUC existing branches will continue to use hardcoded vercel config, so let's merge this and remove the env vars and config from vercel in a few weeks.