### PR TITLE
web: hardcode the production-ready locales in the middleware

### DIFF
--- a/app/web/middleware.ts
+++ b/app/web/middleware.ts
@@ -31,6 +31,8 @@ async function getProductionReadyLocales(): Promise<string[]> {
     return productionReadyLocalesCache.data;
   }
 
+  // Hardcoded to keep Weblate out of the request path.
+  return ["de", "en", "es", "it", "pt-BR", "ru", "zh-Hans", "zh-Hant"];
   const weblateLanguages = await fetchWeblateLanguages();
   const productionReadyLocales = getLocaleInfos(weblateLanguages)
     .filter(isLocaleProductionReady)


### PR DESCRIPTION
noAI: we shouldn't have weblate in the critical path of prod (it is not guaranteed to be up and it adds latency), so this hardcodes the currently available languages to get rid of that dependency.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._