### PR TITLE
Web: Fix pets allowed search filter not being saved on Apply

### DIFF
--- a/app/web/features/search/state/mapSearchReducers.test.ts
+++ b/app/web/features/search/state/mapSearchReducers.test.ts
@@ -1,0 +1,27 @@
+import { initialState, mapSearchActionTypes, mapSearchReducer } from "./mapSearchReducers";
+
+describe("mapSearchReducer SET_FILTERS", () => {
+  it("persists acceptsPets when set to true", () => {
+    const state = mapSearchReducer(initialState, {
+      type: mapSearchActionTypes.SET_FILTERS,
+      payload: { acceptsPets: true },
+    });
+
+    expect(state.filters.acceptsPets).toBe(true);
+    expect(state.hasActiveFilters).toBe(true);
+  });
+
+  it("normalizes acceptsPets false back to undefined", () => {
+    const withPets = mapSearchReducer(initialState, {
+      type: mapSearchActionTypes.SET_FILTERS,
+      payload: { acceptsPets: true },
+    });
+
+    const state = mapSearchReducer(withPets, {
+      type: mapSearchActionTypes.SET_FILTERS,
+      payload: { acceptsPets: false },
+    });
+
+    expect(state.filters.acceptsPets).toBeUndefined();
+  });
+});

--- a/app/web/features/search/state/mapSearchReducers.ts
+++ b/app/web/features/search/state/mapSearchReducers.ts
@@ -321,6 +321,9 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
         if (key === "acceptsLastMinRequests") {
           updatedFilters.acceptsLastMinRequests = action.payload[key] === false ? undefined : action.payload[key];
         }
+        if (key === "acceptsPets") {
+          updatedFilters.acceptsPets = action.payload[key] === false ? undefined : action.payload[key];
+        }
         if (key === "showEmptyProfile") {
           updatedFilters.showEmptyProfile = action.payload[key];
         }


### PR DESCRIPTION
Fixes the "pets allowed" filter in search not being saved when clicking Apply.

closes #9710

## Root cause

In `app/web/features/search/state/mapSearchReducers.ts`, the `SET_FILTERS` case copies each filter key explicitly, but there was no branch for `acceptsPets` — the value was silently dropped on Apply. The dialog's local state made the switch look fine until reopening. The filter checklist in `docs/architecture/frontend/map-search.md` lists exactly this step.

The fix adds the missing branch, following the existing `acceptsKids` pattern (`false` normalizes to `undefined`).

## Testing

- Replicated the bug on current `develop` locally (filter off again after Apply + reopen), then confirmed it persists correctly with the fix (results narrowed from 307 to 10 with the filter on).
- Added `features/search/state/mapSearchReducers.test.ts` regression tests: `acceptsPets: true` persists and marks filters active; `false` normalizes back to `undefined`. Test fails on clean `develop`, passes with the fix.
- Full web jest suite: 989 passed; single failure in `components/MarkdownInput` (image upload timeout) fails identically on clean `develop` in my env — unrelated to this change.
- `tsc --noEmit` clean; prettier + eslint applied.

**Web frontend checklist**
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me
