### PR TITLE
Return upload metadata in the admin API

### DIFF
--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -8,7 +8,7 @@ import grpc
 from google.protobuf import empty_pb2
 from google.protobuf.wrappers_pb2 import Int64Value
 from sqlalchemy import select, tuple_
-from sqlalchemy.orm import Session, aliased, selectinload
+from sqlalchemy.orm import Session, aliased, selectinload, undefer
 from sqlalchemy.sql import and_, func, or_
 from user_agents import parse as user_agents_parse
 
@@ -286,6 +286,23 @@ def _content_report_to_pb(content_report: ContentReport) -> admin_pb2.ContentRep
         content_ref=content_report.content_ref,
         user_agent=content_report.user_agent,
         page=content_report.page,
+    )
+
+
+def _upload_metadata_to_pb(upload: Upload) -> admin_pb2.UploadMetadata | None:
+    # the media service always sends the original size, so this is unset only for uploads made before we
+    # started capturing metadata
+    if upload.original_size is None:
+        return None
+
+    return admin_pb2.UploadMetadata(
+        parsed_json=json.dumps(upload.metadata_parsed, sort_keys=True) if upload.metadata_parsed else "",
+        parse_error=upload.metadata_parse_error or "",
+        original_filename=upload.original_filename or "",
+        original_format=upload.original_format or "",
+        original_size=upload.original_size,
+        original_width=upload.original_width or 0,
+        original_height=upload.original_height or 0,
     )
 
 
@@ -1454,7 +1471,19 @@ class Admin(admin_pb2_grpc.AdminServicer):
 
         page_size = min(MAX_PAGINATION_LENGTH, request.page_size or MAX_PAGINATION_LENGTH)
 
-        statement = select(Upload).where(Upload.creator_user_id == user.id)
+        statement = (
+            select(Upload)
+            .where(Upload.creator_user_id == user.id)
+            .options(
+                undefer(Upload.metadata_parsed),
+                undefer(Upload.metadata_parse_error),
+                undefer(Upload.original_filename),
+                undefer(Upload.original_format),
+                undefer(Upload.original_size),
+                undefer(Upload.original_width),
+                undefer(Upload.original_height),
+            )
+        )
         if request.page_token:
             cursor_created = session.execute(
                 select(Upload.created).where(Upload.key == request.page_token)
@@ -1479,6 +1508,7 @@ class Admin(admin_pb2_grpc.AdminServicer):
                     thumbnail_url=upload.thumbnail_url,
                     credit=upload.credit or "",
                     created=Timestamp_from_datetime(upload.created),
+                    metadata=_upload_metadata_to_pb(upload),
                     uses=[
                         admin_pb2.UploadUse(
                             type=uploadusetype2api[use.use_type],

--- a/app/backend/src/couchers/servicers/admin.py
+++ b/app/backend/src/couchers/servicers/admin.py
@@ -289,20 +289,15 @@ def _content_report_to_pb(content_report: ContentReport) -> admin_pb2.ContentRep
     )
 
 
-def _upload_metadata_to_pb(upload: Upload) -> admin_pb2.UploadMetadata | None:
-    # the media service always sends the original size, so this is unset only for uploads made before we
-    # started capturing metadata
-    if upload.original_size is None:
-        return None
-
+def _upload_metadata_to_pb(upload: Upload) -> admin_pb2.UploadMetadata:
     return admin_pb2.UploadMetadata(
-        parsed_json=json.dumps(upload.metadata_parsed, sort_keys=True) if upload.metadata_parsed else "",
-        parse_error=upload.metadata_parse_error or "",
-        original_filename=upload.original_filename or "",
-        original_format=upload.original_format or "",
+        parsed_json=json.dumps(upload.metadata_parsed, sort_keys=True) if upload.metadata_parsed else None,
+        parse_error=upload.metadata_parse_error,
+        original_filename=upload.original_filename,
+        original_format=upload.original_format,
         original_size=upload.original_size,
-        original_width=upload.original_width or 0,
-        original_height=upload.original_height or 0,
+        original_width=upload.original_width,
+        original_height=upload.original_height,
     )
 
 

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1746,6 +1746,43 @@ def test_ListUserUploads(db):
     assert upload0.HasField("created")
 
 
+def test_ListUserUploads_metadata(db):
+    super_user, super_token = generate_user(is_superuser=True)
+    user, _ = generate_user(complete_profile=False)
+
+    with session_scope() as session:
+        session.add(
+            Upload(
+                key="with_metadata",
+                filename="photo.jpg",
+                creator_user_id=user.id,
+                metadata_exif=b"\x01\x02\x03",
+                metadata_parsed={"Image Make": "Canon", "EXIF LensModel": "50mm"},
+                original_filename="IMG_1234.HEIC",
+                original_format="heif",
+                original_size=123456,
+                original_width=4032,
+                original_height=3024,
+            )
+        )
+        session.add(Upload(key="without_metadata", filename="old.jpg", creator_user_id=user.id))
+
+    with real_admin_session(super_token) as api:
+        res = api.ListUserUploads(admin_pb2.ListUserUploadsReq(user=user.username))
+
+    uploads = {u.key: u for u in res.uploads}
+    assert not uploads["without_metadata"].HasField("metadata")
+
+    metadata = uploads["with_metadata"].metadata
+    assert json.loads(metadata.parsed_json) == {"Image Make": "Canon", "EXIF LensModel": "50mm"}
+    assert metadata.parse_error == ""
+    assert metadata.original_filename == "IMG_1234.HEIC"
+    assert metadata.original_format == "heif"
+    assert metadata.original_size == 123456
+    assert metadata.original_width == 4032
+    assert metadata.original_height == 3024
+
+
 def test_ListUserUploads_pagination(db):
     super_user, super_token = generate_user(is_superuser=True)
     user, _ = generate_user(complete_profile=False)

--- a/app/backend/src/tests/test_admin.py
+++ b/app/backend/src/tests/test_admin.py
@@ -1771,7 +1771,7 @@ def test_ListUserUploads_metadata(db):
         res = api.ListUserUploads(admin_pb2.ListUserUploadsReq(user=user.username))
 
     uploads = {u.key: u for u in res.uploads}
-    assert not uploads["without_metadata"].HasField("metadata")
+    assert uploads["without_metadata"].metadata == admin_pb2.UploadMetadata()
 
     metadata = uploads["with_metadata"].metadata
     assert json.loads(metadata.parsed_json) == {"Image Make": "Canon", "EXIF LensModel": "50mm"}

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -694,6 +694,18 @@ message UploadUse {
   string url = 6;
 }
 
+message UploadMetadata {
+  // JSON object of the metadata tags parsed out of the original file
+  string parsed_json = 1;
+  string parse_error = 2;
+
+  string original_filename = 3;
+  string original_format = 4;
+  uint64 original_size = 5;
+  uint32 original_width = 6;
+  uint32 original_height = 7;
+}
+
 message UserUpload {
   string key = 1;
   string filename = 2;
@@ -702,6 +714,8 @@ message UserUpload {
   string credit = 5;
   google.protobuf.Timestamp created = 6;
   repeated UploadUse uses = 7;
+  // not set for uploads made before we started capturing metadata
+  UploadMetadata metadata = 8;
 }
 
 message ListUserUploadsRes {

--- a/app/proto/admin.proto
+++ b/app/proto/admin.proto
@@ -695,7 +695,6 @@ message UploadUse {
 }
 
 message UploadMetadata {
-  // JSON object of the metadata tags parsed out of the original file
   string parsed_json = 1;
   string parse_error = 2;
 
@@ -714,7 +713,6 @@ message UserUpload {
   string credit = 5;
   google.protobuf.Timestamp created = 6;
   repeated UploadUse uses = 7;
-  // not set for uploads made before we started capturing metadata
   UploadMetadata metadata = 8;
 }
 


### PR DESCRIPTION
Adds the image metadata captured on upload to the `UserUpload` objects returned by `ListUserUploads` in the admin API.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._