### PR TITLE
Mobile: upload original images from the native picker

### DIFF
--- a/app/mobile/components/WebEmbed.tsx
+++ b/app/mobile/components/WebEmbed.tsx
@@ -282,6 +282,7 @@ export default function WebEmbed({
     success: boolean;
     imageBase64?: string;
     mimeType?: string;
+    fileName?: string;
     canceled?: boolean;
     error?: string;
   }) => {

--- a/app/mobile/feature-flags.dev.json
+++ b/app/mobile/feature-flags.dev.json
@@ -1,4 +1,5 @@
 {
+  "native_upload_original_images": true,
   "test_growthbook_integration": true,
   "show_moderator_badge": true,
   "public_trips_enabled": true

--- a/app/mobile/hooks/useImagePicker.ts
+++ b/app/mobile/hooks/useImagePicker.ts
@@ -1,3 +1,4 @@
+import { useFeatureValue } from "@growthbook/growthbook-react";
 import {
   ImagePickerResult,
   launchCameraAsync,
@@ -12,6 +13,7 @@ interface ImagePickResult {
   success: boolean;
   imageBase64?: string;
   mimeType?: string;
+  fileName?: string;
   canceled?: boolean;
   error?: string;
 }
@@ -26,6 +28,11 @@ interface UseImagePickerReturn {
  */
 export function useImagePicker(): UseImagePickerReturn {
   const { t } = useTranslation();
+  // At quality 1 the picker hands back a copy of the original file rather than
+  // re-encoding it, leaving the media server's encode as the only one.
+  const quality = useFeatureValue("native_upload_original_images", false)
+    ? 1
+    : 0.8;
 
   const showPicker = useCallback(
     async (
@@ -73,14 +80,14 @@ export function useImagePicker(): UseImagePickerReturn {
           result = await launchCameraAsync({
             mediaTypes: ["images"],
             allowsEditing: false,
-            quality: 0.8,
+            quality,
             base64: true,
           });
         } else {
           result = await launchImageLibraryAsync({
             mediaTypes: ["images"],
             allowsEditing: false,
-            quality: 0.8,
+            quality,
             base64: true,
           });
         }
@@ -100,6 +107,7 @@ export function useImagePicker(): UseImagePickerReturn {
           success: true,
           imageBase64: asset.base64,
           mimeType,
+          fileName: asset.fileName ?? undefined,
         });
       } catch (error) {
         if (__DEV__) {
@@ -112,7 +120,7 @@ export function useImagePicker(): UseImagePickerReturn {
         });
       }
     },
-    [t],
+    [quality, t],
   );
 
   const pickImage = useCallback(

--- a/app/mobile/tests/hooks/useImagePicker.test.ts
+++ b/app/mobile/tests/hooks/useImagePicker.test.ts
@@ -1,8 +1,14 @@
+import { useFeatureValue } from "@growthbook/growthbook-react";
 import { renderHook, waitFor } from "@testing-library/react-native";
 import * as ImagePicker from "expo-image-picker";
 import { ActionSheetIOS, Alert, Linking, Platform } from "react-native";
 
 import { useImagePicker } from "@/hooks/useImagePicker";
+
+// Mock growthbook - flags resolve to their in-code default unless a test overrides
+jest.mock("@growthbook/growthbook-react", () => ({
+  useFeatureValue: jest.fn(),
+}));
 
 // Mock expo-image-picker
 jest.mock("expo-image-picker", () => ({
@@ -23,6 +29,9 @@ describe("useImagePicker", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (useFeatureValue as jest.Mock).mockImplementation(
+      (_key: string, fallback: unknown) => fallback,
+    );
   });
 
   describe("iOS platform", () => {
@@ -527,6 +536,69 @@ describe("useImagePicker", () => {
           imageBase64: "test-base64",
           mimeType: "image/jpeg", // Default
         });
+      });
+
+      showActionSheetSpy.mockRestore();
+    });
+
+    it("passes through the original filename", async () => {
+      (ImagePicker.launchImageLibraryAsync as jest.Mock).mockResolvedValue({
+        canceled: false,
+        assets: [
+          {
+            base64: "test-base64",
+            mimeType: "image/heic",
+            fileName: "IMG_1234.HEIC",
+          },
+        ],
+      });
+
+      const showActionSheetSpy = jest
+        .spyOn(ActionSheetIOS, "showActionSheetWithOptions")
+        .mockImplementation((options, callback) => {
+          callback(2); // Choose from library
+        });
+
+      const { result } = renderHook(() => useImagePicker());
+
+      result.current.pickImage(mockOnResult);
+
+      await waitFor(() => {
+        expect(mockOnResult).toHaveBeenCalledWith({
+          success: true,
+          imageBase64: "test-base64",
+          mimeType: "image/heic",
+          fileName: "IMG_1234.HEIC",
+        });
+      });
+
+      showActionSheetSpy.mockRestore();
+    });
+
+    it("requests the uncompressed original when the flag is on", async () => {
+      (useFeatureValue as jest.Mock).mockImplementation(
+        (key: string, fallback: unknown) =>
+          key === "native_upload_original_images" ? true : fallback,
+      );
+      (ImagePicker.launchImageLibraryAsync as jest.Mock).mockResolvedValue({
+        canceled: false,
+        assets: [{ base64: "test-base64", mimeType: "image/jpeg" }],
+      });
+
+      const showActionSheetSpy = jest
+        .spyOn(ActionSheetIOS, "showActionSheetWithOptions")
+        .mockImplementation((options, callback) => {
+          callback(2); // Choose from library
+        });
+
+      const { result } = renderHook(() => useImagePicker());
+
+      result.current.pickImage(mockOnResult);
+
+      await waitFor(() => {
+        expect(ImagePicker.launchImageLibraryAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ quality: 1 }),
+        );
       });
 
       showActionSheetSpy.mockRestore();

--- a/app/web/components/GalleryEditor/GalleryEditor.test.tsx
+++ b/app/web/components/GalleryEditor/GalleryEditor.test.tsx
@@ -207,6 +207,7 @@ describe("GalleryEditor", () => {
         success: true,
         imageBase64: "dGVzdGltYWdl", // "testimage" in base64
         mimeType: "image/jpeg",
+        fileName: "IMG_1234.JPG",
       });
 
       mockUseNativeImagePicker.mockReturnValue({
@@ -233,9 +234,9 @@ describe("GalleryEditor", () => {
         expect(mockPickImage).toHaveBeenCalled();
       });
 
-      // Upload should be called with the converted file
+      // Upload should be called with the converted file, keeping its original name
       await waitFor(() => {
-        expect(mockUploadFile).toHaveBeenCalled();
+        expect(mockUploadFile).toHaveBeenCalledWith(expect.objectContaining({ name: "IMG_1234.JPG" }));
       });
     });
 

--- a/app/web/components/GalleryEditor/GalleryEditor.tsx
+++ b/app/web/components/GalleryEditor/GalleryEditor.tsx
@@ -195,7 +195,7 @@ export default function GalleryEditor({
           const file = base64ToFile(
             result.imageBase64,
             result.mimeType,
-            `photo.${result.mimeType.split("/")[1] || "jpg"}`,
+            result.fileName ?? `photo.${result.mimeType.split("/")[1] || "jpg"}`,
           );
           const uploadResult = await service.api.uploadFile(file);
           await addPhotoMutation.mutateAsync({ uploadKey: uploadResult.key });

--- a/app/web/components/ImageInput/ImageInput.tsx
+++ b/app/web/components/ImageInput/ImageInput.tsx
@@ -151,7 +151,7 @@ function ImageInput(props: RectImgInputProps) {
       if (result.success) {
         const dataUrl = `data:${result.mimeType};base64,${result.imageBase64}`;
         const extension = result.mimeType.split("/")[1] || "jpg";
-        const file = base64ToFile(result.imageBase64, result.mimeType, `image.${extension}`);
+        const file = base64ToFile(result.imageBase64, result.mimeType, result.fileName ?? `image.${extension}`);
 
         // Check file size before uploading
         if (file.size > MAX_FILE_SIZE) {

--- a/app/web/utils/nativeLink.ts
+++ b/app/web/utils/nativeLink.ts
@@ -71,7 +71,7 @@ export function sendNativeRequestReview() {
 
 // Image picker bridge for native mobile app
 export type ImagePickResult =
-  | { success: true; imageBase64: string; mimeType: string }
+  | { success: true; imageBase64: string; mimeType: string; fileName?: string }
   | { success: false; canceled?: boolean; error?: string };
 
 type ImagePickCallback = (result: ImagePickResult) => void;


### PR DESCRIPTION
The native app can't use the WebView's file input for photos, so uploads on iOS and Android go through a native image picker and are handed back to the web layer, which sends them on to the media server. The picker has been asking for JPEG at 80% quality, so every photo is encoded on the device and then encoded again by the media server, and the filename the picker gives us is dropped in favour of a generated one. This adds a `native_upload_original_images` feature flag, off by default, that makes the picker return the original file untouched so the media server's encode is the only one, and passes the picker's filename through to the upload unconditionally.

## Testing
Enable `native_upload_original_images` (already set in `app/mobile/feature-flags.dev.json`) and upload a photo from both the profile photo input and the gallery editor in the native app.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._