### PR TITLE
Return the signup flow's email address in SignupFlowRes

### DIFF
--- a/app/backend/src/couchers/servicers/auth.py
+++ b/app/backend/src/couchers/servicers/auth.py
@@ -464,6 +464,7 @@ class Auth(auth_pb2_grpc.AuthServicer):
         else:
             return auth_pb2.SignupFlowRes(
                 flow_token=flow.flow_token,
+                email=flow.email,
                 need_account=not flow.account_is_filled,
                 need_feedback=False,
                 need_verify_email=not flow.email_verified,

--- a/app/backend/src/tests/test_auth.py
+++ b/app/backend/src/tests/test_auth.py
@@ -72,6 +72,7 @@ def test_signup_incremental(db):
     flow_token = res.flow_token
     assert res.flow_token
     assert not res.HasField("auth_res")
+    assert res.email == "email@couchers.org.invalid"
     assert not res.need_basic
     assert res.need_account
     assert not res.need_feedback
@@ -91,6 +92,7 @@ def test_signup_incremental(db):
 
     assert res.flow_token == flow_token
     assert not res.HasField("auth_res")
+    assert res.email == "email@couchers.org.invalid"
     assert not res.need_basic
     assert res.need_account
     assert not res.need_feedback
@@ -116,6 +118,7 @@ def test_signup_incremental(db):
 
     assert res.flow_token == flow_token
     assert not res.HasField("auth_res")
+    assert res.email == "email@couchers.org.invalid"
     assert not res.need_basic
     assert res.need_account
     assert not res.need_feedback
@@ -134,6 +137,7 @@ def test_signup_incremental(db):
 
     assert res.flow_token == flow_token
     assert not res.HasField("auth_res")
+    assert res.email == "email@couchers.org.invalid"
     assert not res.need_basic
     assert res.need_account
     assert not res.need_feedback
@@ -152,6 +156,7 @@ def test_signup_incremental(db):
 
     assert res.flow_token == flow_token
     assert not res.HasField("auth_res")
+    assert res.email == "email@couchers.org.invalid"
     assert not res.need_basic
     assert res.need_account
     assert not res.need_feedback
@@ -170,6 +175,7 @@ def test_signup_incremental(db):
 
     assert res.flow_token == flow_token
     assert not res.HasField("auth_res")
+    assert res.email == "email@couchers.org.invalid"
     assert not res.need_basic
     assert res.need_account
     assert not res.need_feedback
@@ -199,6 +205,7 @@ def test_signup_incremental(db):
 
     assert not res.flow_token
     assert res.HasField("auth_res")
+    assert not res.email
     assert res.auth_res.user_id
     assert not res.auth_res.jailed
     assert not res.need_basic

--- a/app/proto/api/auth.proto
+++ b/app/proto/api/auth.proto
@@ -128,6 +128,7 @@ message SignupFlowReq {
 message SignupFlowRes {
   // a token used to link the user's information across the signup flow
   string flow_token = 1 [ (is_token) = true ];
+  string email = 10;
   // auth_res is included if and only if signup is successful
   AuthRes auth_res = 3;
   // which parts are missing?

--- a/app/web/features/auth/signup/AccountForm.test.tsx
+++ b/app/web/features/auth/signup/AccountForm.test.tsx
@@ -65,6 +65,7 @@ describe("AccountForm", () => {
   beforeEach(() => {
     signupFlowAccountMock.mockResolvedValue({
       flowToken: "token",
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needFeedback: false,
@@ -81,6 +82,7 @@ describe("AccountForm", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: false,
           needAccount: true,
           needFeedback: false,
@@ -314,6 +316,7 @@ describe("AccountForm", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: false,
           needAccount: true,
           needFeedback: false,
@@ -358,6 +361,7 @@ describe("AccountForm", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: false,
           needAccount: true,
           needFeedback: false,

--- a/app/web/features/auth/signup/BasicForm.test.tsx
+++ b/app/web/features/auth/signup/BasicForm.test.tsx
@@ -16,6 +16,7 @@ const startSignupMock = service.auth.startSignup as MockedService<typeof service
 const stateAfterStart = {
   flowToken: "dummy-token",
   success: false,
+  email: "test@example.com",
   needBasic: false,
   needAccount: false,
   needAcceptCommunityGuidelines: true,

--- a/app/web/features/auth/signup/CommunityGuidelinesForm.test.tsx
+++ b/app/web/features/auth/signup/CommunityGuidelinesForm.test.tsx
@@ -22,6 +22,7 @@ describe("community guidelines signup form", () => {
       "auth.flowState",
       JSON.stringify({
         flowToken: "dummy-token",
+        email: "test@example.com",
         needBasic: false,
         needAccount: true,
         needFeedback: false,
@@ -48,6 +49,7 @@ describe("community guidelines signup form", () => {
   it("works only with all boxes checked", async () => {
     signupFlowCommunityGuidelinesMock.mockResolvedValue({
       flowToken: "dummy-token",
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,

--- a/app/web/features/auth/signup/MotivationsForm.test.tsx
+++ b/app/web/features/auth/signup/MotivationsForm.test.tsx
@@ -20,6 +20,7 @@ describe("MotivationsForm", () => {
       "auth.flowState",
       JSON.stringify({
         flowToken: "dummy-token",
+        email: "test@example.com",
         needBasic: false,
         needAccount: false,
         needFeedback: false,
@@ -38,6 +39,7 @@ describe("MotivationsForm", () => {
   it("submits with selected motivations", async () => {
     signupFlowMotivationsMock.mockResolvedValue({
       flowToken: "dummy-token",
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,
@@ -62,6 +64,7 @@ describe("MotivationsForm", () => {
   it("submits with no motivations selected", async () => {
     signupFlowMotivationsMock.mockResolvedValue({
       flowToken: "dummy-token",
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,

--- a/app/web/features/auth/signup/Signup.test.tsx
+++ b/app/web/features/auth/signup/Signup.test.tsx
@@ -119,6 +119,7 @@ describe("Signup", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: true,
           needAccount: true,
           needAcceptCommunityGuidelines: true,
@@ -129,6 +130,7 @@ describe("Signup", () => {
       );
       startSignupMock.mockResolvedValue({
         flowToken: "token",
+        email: "test@example.com",
         needBasic: false,
         needAccount: true,
         needAcceptCommunityGuidelines: true,
@@ -151,6 +153,7 @@ describe("Signup", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: false,
           needAccount: true,
           needAcceptCommunityGuidelines: true,
@@ -161,6 +164,7 @@ describe("Signup", () => {
       );
       signupFlowAccountMock.mockResolvedValue({
         flowToken: "token",
+        email: "test@example.com",
         needBasic: false,
         needAccount: false,
         needAcceptCommunityGuidelines: true,
@@ -201,6 +205,7 @@ describe("Signup", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: false,
           needAccount: false,
           needAcceptCommunityGuidelines: true,
@@ -211,6 +216,7 @@ describe("Signup", () => {
       );
       signupFlowCommunityGuidelinesMock.mockResolvedValue({
         flowToken: "token",
+        email: "test@example.com",
         needBasic: false,
         needAccount: false,
         needAcceptCommunityGuidelines: false,
@@ -240,6 +246,7 @@ describe("Signup", () => {
         "auth.flowState",
         JSON.stringify({
           flowToken: "token",
+          email: "test@example.com",
           needBasic: false,
           needAccount: false,
           needAcceptCommunityGuidelines: false,
@@ -251,6 +258,7 @@ describe("Signup", () => {
       signupFlowMotivationsMock.mockResolvedValue({
         flowToken: "token",
         authRes: { userId: 1, jailed: false },
+        email: "test@example.com",
         needBasic: false,
         needAccount: false,
         needAcceptCommunityGuidelines: false,
@@ -275,6 +283,7 @@ describe("Signup", () => {
       "auth.flowState",
       JSON.stringify({
         flowToken: "token",
+        email: "test@example.com",
         needBasic: true,
         needAccount: true,
         needAcceptCommunityGuidelines: true,
@@ -294,6 +303,7 @@ describe("Signup", () => {
 
     startSignupMock.mockResolvedValue({
       flowToken: "token",
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needAcceptCommunityGuidelines: true,
@@ -333,6 +343,7 @@ describe("Signup", () => {
 
   it("displays the basic form if it is needed", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: true,
       needAccount: true,
       needAcceptCommunityGuidelines: true,
@@ -348,6 +359,7 @@ describe("Signup", () => {
 
   it("displays the account form when account, feedback, guidelines and email are pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needFeedback: false,
@@ -363,6 +375,7 @@ describe("Signup", () => {
 
   it("displays the account form when account, guidelines and email are pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needAcceptCommunityGuidelines: true,
@@ -378,6 +391,7 @@ describe("Signup", () => {
 
   it("displays the account form when only account is pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needAcceptCommunityGuidelines: false,
@@ -393,6 +407,7 @@ describe("Signup", () => {
 
   it("displays the guidelines form when guidelines, feedback and email are pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: true,
@@ -408,6 +423,7 @@ describe("Signup", () => {
 
   it("displays the guidelines form when only it and feedback are pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: true,
@@ -423,6 +439,7 @@ describe("Signup", () => {
 
   it("displays the motivations form when only motivations is pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,
@@ -438,6 +455,7 @@ describe("Signup", () => {
 
   it("displays the verify email message when email is pending", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,
@@ -453,6 +471,7 @@ describe("Signup", () => {
 
   it("displays the redirect message when nothing is pending and has authRes", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,
@@ -469,6 +488,7 @@ describe("Signup", () => {
 
   it("throws an error if nothing is pending but there is no authres", async () => {
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: false,
       needAcceptCommunityGuidelines: false,
@@ -484,6 +504,7 @@ describe("Signup", () => {
 
   it("sets the email flow state correctly when given a url token", async () => {
     signupFlowEmailTokenMock.mockResolvedValue({
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needAcceptCommunityGuidelines: true,
@@ -493,6 +514,7 @@ describe("Signup", () => {
       flowToken: "token",
     });
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needAcceptCommunityGuidelines: true,
@@ -519,6 +541,7 @@ describe("Signup", () => {
       message: "Invalid token",
     });
     const state: SignupFlowRes.AsObject = {
+      email: "test@example.com",
       needBasic: false,
       needAccount: true,
       needAcceptCommunityGuidelines: true,

--- a/app/web/features/auth/useAuthStore.test.ts
+++ b/app/web/features/auth/useAuthStore.test.ts
@@ -253,6 +253,7 @@ describe("updateSignupState action", () => {
     await act(() =>
       result.current.authActions.updateSignupState({
         flowToken: "dummy-token",
+        email: "test@example.com",
         needBasic: false,
         needAccount: true,
         needFeedback: false,
@@ -283,6 +284,7 @@ describe("updateSignupState action", () => {
           userId: 51,
           jailed: false,
         },
+        email: "test@example.com",
         needBasic: false,
         needAccount: false,
         needFeedback: false,


### PR DESCRIPTION
Signing up goes through the Auth service's `SignupFlow` RPC, which the web client drives step by step, keeping the response in local state in between. That response has never included the email address the flow was started with, and the client doesn't retain what was typed, so it can't tell the user which address they are signing up with — the verify-email step asks them to check "your email address" without naming it, and after a reload, or when continuing from the emailed link, the address is gone entirely. This adds an `email` field to `SignupFlowRes`, populated while the flow is incomplete. Nothing reads it yet.

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [x] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._