### PR TITLE
Web: Fix search filters being ignored or inverted after Apply

### DIFF
--- a/app/web/features/search/FilterDialog.tsx
+++ b/app/web/features/search/FilterDialog.tsx
@@ -158,10 +158,7 @@ const FilterDialog = ({ filters, isOpen, onCloseDialog, resetFilters, updateFilt
     }
   };
 
-  const handleDrinkingAllowedChange = (
-    event: React.MouseEvent<HTMLElement>,
-    newDrinkingAllowed: boolean | undefined,
-  ) => {
+  const handleDrinkingAllowedChange = (event: React.MouseEvent<HTMLElement>, newDrinkingAllowed: boolean | null) => {
     updateFilter({ drinkingAllowed: newDrinkingAllowed });
   };
 
@@ -207,7 +204,7 @@ const FilterDialog = ({ filters, isOpen, onCloseDialog, resetFilters, updateFilt
     updateFilter({ sleepingArrangement: newSleepingArrangement });
   };
 
-  const handleSmokesAtHomeChange = (event: React.MouseEvent<HTMLElement>, newSmokesAtHome: boolean | undefined) => {
+  const handleSmokesAtHomeChange = (event: React.MouseEvent<HTMLElement>, newSmokesAtHome: boolean | null) => {
     updateFilter({ smokesAtHome: newSmokesAtHome });
   };
 

--- a/app/web/features/search/SearchPage.tsx
+++ b/app/web/features/search/SearchPage.tsx
@@ -35,7 +35,7 @@ export type FilterOptions = {
   ageMin?: number | undefined;
   ageMax?: number | undefined;
   showEmptyProfile?: boolean;
-  drinkingAllowed?: boolean | undefined;
+  drinkingAllowed?: boolean | null;
   hasReferences?: boolean;
   hasStrongVerification?: boolean;
   hostingStatus?: HostingStatus[];
@@ -46,7 +46,7 @@ export type FilterOptions = {
   lat?: number;
   selectedUserId?: number;
   sleepingArrangement?: SleepingArrangementOptions[];
-  smokesAtHome?: boolean | undefined;
+  smokesAtHome?: boolean | null;
   sameGenderOnly?: boolean;
 };
 

--- a/app/web/features/search/hooks/useUserSearch.ts
+++ b/app/web/features/search/hooks/useUserSearch.ts
@@ -4,8 +4,8 @@ import { RpcError } from "grpc-web";
 import { UserSearchV2Res } from "proto/search_pb";
 import { useRef } from "react";
 import { service } from "service";
+import { UserSearchFilters } from "service/search";
 
-import { FilterOptions } from "../SearchPage";
 import { MapSearchState } from "../state/mapSearchReducers";
 
 const calculateCurrentRange = ({
@@ -31,7 +31,7 @@ const calculateCurrentRange = ({
   return `${startRange}-${endRange}`;
 };
 
-export function useUserSearch(searchParams: FilterOptions, mapSearchState: MapSearchState) {
+export function useUserSearch(searchParams: UserSearchFilters, mapSearchState: MapSearchState) {
   const meetsSearchCriteria =
     mapSearchState.hasActiveFilters ||
     mapSearchState.search.bbox !== undefined ||
@@ -73,7 +73,7 @@ export function useUserSearch(searchParams: FilterOptions, mapSearchState: MapSe
   // Rolls when filters/bbox/query change, stays put across pagination within
   // the same intent. searchParams keeps a stable reference across pagination.
   const searchQueryIdRef = useRef<string | null>(null);
-  const prevSearchParamsRef = useRef<FilterOptions | null>(null);
+  const prevSearchParamsRef = useRef<UserSearchFilters | null>(null);
   if (searchQueryIdRef.current === null || prevSearchParamsRef.current !== searchParams) {
     prevSearchParamsRef.current = searchParams;
     searchQueryIdRef.current = makeSearchQueryId();

--- a/app/web/features/search/state/mapSearchReducers.test.ts
+++ b/app/web/features/search/state/mapSearchReducers.test.ts
@@ -1,27 +1,65 @@
-import { initialState, mapSearchActionTypes, mapSearchReducer } from "./mapSearchReducers";
+import { MeetupStatus } from "proto/api_pb";
+
+import { FilterOptions } from "../SearchPage";
+import { lastActiveOptions } from "../utils/constants";
+import { initialState, mapSearchActionTypes, mapSearchReducer, MapSearchState } from "./mapSearchReducers";
+
+const setFilters = (state: MapSearchState, payload: FilterOptions) =>
+  mapSearchReducer(state, { type: mapSearchActionTypes.SET_FILTERS, payload });
 
 describe("mapSearchReducer SET_FILTERS", () => {
   it("persists acceptsPets when set to true", () => {
-    const state = mapSearchReducer(initialState, {
-      type: mapSearchActionTypes.SET_FILTERS,
-      payload: { acceptsPets: true },
-    });
+    const state = setFilters(initialState, { acceptsPets: true });
 
     expect(state.filters.acceptsPets).toBe(true);
     expect(state.hasActiveFilters).toBe(true);
   });
 
   it("normalizes acceptsPets false back to undefined", () => {
-    const withPets = mapSearchReducer(initialState, {
-      type: mapSearchActionTypes.SET_FILTERS,
-      payload: { acceptsPets: true },
-    });
-
-    const state = mapSearchReducer(withPets, {
-      type: mapSearchActionTypes.SET_FILTERS,
-      payload: { acceptsPets: false },
-    });
+    const state = setFilters(setFilters(initialState, { acceptsPets: true }), { acceptsPets: false });
 
     expect(state.filters.acceptsPets).toBeUndefined();
+  });
+
+  it("marks filters as active when only meetupStatus is set", () => {
+    const state = setFilters(initialState, { meetupStatus: [MeetupStatus.MEETUP_STATUS_WANTS_TO_MEETUP] });
+
+    expect(state.filters.meetupStatus).toEqual([MeetupStatus.MEETUP_STATUS_WANTS_TO_MEETUP]);
+    expect(state.hasActiveFilters).toBe(true);
+  });
+
+  it.each(["drinkingAllowed", "smokesAtHome"] as const)("clears %s when its toggle is deselected", (key) => {
+    const withValue = setFilters(initialState, { [key]: true });
+    expect(withValue.filters[key]).toBe(true);
+
+    // an exclusive ToggleButtonGroup reports a deselection as null
+    const state = setFilters(withValue, { [key]: null });
+
+    expect(state.filters[key]).toBeUndefined();
+    expect(state.hasActiveFilters).toBe(false);
+  });
+
+  it.each(["drinkingAllowed", "smokesAtHome"] as const)("keeps %s when explicitly set to false", (key) => {
+    const state = setFilters(initialState, { [key]: false });
+
+    expect(state.filters[key]).toBe(false);
+    expect(state.hasActiveFilters).toBe(true);
+  });
+
+  it("normalizes lastActive 'any' back to undefined", () => {
+    const withLastActive = setFilters(initialState, { lastActive: lastActiveOptions.LAST_ACTIVE_LAST_MONTH });
+    expect(withLastActive.hasActiveFilters).toBe(true);
+
+    const state = setFilters(withLastActive, { lastActive: lastActiveOptions.LAST_ACTIVE_ANY });
+
+    expect(state.filters.lastActive).toBeUndefined();
+    expect(state.hasActiveFilters).toBe(false);
+  });
+
+  it("does not report active filters after applying unchanged filters on a freshly loaded page", () => {
+    // pages/search.tsx seeds the filters from URL params only, so keys can be missing entirely
+    const state = setFilters({ ...initialState, filters: {} }, {});
+
+    expect(state.hasActiveFilters).toBe(false);
   });
 });

--- a/app/web/features/search/state/mapSearchReducers.ts
+++ b/app/web/features/search/state/mapSearchReducers.ts
@@ -4,7 +4,13 @@ import { UserSearchFilters } from "service/search";
 import { GeocodeResult } from "utils/hooks";
 
 import { FilterOptions } from "../SearchPage";
-import { Coordinates, DEFAULT_AGE_MAX, DEFAULT_AGE_MIN, MAX_MAP_ZOOM_LEVEL_FOR_SEARCH } from "../utils/constants";
+import {
+  Coordinates,
+  DEFAULT_AGE_MAX,
+  DEFAULT_AGE_MIN,
+  lastActiveOptions,
+  MAX_MAP_ZOOM_LEVEL_FOR_SEARCH,
+} from "../utils/constants";
 import { getHasActiveFilters } from "../utils/mapUtils";
 
 /** WHY USE A REDUCER FOR OUR MAP STATE?
@@ -124,7 +130,7 @@ const initialState: MapSearchState = {
     ageMax: undefined,
     showEmptyProfile: undefined,
     drinkingAllowed: undefined,
-    lastActive: 0,
+    lastActive: undefined,
     hasReferences: undefined,
     hasStrongVerification: undefined,
     hostingStatus: undefined,
@@ -328,7 +334,8 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
           updatedFilters.showEmptyProfile = action.payload[key];
         }
         if (key === "drinkingAllowed") {
-          updatedFilters.drinkingAllowed = action.payload[key];
+          // an exclusive ToggleButtonGroup reports a deselection as null
+          updatedFilters.drinkingAllowed = action.payload[key] ?? undefined;
         }
         if (key === "hasReferences") {
           updatedFilters.hasReferences = action.payload[key] === false ? undefined : action.payload[key];
@@ -347,7 +354,8 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
         }
 
         if (key === "lastActive") {
-          updatedFilters.lastActive = action.payload[key];
+          updatedFilters.lastActive =
+            action.payload[key] === lastActiveOptions.LAST_ACTIVE_ANY ? undefined : action.payload[key];
         }
 
         if (key === "numGuests") {
@@ -358,7 +366,7 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
             action.payload[key] && action.payload[key].length === 0 ? undefined : action.payload[key];
         }
         if (key === "smokesAtHome") {
-          updatedFilters.smokesAtHome = action.payload[key];
+          updatedFilters.smokesAtHome = action.payload[key] ?? undefined;
         }
         if (key === "sameGenderOnly") {
           updatedFilters.sameGenderOnly = action.payload[key] === false ? undefined : action.payload[key];

--- a/app/web/features/search/utils/mapUtils.ts
+++ b/app/web/features/search/utils/mapUtils.ts
@@ -51,6 +51,7 @@ const getHasActiveFilters = (state: MapSearchState, initialState: MapSearchState
     state.filters.ageMax !== initialState.filters.ageMax ||
     state.filters.acceptsPets !== initialState.filters.acceptsPets ||
     state.filters.hostingStatus !== initialState.filters.hostingStatus ||
+    state.filters.meetupStatus !== initialState.filters.meetupStatus ||
     state.filters.numGuests !== initialState.filters.numGuests ||
     state.filters.showEmptyProfile !== initialState.filters.showEmptyProfile ||
     state.filters.acceptsKids !== initialState.filters.acceptsKids ||


### PR DESCRIPTION
The map search page keeps its filters in a reducer that lists every filter by hand in several places: the initial state, the Apply handler and the active-filter check. These are similar to the failure in #9717 and were discovered while reviewing that PR. The meetup status filter is missing from the active-filter check, so applying it on its own shows no results and no filter indicator. The alcohol and smoking toggles report a deselection as `null`, which reaches the backend as `false` and inverts the filter. The last-active filter starts as `0` in the reducer but is absent from the state seeded on page load, so applying the dialog without any changes marks filters as active. This fixes all three; consolidating the hand-maintained lists is left for a follow-up PR.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_This PR was created with the Couchers PR skill._