### PR TITLE
Frontend/i18n: Split English (US) and English (International)

### DIFF
--- a/app/backend/src/couchers/i18n/locales.py
+++ b/app/backend/src/couchers/i18n/locales.py
@@ -20,6 +20,10 @@ NON_TRANSLATED_LOCALES: list[str] = ["en-US"]
 # Some mutually intelligible language variants fallback to each other.
 _LOCALE_FALLBACKS: dict[str, str] = {"pt-BR": "pt", "pt": "pt-BR", "es-419": "es", "es": "es-419"}
 
+# Locales whose Babel formatting differs from their literal locale code.
+# Our "en" locale should use international English formatting.
+_BABEL_LOCALE_REMAP: dict[str, str] = {"en": "en-001"}
+
 
 def get_locales_with_translations() -> list[str]:
     """Gets the list of locales which have translations."""
@@ -85,8 +89,7 @@ def get_babel_locale(locale: str) -> babel.Locale:
     Returns the babel locale object for a given locale string.
     Guaranteed by tests to succeed for supported locales.
     """
-    # TODO(#9184): Once we have en-US available, "en" should return the babel locale for "en-001" (Global English)
-    return babel.Locale.parse(locale, sep="-")
+    return babel.Locale.parse(_BABEL_LOCALE_REMAP.get(locale, locale), sep="-")
 
 
 def load_locales(directory: Path) -> I18Next:

--- a/app/backend/src/tests/test_i18n_locales.py
+++ b/app/backend/src/tests/test_i18n_locales.py
@@ -69,6 +69,16 @@ def test_all_supported_locales_have_babel_locales():
         assert babel_locale.territories
 
 
+def test_get_babel_locale_remaps_en_to_international():
+    """ "en" is remapped to international (en-001) formatting, distinct from "en-US"."""
+    en_babel_locale = get_babel_locale("en")
+    en_us_babel_locale = get_babel_locale("en-US")
+
+    assert en_babel_locale.territory == "001"
+    assert en_us_babel_locale.territory == "US"
+    assert en_babel_locale.date_formats["short"].pattern != en_us_babel_locale.date_formats["short"].pattern
+
+
 def test_get_locale_chain():
     """Test that fallbacks are correctly set up"""
     assert get_locale_chain("en") == ["en"]

--- a/app/web/features/donations/DonationBanner.test.tsx
+++ b/app/web/features/donations/DonationBanner.test.tsx
@@ -63,7 +63,7 @@ describe("DonationBanner", () => {
 
     // Should also show the progress bar
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
-    expect(screen.getByText("$5,000 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$5,000 / US$10,000")).toBeInTheDocument();
   });
 
   it("navigates to donations page with utm_source when button is clicked", async () => {
@@ -278,7 +278,7 @@ describe("DonationBanner", () => {
 
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).toHaveAttribute("aria-valuenow", "75");
-    expect(screen.getByText("$7,500 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$7,500 / US$10,000")).toBeInTheDocument();
   });
 
   it("caps progress at 100% when donations exceed goal", async () => {
@@ -305,6 +305,6 @@ describe("DonationBanner", () => {
 
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).toHaveAttribute("aria-valuenow", "100");
-    expect(screen.getByText("$15,000 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$15,000 / US$10,000")).toBeInTheDocument();
   });
 });

--- a/app/web/features/donations/DonationDriveBlock.tsx
+++ b/app/web/features/donations/DonationDriveBlock.tsx
@@ -3,6 +3,7 @@ import { Alert, alpha, styled } from "@mui/material";
 import useAccountInfo from "features/auth/useAccountInfo";
 import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
+import { localizeUSD } from "i18n/numbers";
 import { theme } from "theme";
 
 import DonationProgressBar from "./DonationProgressBar";
@@ -50,14 +51,7 @@ export default function DonationDriveBlock({ onClose, action, alwaysShow = false
     return null;
   }
 
-  const formattedGoal = donationStats
-    ? new Intl.NumberFormat(i18n.language, {
-        style: "currency",
-        currency: "USD",
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
-      }).format(donationStats.goal)
-    : "";
+  const formattedGoal = donationStats ? localizeUSD(donationStats.goal, i18n.language) : "";
 
   return (
     <Alert

--- a/app/web/features/donations/DonationProgressBar.test.tsx
+++ b/app/web/features/donations/DonationProgressBar.test.tsx
@@ -56,7 +56,7 @@ describe("DonationProgressBar", () => {
     });
     expect(progressBar).toBeInTheDocument();
     expect(progressBar).toHaveAttribute("aria-valuenow", "50");
-    expect(screen.getByText("$5,000 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$5,000 / US$10,000")).toBeInTheDocument();
   });
 
   it("displays correct progress percentage for 75%", () => {
@@ -72,7 +72,7 @@ describe("DonationProgressBar", () => {
 
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).toHaveAttribute("aria-valuenow", "75");
-    expect(screen.getByText("$7,500 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$7,500 / US$10,000")).toBeInTheDocument();
   });
 
   it("caps progress at 100% when donations exceed goal", () => {
@@ -88,7 +88,7 @@ describe("DonationProgressBar", () => {
 
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).toHaveAttribute("aria-valuenow", "100");
-    expect(screen.getByText("$15,000 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$15,000 / US$10,000")).toBeInTheDocument();
   });
 
   it("formats large numbers with commas", () => {
@@ -102,7 +102,7 @@ describe("DonationProgressBar", () => {
 
     render(<DonationProgressBar />, { wrapper });
 
-    expect(screen.getByText("$123,456 / $500,000")).toBeInTheDocument();
+    expect(screen.getByText("US$123,456 / US$500,000")).toBeInTheDocument();
   });
 
   it("handles zero donations", () => {
@@ -118,6 +118,6 @@ describe("DonationProgressBar", () => {
 
     const progressBar = screen.getByRole("progressbar");
     expect(progressBar).toHaveAttribute("aria-valuenow", "0");
-    expect(screen.getByText("$0 / $10,000")).toBeInTheDocument();
+    expect(screen.getByText("US$0 / US$10,000")).toBeInTheDocument();
   });
 });

--- a/app/web/features/donations/DonationProgressBar.tsx
+++ b/app/web/features/donations/DonationProgressBar.tsx
@@ -1,6 +1,7 @@
 import { alpha, Box, LinearProgress, Skeleton, styled } from "@mui/material";
 import { useTranslation } from "i18n";
 import { GLOBAL } from "i18n/namespaces";
+import { localizeUSD } from "i18n/numbers";
 
 import useDonationStats from "./useDonationStats";
 
@@ -50,15 +51,8 @@ export default function DonationProgressBar() {
 
   const progress = Math.min((donationStats.totalDonatedYtd / donationStats.goal) * 100, 100);
 
-  const currencyFormatter = new Intl.NumberFormat(i18n.language, {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  });
-
-  const formattedRaised = currencyFormatter.format(donationStats.totalDonatedYtd);
-  const formattedGoal = currencyFormatter.format(donationStats.goal);
+  const formattedRaised = localizeUSD(donationStats.totalDonatedYtd, i18n.language);
+  const formattedGoal = localizeUSD(donationStats.goal, i18n.language);
 
   return (
     <ProgressRow>

--- a/app/web/features/donations/DonationsBox.tsx
+++ b/app/web/features/donations/DonationsBox.tsx
@@ -17,6 +17,7 @@ import { DONATIONS_BOX_CURRENCY, DONATIONS_BOX_VALUES } from "features/donations
 import { RpcError } from "grpc-web";
 import { Trans, useTranslation } from "i18n";
 import { DONATIONS } from "i18n/namespaces";
+import { localizeUSD } from "i18n/numbers";
 import { useRouter } from "next/router";
 import React, { PropsWithChildren, useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -207,7 +208,7 @@ interface DonationFormData {
 }
 
 export default function DonationsBox() {
-  const { t } = useTranslation(DONATIONS);
+  const { t, i18n } = useTranslation(DONATIONS);
 
   const [isPredefinedAmount, setIsPredefinedAmount] = useState(true);
 
@@ -271,13 +272,6 @@ export default function DonationsBox() {
       setIsPredefinedAmount(true);
     };
 
-  const formatDonationValue = (val: number) =>
-    new Intl.NumberFormat("en-US", {
-      currency: "USD",
-      minimumFractionDigits: 0,
-      style: "currency",
-    }).format(val);
-
   return (
     <StyledForm onSubmit={onSubmit}>
       {error && <Alert severity="error">{error.message}</Alert>}
@@ -330,7 +324,7 @@ export default function DonationsBox() {
                       onChange: field.onChange,
                     })}
                   >
-                    {formatDonationValue(value)}
+                    {localizeUSD(value, i18n.language)}
                   </StyledAmountButton>
                 );
               }),

--- a/app/web/i18n/allLanguages.js
+++ b/app/web/i18n/allLanguages.js
@@ -3,6 +3,7 @@ const allLanguages = [
   "cs",
   "de",
   "en",
+  "en-US",
   "es",
   "es-419",
   "fr",

--- a/app/web/i18n/datetimes.test.ts
+++ b/app/web/i18n/datetimes.test.ts
@@ -153,11 +153,11 @@ describe("localizeDateTime", () => {
 describe("localizeDateTime-derived helpers", () => {
   // Sanity check. Testing is otherwise covered by localizeDateTime, which these functions delegate to.
   it("localizeDateOnly", () => {
-    expect(localizeDateOnly(janFirst2000.add({ hours: 7 }), "en")).toBe("January 1, 2000");
+    expect(localizeDateOnly(janFirst2000.add({ hours: 7 }), "en")).toBe("1 January 2000");
   });
 
   it("localizeTimeOnly", () => {
-    expect(localizeTimeOnly(janFirst2000.add({ hours: 7 }), "en")).toBe("7:00 AM");
+    expect(localizeTimeOnly(janFirst2000.add({ hours: 7 }), "en")).toBe("7:00 am");
   });
 
   // Sanity check. Testing is otherwise covered by localizeDateTime, which these functions delegate to.
@@ -411,7 +411,8 @@ describe("localizeTimeZone", () => {
 
 describe("getMuiDateFormat", () => {
   it("works for common locales", () => {
-    expect(getMuiDateFormat("en")).toEqual("MM/DD/YYYY");
+    expect(getMuiDateFormat("en")).toEqual("DD/MM/YYYY");
+    expect(getMuiDateFormat("en-US")).toEqual("MM/DD/YYYY");
     expect(getMuiDateFormat("de")).toEqual("DD.MM.YYYY");
     expect(getMuiDateFormat("ja-JP")).toEqual("YYYY/MM/DD");
     expect(getMuiDateFormat("fr-CA")).toEqual("YYYY-MM-DD");
@@ -430,6 +431,7 @@ describe("getMuiDateFormat", () => {
 describe("getMuiTimeFormat", () => {
   it("works for common locales", () => {
     expect(getMuiTimeFormat("en")).toEqual("h:mm a");
+    expect(getMuiTimeFormat("en-US")).toEqual("h:mm a");
     expect(getMuiTimeFormat("de")).toEqual("HH:mm");
     expect(getMuiTimeFormat("ja-JP")).toEqual("H:mm");
   });

--- a/app/web/i18n/datetimes.ts
+++ b/app/web/i18n/datetimes.ts
@@ -1,10 +1,11 @@
 // format a date
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { capitalizeFirstLetter } from "i18n/casing";
+import { toFormatLocale } from "i18n/locales";
 import { TFunction } from "i18next";
 import { Temporal } from "temporal-polyfill";
 import { approxDateDuration, timestampToInstant, UTC_TIMEZONE } from "utils/date";
-import dayjs, { i18nToDayjsLocale } from "utils/dayjs";
+import dayjs, { toDayjsLocale } from "utils/dayjs";
 
 /**
  * Converts a Temporal date/time object to a Date
@@ -175,6 +176,7 @@ function getIntlDateTimeFormatUTC(
   options?: LocalizeDateTimeOptions,
   dateComponents?: { year?: number },
 ): Intl.DateTimeFormat {
+  locale = toFormatLocale(locale);
   const intlOptions = getIntlDateTimeFormatOptionsUTC(options, dateComponents);
   const cacheKey = JSON.stringify({ ...intlOptions, locale });
   let format = intlDateTimeFormatCache.get(cacheKey);
@@ -236,6 +238,7 @@ export function localizeTimeZone(
     capitalize?: boolean;
   },
 ) {
+  locale = toFormatLocale(locale);
   const intlOptions: Intl.DateTimeFormatOptions = {
     timeZone: timeZone,
     timeZoneName: options?.short ? "short" : "long",
@@ -254,6 +257,7 @@ const isoMuiDateFormat = "YYYY-MM-DD";
 
 /** Gets the date format for a locale using Material UI placeholders. */
 export function getMuiDateFormat(locale: string): string {
+  locale = toFormatLocale(locale);
   if (Intl.DateTimeFormat.supportedLocalesOf(locale).length === 0) {
     return isoMuiDateFormat;
   }
@@ -276,6 +280,7 @@ const defaultMuiTimeFormat = "HH:mm";
 
 /** Gets a localized time format string compatible with Material UI time pickers. */
 export function getMuiTimeFormat(locale: string): string {
+  locale = toFormatLocale(locale);
   if (Intl.DateTimeFormat.supportedLocalesOf(locale).length === 0) {
     return defaultMuiTimeFormat;
   }
@@ -413,5 +418,5 @@ export function localizeDuration(duration: Temporal.Duration, locale: string) {
   else if (duration.minutes > 0) dayjsDuration = dayjs.duration(duration.minutes, "minutes");
   else dayjsDuration = dayjs.duration(duration.seconds, "seconds");
 
-  return dayjsDuration.locale(i18nToDayjsLocale(locale)).humanize();
+  return dayjsDuration.locale(toDayjsLocale(locale)).humanize();
 }

--- a/app/web/i18n/locales.test.ts
+++ b/app/web/i18n/locales.test.ts
@@ -6,6 +6,7 @@ import {
   getLocaleReadiness,
   LOCALE_AUTONYMS,
   LocaleReadiness,
+  toFormatLocale,
 } from "./locales";
 import { WeblateLanguage } from "./weblate";
 
@@ -93,5 +94,16 @@ describe("getLocaleInfos", () => {
       autonym: LOCALE_AUTONYMS.en,
       stringAvailabilityPercent: 100,
     });
+  });
+});
+
+describe("toFormatLocale", () => {
+  it("remaps en to en-001 for international date/number formatting", () => {
+    expect(toFormatLocale("en")).toBe("en-001");
+  });
+
+  it("leaves other locales, including en-US, unchanged", () => {
+    expect(toFormatLocale("en-US")).toBe("en-US");
+    expect(toFormatLocale("fr")).toBe("fr");
   });
 });

--- a/app/web/i18n/locales.ts
+++ b/app/web/i18n/locales.ts
@@ -7,14 +7,15 @@ export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
 export const DEFAULT_LOCALE = "en";
 
 // Locales which don't rely on translation progress.
-export const ALWAYS_AVAILABLE_LOCALES = ["en"];
+export const ALWAYS_AVAILABLE_LOCALES = ["en", "en-US"];
 
 // Autonym = a language name as written in its own language.
 export const LOCALE_AUTONYMS: Record<string, string> = {
   ca: "Català",
   cs: "Čeština",
   de: "Deutsch",
-  en: "English",
+  en: "English (International)",
+  "en-US": "English (US)",
   es: "Español (España)",
   "es-419": "Español (Latinoamérica)",
   fr: "Français",
@@ -35,6 +36,16 @@ export const LOCALE_AUTONYMS: Record<string, string> = {
   "zh-Hans": "中文（简体）",
   "zh-Hant": "中文（繁體）",
 };
+
+// Locales whose Intl API-based formatting differs from their literal code
+// (translations are unaffected). Mirrors the backend's remap in
+// couchers/i18n/locales.py.
+const FORMAT_LOCALE_REMAP: Record<string, string> = { en: "en-001" };
+
+/** Maps locale code to the one that should be used for Intl date/number formatting. */
+export function toFormatLocale(locale: string): string {
+  return FORMAT_LOCALE_REMAP[locale] ?? locale;
+}
 
 export interface LocaleInfo {
   code: string;

--- a/app/web/i18n/numbers.test.ts
+++ b/app/web/i18n/numbers.test.ts
@@ -1,0 +1,16 @@
+import { localizeUSD } from "i18n/numbers";
+
+describe("localizeUSD", () => {
+  it("formats for different locales", () => {
+    expect(localizeUSD(99.99, "en")).toBe("US$99.99");
+    expect(localizeUSD(99.99, "en-US")).toBe("$99.99");
+    // es uses a non-breaking space ( ) before the currency symbol
+    expect(localizeUSD(99.99, "es")).toBe("99,99 US$");
+  });
+
+  it("shows cents only when present", () => {
+    expect(localizeUSD(1, "en")).toBe("US$1");
+    expect(localizeUSD(1.1, "en")).toBe("US$1.10");
+    expect(localizeUSD(1.11, "en")).toBe("US$1.11");
+  });
+});

--- a/app/web/i18n/numbers.ts
+++ b/app/web/i18n/numbers.ts
@@ -1,0 +1,26 @@
+import { toFormatLocale } from "i18n/locales";
+
+// Creating Intl.NumberFormat every time is slow, so cache one per locale+options.
+const intlNumberFormatCache = new Map<string, Intl.NumberFormat>();
+
+/** Gets a cached Intl.NumberFormat, applying our locale -> format-locale mapping. */
+function getIntlNumberFormat(locale: string, options?: Intl.NumberFormatOptions): Intl.NumberFormat {
+  const formatLocale = toFormatLocale(locale);
+  const cacheKey = JSON.stringify({ ...options, locale: formatLocale });
+  let format = intlNumberFormatCache.get(cacheKey);
+  if (!format) {
+    format = new Intl.NumberFormat(formatLocale, options);
+    intlNumberFormatCache.set(cacheKey, format);
+  }
+  return format;
+}
+
+/** Localizes a USD amount, e.g. "$1,234" / "US$1,234" depending on locale. */
+export function localizeUSD(amount: number, locale: string): string {
+  return getIntlNumberFormat(locale, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}

--- a/app/web/next-i18next.config.js
+++ b/app/web/next-i18next.config.js
@@ -92,6 +92,10 @@ module.exports = {
   localePath: (locale, namespace) => {
     // eslint-disable-next-line
     const path = require("path");
+    if (locale === "en-US") {
+      // en-US is a format-only locale. The translation is shared.
+      locale = "en";
+    }
     if (namespace === "global") {
       return path.resolve(process.cwd(), `resources/locales/${locale.replace("-", "_")}.json`);
     }

--- a/app/web/pages/_app.tsx
+++ b/app/web/pages/_app.tsx
@@ -24,7 +24,7 @@ import React, { ReactNode, useEffect } from "react";
 import TagManager from "react-gtm-module";
 import { polyfill } from "seamless-scroll-polyfill";
 import { theme } from "theme";
-import { i18nToDayjsLocale } from "utils/dayjs";
+import { toDayjsLocale } from "utils/dayjs";
 
 type AppWithLayoutProps = Omit<AppProps, "Component"> & {
   Component: AppProps["Component"] & {
@@ -76,7 +76,7 @@ function MyApp(props: AppWithLayoutProps) {
   return (
     <AppCacheProvider {...props}>
       <StyledEngineProvider injectFirst>
-        <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={i18nToDayjsLocale(language)}>
+        <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={toDayjsLocale(language)}>
           <ThemeProvider theme={theme}>
             <ErrorBoundary isFatal>
               <AnalyticsProvider>

--- a/app/web/utils/dayjs.test.ts
+++ b/app/web/utils/dayjs.test.ts
@@ -1,28 +1,31 @@
-import dayjs, { i18nToDayjsLocale } from "utils/dayjs";
+import dayjs, { toDayjsLocale } from "utils/dayjs";
 
-describe("i18nToDayjsLocale", () => {
+describe("toDayjsLocale", () => {
   it("formats a long date in the language's locale at the call site", () => {
     // Specify the locale at the formatting site rather than via global state.
-    const format = (code: string) => dayjs("2021-03-20").locale(i18nToDayjsLocale(code)).format("LL");
+    const format = (code: string) => dayjs("2021-03-20").locale(toDayjsLocale(code)).format("LL");
 
     expect(format("es")).toBe("20 de marzo de 2021");
     expect(format("de")).toBe("20. März 2021");
-    expect(format("en")).toBe("March 20, 2021");
+    expect(format("en")).toBe("20 March 2021");
+    expect(format("en-US")).toBe("March 20, 2021");
   });
 
   it("maps i18n codes that differ from dayjs locale names", () => {
     // pt-BR -> pt-br
-    expect(dayjs("2021-03-20").locale(i18nToDayjsLocale("pt-BR")).format("LL")).toMatch(/mar[çc]o/i);
+    expect(dayjs("2021-03-20").locale(toDayjsLocale("pt-BR")).format("LL")).toMatch(/mar[çc]o/i);
 
     // zh-Hans -> zh-cn
-    expect(dayjs("2021-03-20").locale(i18nToDayjsLocale("zh-Hans")).format("LL")).toContain("3月");
+    expect(dayjs("2021-03-20").locale(toDayjsLocale("zh-Hans")).format("LL")).toContain("3月");
+  });
+
+  it("maps en to en-gb and en-US to dayjs's built-in en", () => {
+    expect(toDayjsLocale("en")).toBe("en-gb");
+    expect(toDayjsLocale("en-US")).toBe("en");
   });
 
   it("falls back to the base language, then English, for unmapped codes", () => {
-    // base-language fallback: en-US -> en
-    expect(i18nToDayjsLocale("en-US")).toBe("en");
-
     // fully unknown -> en
-    expect(i18nToDayjsLocale("xx")).toBe("en");
+    expect(toDayjsLocale("xx")).toBe("en");
   });
 });

--- a/app/web/utils/dayjs.ts
+++ b/app/web/utils/dayjs.ts
@@ -1,11 +1,15 @@
+// Register all locales we support with dayjs.
+// use dayjs(x).locale()
 // Locale data for every app language so dayjs can render month/day names and
-// relative/duration strings in the user's language (en is built in). Importing
-// a locale only registers it; the locale is always specified at the formatting
-// site (via MUI's adapterLocale, or `dayjs(x).locale(i18nToDayjsLocale(ln))`) —
-// we never mutate dayjs's global locale.
+// relative/duration strings in the user's language ("en" -- dayjs's US-oriented
+// default -- is built in, but we use "en-gb" for international formatting; see
+// I18N_TO_DAYJS_LOCALE below). Importing a locale only registers it; the locale
+// is always specified at the formatting site (via MUI's adapterLocale, or
+// `dayjs(x).locale(toDayjsLocale(ln))`) — we never mutate dayjs's global locale.
 import "dayjs/locale/ca";
 import "dayjs/locale/cs";
 import "dayjs/locale/de";
+import "dayjs/locale/en-gb"; // For our "en" locale (international English)
 import "dayjs/locale/es";
 import "dayjs/locale/fr";
 import "dayjs/locale/he";
@@ -32,7 +36,6 @@ import LocalizedFormat from "dayjs/plugin/localizedFormat";
 import RelativeTime from "dayjs/plugin/relativeTime";
 import Timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { DEFAULT_LOCALE } from "i18n/locales";
 
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
@@ -41,42 +44,23 @@ dayjs.extend(RelativeTime);
 dayjs.extend(Timezone);
 dayjs.extend(LocalizedFormat);
 
-// Maps an i18n language code to the matching dayjs locale name (they differ for
-// some: e.g. "pt-BR" -> "pt-br", "zh-Hans" -> "zh-cn"). en is the built-in default.
-const I18N_TO_DAYJS_LOCALE: Record<string, string> = {
-  ca: "ca",
-  cs: "cs",
-  de: "de",
-  en: "en",
-  es: "es",
+// Dayjs-supported locale codes don't map 1:1 with our ISO locales
+const DAYJS_LOCALE_REMAP: Record<string, string> = {
+  // Our "en" is international English (dd/mm/yyyy, 12h clock)
+  // dayjs doesn't have en-001, but en-au approximates it.
+  en: "en-au",
+  // dayjs' "en" locale uses US conventions (mm/dd/yyyy, 12h clock).
+  "en-US": "en",
   "es-419": "es",
-  fr: "fr",
-  he: "he",
-  hi: "hi",
-  hu: "hu",
-  it: "it",
-  ja: "ja",
   "nb-NO": "nb",
-  nl: "nl",
-  pl: "pl",
-  pt: "pt",
   "pt-BR": "pt-br",
-  ru: "ru",
-  sv: "sv",
-  tr: "tr",
-  uk: "uk",
   "zh-Hans": "zh-cn",
   "zh-Hant": "zh-tw",
 };
 
-/**
- * Maps an i18n language code to a registered dayjs locale name, falling back to
- * the base language, then English, for unmapped codes. Use this for MUI's
- * LocalizationProvider `adapterLocale` and for call-site formatting, e.g.
- * `dayjs(x).locale(i18nToDayjsLocale(language)).format("LL")`.
- */
-export function i18nToDayjsLocale(language: string): string {
-  return I18N_TO_DAYJS_LOCALE[language] ?? I18N_TO_DAYJS_LOCALE[language.split("-")[0]] ?? DEFAULT_LOCALE;
+/** Maps a supported ISO locale code to the locale name used for formatting with dayjs. */
+export function toDayjsLocale(locale: string): string {
+  return DAYJS_LOCALE_REMAP[locale] ?? locale.toLowerCase();
 }
 
 export { Dayjs };

--- a/app/web/utils/dayjs.ts
+++ b/app/web/utils/dayjs.ts
@@ -1,11 +1,9 @@
+// Prefer Temporal and Intl APIs to dayjs, they're richer and safer.
+// We still need dayjs for:
+// - The MUI locale adapter needed for date/time pickers.
+// - Formatting durations ("5 minutes"). Intl.RelativeTimeFormat always adds "in" or "ago".
+
 // Register all locales we support with dayjs.
-// use dayjs(x).locale()
-// Locale data for every app language so dayjs can render month/day names and
-// relative/duration strings in the user's language ("en" -- dayjs's US-oriented
-// default -- is built in, but we use "en-gb" for international formatting; see
-// I18N_TO_DAYJS_LOCALE below). Importing a locale only registers it; the locale
-// is always specified at the formatting site (via MUI's adapterLocale, or
-// `dayjs(x).locale(toDayjsLocale(ln))`) — we never mutate dayjs's global locale.
 import "dayjs/locale/ca";
 import "dayjs/locale/cs";
 import "dayjs/locale/de";


### PR DESCRIPTION
Fixes #9184.

Offer two English locales: "English (International)", the default, and "English (US)", to disambiguate date formats. Impacts most date-related tests because the day-month ordering changes.

- Add `en-US` supported locale, such that `en` now means "English (International)"
- Update `en` locale to use `en-001` for formatting (international English)
  - dayjs doesn't have `en-001` so we use `en-au` 
  - Fix expected date formats in all tests (now reflecting the international English default)
- Extract currency formatting function to i18n folder

#9407 already implemented the backend part (supporting an `en-US` locale) but was dormant. This change makes `en` use `en-001` for formatting on the backend as well.

Also tweaked some function names.

Fixes #9184

## Testing
Used Vercel preview.

Language picker:

<img width="432" height="341" alt="image" src="https://github.com/user-attachments/assets/9f49e265-35ec-4079-902f-f19fe5d498cc" />

English (International):

<img width="807" height="232" alt="image" src="https://github.com/user-attachments/assets/d8122910-87d5-4524-89d5-6a0154cedbd2" />

English (US):

<img width="782" height="225" alt="image" src="https://github.com/user-attachments/assets/753d7731-1595-4c97-bcc2-3ba6f86a5c2e" />


<!--
Include screenshots and any necessary dev environment adjustments such as editing .env files.
Fill applicable checklists below, or remove those that don't apply.
-->

**Backend checklist**
- [x] Added tests for any new code or added a regression test if fixing a bug
- [ ] Run the backend locally and it works
- [ ] Added migrations if there are any database changes, rebased onto `develop` if necessary for linear migration history

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

<!--
Create the code review as a draft if still iterating or validating via CI.
Once published, reviewers will be added based on changes, but feel free to add more.
Once your code is approved, you can merge it if you have write access.
--->
