### PR TITLE
Frontend/i18n: Add build-time translation stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ __pycache__/
 
 .envrc
 
+# Build intermediates and outputs
+*.gen.*
+
 # helps Lennart configure his vim
 pyrightconfig.json
 

--- a/app/web/Makefile
+++ b/app/web/Makefile
@@ -1,0 +1,18 @@
+# Makefile for the frontend of the application
+# Run 'make [command]' in app/web to execute the specified command
+.SILENT:
+
+.PHONY: default
+default: translation-stats
+
+.PHONY: FORCE
+FORCE: # Target that forces always rebuilding
+
+# Generate translation progress stats.
+TRANSLATION_STATS_FILE := i18n/translationStats.gen.json
+
+.PHONY: translation-stats
+translation-stats: ${TRANSLATION_STATS_FILE}
+
+${TRANSLATION_STATS_FILE}: FORCE
+	node scripts/generate-translation-stats.js "${TRANSLATION_STATS_FILE}"

--- a/app/web/scripts/generate-translation-stats.js
+++ b/app/web/scripts/generate-translation-stats.js
@@ -30,7 +30,9 @@ function writeTranslationStats(appStats, outputFile) {
 
   fs.mkdirSync(path.dirname(outputFile), { recursive: true });
   fs.writeFileSync(outputFile, JSON.stringify(stats, null, 2) + "\n");
-  console.log(`Generated translation stats for ${stats.length} locales at ${path.relative(process.cwd(), outputFile)}.`);
+  console.log(
+    `Generated translation stats for ${stats.length} locales at ${path.relative(process.cwd(), outputFile)}.`,
+  );
 }
 
 // Counts total and translated strings for each locale of the whole app.

--- a/app/web/scripts/generate-translation-stats.js
+++ b/app/web/scripts/generate-translation-stats.js
@@ -1,0 +1,115 @@
+/* eslint-disable */
+const fs = require("fs");
+const path = require("path");
+
+const { allLanguages } = require("../i18n/allLanguages");
+const { NAMESPACES, MOD } = require("../i18n/namespaces");
+/* eslint-enable */
+
+const RESOURCES_DIR = path.join(__dirname, "..", "resources", "locales");
+const FEATURES_DIR = path.join(__dirname, "..", "features");
+
+const UNTRANSLATED_NAMESPACES = [MOD];
+
+// Main entry point
+function main(outputFile) {
+  if (!outputFile) {
+    throw new Error("Usage: generate-translation-stats.js <output-file>");
+  }
+  writeTranslationStats(getAppTranslationStats(), outputFile);
+}
+
+// Writes the translation stats to the given output path.
+function writeTranslationStats(appStats, outputFile) {
+  const stats = Object.entries(appStats)
+    .map(([code, { total, translated }]) => ({
+      code,
+      translated_percent: total === 0 ? 100 : Math.round((100 * translated) / total),
+    }))
+    .sort((a, b) => a.code.localeCompare(b.code));
+
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, JSON.stringify(stats, null, 2) + "\n");
+  console.log(`Generated translation stats for ${stats.length} locales at ${path.relative(process.cwd(), outputFile)}.`);
+}
+
+// Counts total and translated strings for each locale of the whole app.
+function getAppTranslationStats() {
+  const appStats = {};
+  for (const locale of allLanguages) {
+    appStats[locale] = { total: 0, translated: 0 };
+  }
+
+  for (const namespace of NAMESPACES) {
+    if (UNTRANSLATED_NAMESPACES.includes(namespace)) continue;
+
+    const componentStats = getComponentTranslationStats(namespace);
+    for (const locale of allLanguages) {
+      appStats[locale].total += componentStats[locale].total;
+      appStats[locale].translated += componentStats[locale].translated;
+    }
+  }
+
+  return appStats;
+}
+
+// Counts total and translated strings for a component of the app.
+// "en" is always fully translated.
+function getComponentTranslationStats(name) {
+  const localeDir = name === "global" ? RESOURCES_DIR : path.join(FEATURES_DIR, name, "locales");
+
+  const enKeys = readLocaleKeys(path.join(localeDir, "en.json"));
+
+  const stats = {};
+  for (const locale of allLanguages) {
+    const weblateLocale = locale.replace("-", "_");
+    const localePath = path.join(localeDir, `${weblateLocale}.json`);
+    const localeKeys = locale === "en" ? enKeys : readLocaleKeys(localePath);
+
+    let translated = 0;
+    for (const key of enKeys) {
+      if (localeKeys.has(key)) translated++;
+    }
+
+    stats[locale] = { total: enKeys.size, translated };
+  }
+  return stats;
+}
+
+// Read all string keys from a given locale file.
+function readLocaleKeys(filePath) {
+  const keys = new Set();
+  if (!fs.existsSync(filePath)) {
+    return keys;
+  }
+
+  const contents = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  gatherFlattenedKeys(keys, contents);
+  return keys;
+}
+
+// Recursively gathers a locale JSON object's normalized leaf-key paths that
+// hold a non-empty string value into the given Set.
+function gatherFlattenedKeys(keys, obj, prefix) {
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${normalizeKey(key)}` : normalizeKey(key);
+    if (typeof value === "string") {
+      if (value.length > 0) keys.add(path);
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      gatherFlattenedKeys(keys, value, path);
+    }
+  }
+}
+
+function normalizeKey(key) {
+  // Ignore CLDR plural categories as they vary between languages.
+  // Assume that if any plural form is defined, the string is defined.
+  return key.replace(/_(zero|one|two|few|many|other)$/, "");
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  // node scripts/generate-translation-stats.js <path>
+  main(process.argv[2]);
+}


### PR DESCRIPTION
See #9704 . The language picker currently depends on what Weblate reports as being translated, when what we care about are the translated strings in the repo.

Adds a Makefile that generates translation stats based on checked-in strings. This isn't called yet as it will integrate with #9680.

This isn't a webpack hook because they don't run on non-webpack tooling like tsc, lint and tests. I went with `make` as it will be necessary in all scenarios since it will also cover the other necessary step: protos generation.

The resulting file generates correctly but isn't used yet since I need to integrate the `make` build in all CI scenarios first.

## Testing
Ran `make` in `app/web`, checked the resulting generated file.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me