### PR TITLE
Web: Consolidate the map search filter key lists

### DIFF
--- a/app/web/features/search/FilterDialog.tsx
+++ b/app/web/features/search/FilterDialog.tsx
@@ -24,19 +24,19 @@ import useCurrentUser from "features/userQueries/useCurrentUser";
 import { useTranslation } from "i18n";
 import { GLOBAL, SEARCH } from "i18n/namespaces";
 import { HostingStatus, MeetupStatus, SleepingArrangement } from "proto/api_pb";
+import { UserSearchFilterOptions } from "service/search";
 import { theme } from "theme";
 
 import { settingsRoute } from "../../routes";
-import { FilterOptions } from "./SearchPage";
 import { useMapSearchActions } from "./state/useMapSearchActions";
 import { DEFAULT_AGE_MAX, DEFAULT_AGE_MIN, lastActiveOptions, SleepingArrangementOptions } from "./utils/constants";
 
 interface FilterDialogProps {
-  filters: FilterOptions;
+  filters: UserSearchFilterOptions;
   isOpen: boolean;
   onCloseDialog: () => void;
   resetFilters: () => void;
-  updateFilter: (filter: FilterOptions) => void;
+  updateFilter: (filter: UserSearchFilterOptions) => void;
 }
 
 const StyledDialog = styled(Dialog)({
@@ -158,8 +158,9 @@ const FilterDialog = ({ filters, isOpen, onCloseDialog, resetFilters, updateFilt
     }
   };
 
+  // exclusive ToggleButtonGroups report a deselection as null
   const handleDrinkingAllowedChange = (event: React.MouseEvent<HTMLElement>, newDrinkingAllowed: boolean | null) => {
-    updateFilter({ drinkingAllowed: newDrinkingAllowed });
+    updateFilter({ drinkingAllowed: newDrinkingAllowed ?? undefined });
   };
 
   const handleShowEmptyProfileChange = () => {
@@ -205,7 +206,7 @@ const FilterDialog = ({ filters, isOpen, onCloseDialog, resetFilters, updateFilt
   };
 
   const handleSmokesAtHomeChange = (event: React.MouseEvent<HTMLElement>, newSmokesAtHome: boolean | null) => {
-    updateFilter({ smokesAtHome: newSmokesAtHome });
+    updateFilter({ smokesAtHome: newSmokesAtHome ?? undefined });
   };
 
   const handleSameGenderOnlyChange = () => {

--- a/app/web/features/search/SearchPage.tsx
+++ b/app/web/features/search/SearchPage.tsx
@@ -4,15 +4,9 @@ import { DEFAULT_DRAWER_WIDTH } from "components/ResizeableDrawer";
 import { useLogEvent } from "features/analytics/hooks";
 import { SearchAnalyticsProvider } from "features/analytics/searchAnalyticsContext";
 import { getOrCreateSearchSessionId } from "features/analytics/searchAttribution";
-import {
-  MapViewOptions,
-  MapViews,
-  MAX_MAP_ZOOM_LEVEL_FOR_SEARCH,
-  SleepingArrangementOptions,
-} from "features/search/utils/constants";
+import { MapViewOptions, MapViews, MAX_MAP_ZOOM_LEVEL_FOR_SEARCH } from "features/search/utils/constants";
 import { useTranslation } from "i18n";
 import { GLOBAL, SEARCH } from "i18n/namespaces";
-import { HostingStatus, MeetupStatus } from "proto/api_pb";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { LngLatLike, MapProvider, MapRef } from "react-map-gl/maplibre";
 
@@ -27,28 +21,6 @@ import { getMapBounds } from "./utils/mapUtils";
  * See map search architecture diagram and a description of the main concepts here:
  * docs/architecture/frontend/map-search.md
  */
-
-export type FilterOptions = {
-  acceptsKids?: boolean;
-  acceptsPets?: boolean;
-  acceptsLastMinRequests?: boolean;
-  ageMin?: number | undefined;
-  ageMax?: number | undefined;
-  showEmptyProfile?: boolean;
-  drinkingAllowed?: boolean | null;
-  hasReferences?: boolean;
-  hasStrongVerification?: boolean;
-  hostingStatus?: HostingStatus[];
-  meetupStatus?: MeetupStatus[];
-  numGuests?: number;
-  lastActive?: number;
-  lng?: number;
-  lat?: number;
-  selectedUserId?: number;
-  sleepingArrangement?: SleepingArrangementOptions[];
-  smokesAtHome?: boolean | null;
-  sameGenderOnly?: boolean;
-};
 
 const SearchPageContainer = styled("div")(({ theme }) => ({
   display: "flex",

--- a/app/web/features/search/state/mapSearchContext.test.tsx
+++ b/app/web/features/search/state/mapSearchContext.test.tsx
@@ -1,0 +1,32 @@
+import { renderHook } from "@testing-library/react";
+import { HostingStatus } from "proto/api_pb";
+import { ReactNode } from "react";
+import { UserSearchFilterOptions } from "service/search";
+
+import { MapSearchProvider, useMapSearchState } from "./mapSearchContext";
+import { initialState } from "./mapSearchReducers";
+
+const renderState = (initialFilters: UserSearchFilterOptions) =>
+  renderHook(() => useMapSearchState(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <MapSearchProvider initialBbox={undefined} initialLocationName={undefined} initialFilters={initialFilters}>
+        {children}
+      </MapSearchProvider>
+    ),
+  }).result.current;
+
+describe("MapSearchProvider", () => {
+  it("seeds every filter key so a freshly loaded page has no active filters", () => {
+    const state = renderState({});
+
+    expect(state.filters).toEqual(initialState.filters);
+    expect(state.hasActiveFilters).toBe(false);
+  });
+
+  it("marks filters passed in from the URL as active", () => {
+    const state = renderState({ hostingStatus: [HostingStatus.HOSTING_STATUS_CAN_HOST] });
+
+    expect(state.filters.hostingStatus).toEqual([HostingStatus.HOSTING_STATUS_CAN_HOST]);
+    expect(state.hasActiveFilters).toBe(true);
+  });
+});

--- a/app/web/features/search/state/mapSearchContext.tsx
+++ b/app/web/features/search/state/mapSearchContext.tsx
@@ -1,8 +1,9 @@
 import { createContext, Dispatch, ReactNode, useContext, useReducer } from "react";
+import { UserSearchFilterOptions } from "service/search";
 import { GeocodeResult } from "utils/hooks";
-import SearchFilters from "utils/searchFilters";
 
-import { initialState, MapSearchAction, mapSearchReducer } from "./mapSearchReducers";
+import { getHasActiveFilters } from "../utils/mapUtils";
+import { initialState, MapSearchAction, mapSearchReducer, MapSearchState } from "./mapSearchReducers";
 
 const MapSearchContext = createContext(initialState);
 const MapSearchDispatchContext = createContext<Dispatch<MapSearchAction>>(() => {
@@ -32,16 +33,19 @@ function MapSearchProvider({
   children: ReactNode;
   initialBbox: GeocodeResult["bbox"] | undefined;
   initialLocationName: string | undefined;
-  initialFilters: SearchFilters;
+  initialFilters: UserSearchFilterOptions;
 }) {
-  const [mapSearchState, dispatch] = useReducer(mapSearchReducer, {
+  const seededState: MapSearchState = {
     ...initialState,
-    hasActiveFilters: Object.keys(initialFilters).length > 0 ? true : false,
-    filters: initialFilters,
+    filters: { ...initialState.filters, ...initialFilters },
     search: {
       query: initialLocationName,
       bbox: initialBbox,
     },
+  };
+  const [mapSearchState, dispatch] = useReducer(mapSearchReducer, {
+    ...seededState,
+    hasActiveFilters: getHasActiveFilters(seededState, initialState),
   });
 
   return (

--- a/app/web/features/search/state/mapSearchReducers.test.ts
+++ b/app/web/features/search/state/mapSearchReducers.test.ts
@@ -1,65 +1,94 @@
-import { MeetupStatus } from "proto/api_pb";
+import { HostingStatus, MeetupStatus, SleepingArrangement } from "proto/api_pb";
+import { UserSearchFilterOptions } from "service/search";
 
-import { FilterOptions } from "../SearchPage";
-import { lastActiveOptions } from "../utils/constants";
-import { initialState, mapSearchActionTypes, mapSearchReducer, MapSearchState } from "./mapSearchReducers";
+import { DEFAULT_AGE_MAX, DEFAULT_AGE_MIN, lastActiveOptions } from "../utils/constants";
+import { FilterUpdates, initialState, mapSearchActionTypes, mapSearchReducer } from "./mapSearchReducers";
 
-const setFilters = (state: MapSearchState, payload: FilterOptions) =>
+// Required<> so that a filter added to UserSearchFilterOptions has to be covered here too
+const activeValues: Required<UserSearchFilterOptions> = {
+  acceptsKids: true,
+  acceptsLastMinRequests: true,
+  acceptsPets: true,
+  ageMin: 25,
+  ageMax: 40,
+  drinkingAllowed: false,
+  hasReferences: true,
+  hasStrongVerification: true,
+  hostingStatus: [HostingStatus.HOSTING_STATUS_CAN_HOST],
+  lastActive: lastActiveOptions.LAST_ACTIVE_LAST_MONTH,
+  meetupStatus: [MeetupStatus.MEETUP_STATUS_WANTS_TO_MEETUP],
+  numGuests: 2,
+  sameGenderOnly: true,
+  showEmptyProfile: false,
+  sleepingArrangement: [SleepingArrangement.SLEEPING_ARRANGEMENT_PRIVATE],
+  smokesAtHome: false,
+};
+
+// What the FilterDialog hands over when each filter is switched back off
+const offValues: Required<FilterUpdates> = {
+  acceptsKids: false,
+  acceptsLastMinRequests: false,
+  acceptsPets: false,
+  ageMin: DEFAULT_AGE_MIN,
+  ageMax: DEFAULT_AGE_MAX,
+  drinkingAllowed: null,
+  hasReferences: false,
+  hasStrongVerification: false,
+  hostingStatus: [],
+  lastActive: lastActiveOptions.LAST_ACTIVE_ANY,
+  meetupStatus: [],
+  numGuests: 0,
+  sameGenderOnly: false,
+  showEmptyProfile: null,
+  sleepingArrangement: [],
+  smokesAtHome: null,
+};
+
+const filterKeys = Object.keys(activeValues) as (keyof UserSearchFilterOptions)[];
+
+const setFilters = (state: typeof initialState, payload: FilterUpdates) =>
   mapSearchReducer(state, { type: mapSearchActionTypes.SET_FILTERS, payload });
 
 describe("mapSearchReducer SET_FILTERS", () => {
-  it("persists acceptsPets when set to true", () => {
-    const state = setFilters(initialState, { acceptsPets: true });
+  it.each(filterKeys)("stores %s and marks filters as active", (key) => {
+    const state = setFilters(initialState, { [key]: activeValues[key] });
 
-    expect(state.filters.acceptsPets).toBe(true);
+    expect(state.filters).toEqual({ ...initialState.filters, [key]: activeValues[key] });
     expect(state.hasActiveFilters).toBe(true);
   });
 
-  it("normalizes acceptsPets false back to undefined", () => {
-    const state = setFilters(setFilters(initialState, { acceptsPets: true }), { acceptsPets: false });
-
-    expect(state.filters.acceptsPets).toBeUndefined();
-  });
-
-  it("marks filters as active when only meetupStatus is set", () => {
-    const state = setFilters(initialState, { meetupStatus: [MeetupStatus.MEETUP_STATUS_WANTS_TO_MEETUP] });
-
-    expect(state.filters.meetupStatus).toEqual([MeetupStatus.MEETUP_STATUS_WANTS_TO_MEETUP]);
-    expect(state.hasActiveFilters).toBe(true);
-  });
-
-  it.each(["drinkingAllowed", "smokesAtHome"] as const)("clears %s when its toggle is deselected", (key) => {
-    const withValue = setFilters(initialState, { [key]: true });
-    expect(withValue.filters[key]).toBe(true);
-
-    // an exclusive ToggleButtonGroup reports a deselection as null
-    const state = setFilters(withValue, { [key]: null });
+  it.each(filterKeys)("normalizes %s back to undefined when switched off", (key) => {
+    const state = setFilters(setFilters(initialState, activeValues), { [key]: offValues[key] });
 
     expect(state.filters[key]).toBeUndefined();
+  });
+
+  it("reports no active filters once every filter is switched off", () => {
+    const allActive = setFilters(initialState, activeValues);
+    expect(allActive.hasActiveFilters).toBe(true);
+
+    const state = setFilters(allActive, offValues);
+
+    expect(state.filters).toEqual(initialState.filters);
     expect(state.hasActiveFilters).toBe(false);
   });
 
-  it.each(["drinkingAllowed", "smokesAtHome"] as const)("keeps %s when explicitly set to false", (key) => {
-    const state = setFilters(initialState, { [key]: false });
+  it("leaves filters that aren't in the payload untouched", () => {
+    const state = setFilters(setFilters(initialState, { acceptsPets: true }), { acceptsKids: true });
 
-    expect(state.filters[key]).toBe(false);
-    expect(state.hasActiveFilters).toBe(true);
+    expect(state.filters.acceptsPets).toBe(true);
+    expect(state.filters.acceptsKids).toBe(true);
   });
 
-  it("normalizes lastActive 'any' back to undefined", () => {
-    const withLastActive = setFilters(initialState, { lastActive: lastActiveOptions.LAST_ACTIVE_LAST_MONTH });
-    expect(withLastActive.hasActiveFilters).toBe(true);
-
-    const state = setFilters(withLastActive, { lastActive: lastActiveOptions.LAST_ACTIVE_ANY });
-
-    expect(state.filters.lastActive).toBeUndefined();
-    expect(state.hasActiveFilters).toBe(false);
-  });
-
-  it("does not report active filters after applying unchanged filters on a freshly loaded page", () => {
-    // pages/search.tsx seeds the filters from URL params only, so keys can be missing entirely
+  it("treats missing filter keys as unset", () => {
     const state = setFilters({ ...initialState, filters: {} }, {});
 
     expect(state.hasActiveFilters).toBe(false);
+  });
+
+  it("resets to the first page", () => {
+    const state = setFilters({ ...initialState, pageNumber: 3 }, { acceptsPets: true });
+
+    expect(state.pageNumber).toBe(1);
   });
 });

--- a/app/web/features/search/state/mapSearchReducers.ts
+++ b/app/web/features/search/state/mapSearchReducers.ts
@@ -1,16 +1,9 @@
 import { LngLatLike } from "maplibre-gl";
 import { HostingStatus, User } from "proto/api_pb";
-import { UserSearchFilters } from "service/search";
+import { UserSearchFilterOptions } from "service/search";
 import { GeocodeResult } from "utils/hooks";
 
-import { FilterOptions } from "../SearchPage";
-import {
-  Coordinates,
-  DEFAULT_AGE_MAX,
-  DEFAULT_AGE_MIN,
-  lastActiveOptions,
-  MAX_MAP_ZOOM_LEVEL_FOR_SEARCH,
-} from "../utils/constants";
+import { Coordinates, DEFAULT_AGE_MAX, DEFAULT_AGE_MIN, MAX_MAP_ZOOM_LEVEL_FOR_SEARCH } from "../utils/constants";
 import { getHasActiveFilters } from "../utils/mapUtils";
 
 /** WHY USE A REDUCER FOR OUR MAP STATE?
@@ -43,7 +36,7 @@ enum mapSearchActionTypes {
 
 // Overall format of the map search state
 type MapSearchState = {
-  filters: UserSearchFilters;
+  filters: UserSearchFilterOptions;
   hasActiveFilters: boolean;
   pageNumber: number;
   search: {
@@ -101,7 +94,7 @@ type MapSearchAction =
     }
   | {
       type: mapSearchActionTypes.SET_FILTERS;
-      payload: FilterOptions;
+      payload: FilterUpdates;
     }
   | {
       type: mapSearchActionTypes.SET_PAGE_NUMBER;
@@ -121,25 +114,82 @@ type MapSearchAction =
       };
     };
 
+type FilterKey = keyof UserSearchFilterOptions;
+
+// MUI's exclusive ToggleButtonGroup reports a deselection as null, so updates may carry null where undefined is meant
+type FilterUpdates = { [K in FilterKey]?: UserSearchFilterOptions[K] | null };
+
+type FilterNormalizers = {
+  [K in FilterKey]-?: (value: UserSearchFilterOptions[K] | null | undefined) => UserSearchFilterOptions[K];
+};
+
+const offToUndefined = (value: boolean | null | undefined) => (value ? true : undefined);
+const nullToUndefined = <T>(value: T | null | undefined) => value ?? undefined;
+const emptyToUndefined = <T>(value: T[] | null | undefined) => (value && value.length > 0 ? value : undefined);
+const zeroToUndefined = (value: number | null | undefined) => value || undefined;
+const defaultToUndefined = (defaultValue: number) => (value: number | null | undefined) =>
+  value === defaultValue ? undefined : (value ?? undefined);
+
+// Maps the value the dialog produces when a filter is switched off to undefined, so an untouched filter and a
+// cleared one look the same to hasActiveFilters and the API request. Omitting a filter here is a type error.
+const filterNormalizers: FilterNormalizers = {
+  acceptsKids: offToUndefined,
+  acceptsLastMinRequests: offToUndefined,
+  acceptsPets: offToUndefined,
+  ageMin: defaultToUndefined(DEFAULT_AGE_MIN),
+  ageMax: defaultToUndefined(DEFAULT_AGE_MAX),
+  // false is a real value for these three (e.g. "alcohol not allowed"), only a deselected toggle means off
+  drinkingAllowed: nullToUndefined,
+  showEmptyProfile: nullToUndefined,
+  smokesAtHome: nullToUndefined,
+  hasReferences: offToUndefined,
+  hasStrongVerification: offToUndefined,
+  hostingStatus: emptyToUndefined,
+  lastActive: zeroToUndefined,
+  meetupStatus: emptyToUndefined,
+  numGuests: zeroToUndefined,
+  sameGenderOnly: offToUndefined,
+  sleepingArrangement: emptyToUndefined,
+};
+
+// Doubles as the canonical list of filter keys (see getHasActiveFilters), so every key must be present
+const initialFilters: { [K in FilterKey]-?: UserSearchFilterOptions[K] | undefined } = {
+  acceptsKids: undefined,
+  acceptsLastMinRequests: undefined,
+  acceptsPets: undefined,
+  ageMin: undefined,
+  ageMax: undefined,
+  drinkingAllowed: undefined,
+  hasReferences: undefined,
+  hasStrongVerification: undefined,
+  hostingStatus: undefined,
+  lastActive: undefined,
+  meetupStatus: undefined,
+  numGuests: undefined,
+  sameGenderOnly: undefined,
+  showEmptyProfile: undefined,
+  sleepingArrangement: undefined,
+  smokesAtHome: undefined,
+};
+
+const normalizeFilter = <K extends FilterKey>(target: UserSearchFilterOptions, key: K, value: FilterUpdates[K]) => {
+  // TS can't resolve the mapped type for a generic key and falls back to a union of all normalizers
+  const normalize = filterNormalizers[key] as (value: FilterUpdates[K]) => UserSearchFilterOptions[K];
+  target[key] = normalize(value);
+};
+
+const normalizeFilters = (updates: FilterUpdates) => {
+  const normalized: UserSearchFilterOptions = {};
+  for (const key of Object.keys(filterNormalizers) as FilterKey[]) {
+    if (key in updates) {
+      normalizeFilter(normalized, key, updates[key]);
+    }
+  }
+  return normalized;
+};
+
 const initialState: MapSearchState = {
-  filters: {
-    acceptsKids: undefined,
-    acceptsLastMinRequests: undefined,
-    acceptsPets: undefined,
-    ageMin: undefined,
-    ageMax: undefined,
-    showEmptyProfile: undefined,
-    drinkingAllowed: undefined,
-    lastActive: undefined,
-    hasReferences: undefined,
-    hasStrongVerification: undefined,
-    hostingStatus: undefined,
-    meetupStatus: undefined,
-    numGuests: undefined,
-    sleepingArrangement: undefined,
-    smokesAtHome: undefined,
-    sameGenderOnly: undefined,
-  },
+  filters: initialFilters,
   hasActiveFilters: false,
   pageNumber: 1,
   search: {
@@ -310,72 +360,10 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
         },
       };
     }
-    case mapSearchActionTypes.SET_FILTERS:
-      const updatedFilters = { ...state.filters };
-
-      for (const key in action.payload) {
-        if (key === "ageMin") {
-          updatedFilters.ageMin = action.payload[key] === DEFAULT_AGE_MIN ? undefined : action.payload[key];
-        }
-        if (key === "ageMax") {
-          updatedFilters.ageMax = action.payload[key] === DEFAULT_AGE_MAX ? undefined : action.payload[key];
-        }
-
-        if (key === "acceptsKids") {
-          updatedFilters.acceptsKids = action.payload[key] === false ? undefined : action.payload[key];
-        }
-        if (key === "acceptsLastMinRequests") {
-          updatedFilters.acceptsLastMinRequests = action.payload[key] === false ? undefined : action.payload[key];
-        }
-        if (key === "acceptsPets") {
-          updatedFilters.acceptsPets = action.payload[key] === false ? undefined : action.payload[key];
-        }
-        if (key === "showEmptyProfile") {
-          updatedFilters.showEmptyProfile = action.payload[key];
-        }
-        if (key === "drinkingAllowed") {
-          // an exclusive ToggleButtonGroup reports a deselection as null
-          updatedFilters.drinkingAllowed = action.payload[key] ?? undefined;
-        }
-        if (key === "hasReferences") {
-          updatedFilters.hasReferences = action.payload[key] === false ? undefined : action.payload[key];
-        }
-        if (key === "hasStrongVerification") {
-          updatedFilters.hasStrongVerification = action.payload[key] === false ? undefined : action.payload[key];
-        }
-        if (key === "hostingStatus") {
-          updatedFilters.hostingStatus =
-            action.payload[key] && action.payload[key].length === 0 ? undefined : action.payload[key];
-        }
-
-        if (key === "meetupStatus") {
-          updatedFilters.meetupStatus =
-            action.payload[key] && action.payload[key].length === 0 ? undefined : action.payload[key];
-        }
-
-        if (key === "lastActive") {
-          updatedFilters.lastActive =
-            action.payload[key] === lastActiveOptions.LAST_ACTIVE_ANY ? undefined : action.payload[key];
-        }
-
-        if (key === "numGuests") {
-          updatedFilters.numGuests = action.payload[key] === 0 ? undefined : action.payload[key];
-        }
-        if (key === "sleepingArrangement") {
-          updatedFilters.sleepingArrangement =
-            action.payload[key] && action.payload[key].length === 0 ? undefined : action.payload[key];
-        }
-        if (key === "smokesAtHome") {
-          updatedFilters.smokesAtHome = action.payload[key] ?? undefined;
-        }
-        if (key === "sameGenderOnly") {
-          updatedFilters.sameGenderOnly = action.payload[key] === false ? undefined : action.payload[key];
-        }
-      }
-
+    case mapSearchActionTypes.SET_FILTERS: {
       const newState = {
         ...state,
-        filters: updatedFilters,
+        filters: { ...state.filters, ...normalizeFilters(action.payload) },
       };
 
       return {
@@ -384,6 +372,7 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
         pageNumber: initialState.pageNumber,
         shouldSearchByUserId: initialState.shouldSearchByUserId,
       };
+    }
 
     case mapSearchActionTypes.SET_PAGE_NUMBER:
       return {
@@ -456,4 +445,4 @@ const mapSearchReducer = (state: MapSearchState, action: MapSearchAction): MapSe
 };
 
 export { initialState, mapSearchActionTypes, mapSearchReducer };
-export type { MapSearchAction, MapSearchState };
+export type { FilterUpdates, MapSearchAction, MapSearchState };

--- a/app/web/features/search/state/useMapSearchActions.ts
+++ b/app/web/features/search/state/useMapSearchActions.ts
@@ -1,9 +1,8 @@
 import { LngLatLike } from "maplibre-gl";
 import { GeocodeResult } from "utils/hooks";
 
-import { FilterOptions } from "../SearchPage";
 import { useMapSearchDispatch } from "../state/mapSearchContext";
-import { mapSearchActionTypes, MapSearchState } from "../state/mapSearchReducers";
+import { FilterUpdates, mapSearchActionTypes, MapSearchState } from "../state/mapSearchReducers";
 import { Coordinates } from "../utils/constants";
 
 function useMapSearchActions() {
@@ -48,7 +47,7 @@ function useMapSearchActions() {
     });
   };
 
-  const setSearchFilters = (newFilters: FilterOptions) => {
+  const setSearchFilters = (newFilters: FilterUpdates) => {
     dispatch({
       type: mapSearchActionTypes.SET_FILTERS,
       payload: newFilters,

--- a/app/web/features/search/state/useSearchFilters.ts
+++ b/app/web/features/search/state/useSearchFilters.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
+import { UserSearchFilterOptions } from "service/search";
 
-import { FilterOptions } from "../SearchPage";
 import { useMapSearchState } from "./mapSearchContext";
 import { initialState } from "./mapSearchReducers";
 
@@ -12,7 +12,7 @@ import { initialState } from "./mapSearchReducers";
 export function useSearchFilters() {
   const { filters: stateFilters } = useMapSearchState();
 
-  const [filters, setFilters] = useState<FilterOptions>(stateFilters);
+  const [filters, setFilters] = useState<UserSearchFilterOptions>(stateFilters);
 
   // Sync local filters with global filters when dialog is opened
   useEffect(() => {
@@ -20,7 +20,7 @@ export function useSearchFilters() {
   }, [stateFilters]);
 
   // Update a single filter
-  const updateFilter = (newFilters: Partial<FilterOptions>) => {
+  const updateFilter = (newFilters: UserSearchFilterOptions) => {
     setFilters((prevFilters) => ({
       ...prevFilters,
       ...newFilters,

--- a/app/web/features/search/utils/mapUtils.ts
+++ b/app/web/features/search/utils/mapUtils.ts
@@ -44,27 +44,10 @@ const loadMapUserPins = async (mapRef: React.RefObject<MapRef | null>) => {
   return;
 };
 
-// @TODO(NA) - Maybe stringify state and initialState and compare them instead? As long as order is the same.
-const getHasActiveFilters = (state: MapSearchState, initialState: MapSearchState) => {
-  return (
-    state.filters.ageMin !== initialState.filters.ageMin ||
-    state.filters.ageMax !== initialState.filters.ageMax ||
-    state.filters.acceptsPets !== initialState.filters.acceptsPets ||
-    state.filters.hostingStatus !== initialState.filters.hostingStatus ||
-    state.filters.meetupStatus !== initialState.filters.meetupStatus ||
-    state.filters.numGuests !== initialState.filters.numGuests ||
-    state.filters.showEmptyProfile !== initialState.filters.showEmptyProfile ||
-    state.filters.acceptsKids !== initialState.filters.acceptsKids ||
-    state.filters.acceptsLastMinRequests !== initialState.filters.acceptsLastMinRequests ||
-    state.filters.drinkingAllowed !== initialState.filters.drinkingAllowed ||
-    state.filters.hasReferences !== initialState.filters.hasReferences ||
-    state.filters.sleepingArrangement !== initialState.filters.sleepingArrangement ||
-    state.filters.hasStrongVerification !== initialState.filters.hasStrongVerification ||
-    state.filters.smokesAtHome !== initialState.filters.smokesAtHome ||
-    state.filters.lastActive !== initialState.filters.lastActive ||
-    state.filters.sameGenderOnly !== initialState.filters.sameGenderOnly
+const getHasActiveFilters = (state: MapSearchState, initialState: MapSearchState) =>
+  (Object.keys(initialState.filters) as (keyof MapSearchState["filters"])[]).some(
+    (key) => state.filters[key] !== initialState.filters[key],
   );
-};
 
 const getMapBounds = (mapRef: React.RefObject<MapRef | null>) => {
   const mapBounds = mapRef.current?.getMap().getBounds();

--- a/app/web/service/search.ts
+++ b/app/web/service/search.ts
@@ -11,15 +11,17 @@ import { EventSearchReq, EventSearchRes, RectArea, UserSearchReq } from "proto/s
 import client from "service/client";
 import { GeocodeResult } from "utils/hooks";
 
-export interface UserSearchFilters {
+/**
+ * The filters a user can set in the search FilterDialog. The map search reducer's initial filters and
+ * normalizers are typed against this, so adding a key here without handling it there won't compile.
+ */
+export interface UserSearchFilterOptions {
   acceptsKids?: boolean;
   acceptsPets?: boolean;
   acceptsLastMinRequests?: boolean;
   ageMin?: number;
   ageMax?: number;
-  drinkingAllowed?: boolean | undefined;
-  query?: string;
-  bbox?: Coordinates;
+  drinkingAllowed?: boolean;
   lastActive?: number; //within x days
   hasReferences?: boolean;
   hasStrongVerification?: boolean;
@@ -27,12 +29,17 @@ export interface UserSearchFilters {
   meetupStatus?: MeetupStatus[];
   numGuests?: number;
   showEmptyProfile?: boolean;
+  sleepingArrangement?: SleepingArrangementOptions[];
+  sameGenderOnly?: boolean;
+  smokesAtHome?: boolean;
+}
+
+export interface UserSearchFilters extends UserSearchFilterOptions {
+  query?: string;
+  bbox?: Coordinates;
   pageNumber?: number;
   pageSize?: number;
   selectedUserId?: number;
-  sleepingArrangement?: SleepingArrangementOptions[];
-  sameGenderOnly?: boolean;
-  smokesAtHome?: boolean | undefined;
 }
 
 function constructUserSearchReq(

--- a/docs/architecture/frontend/map-search.md
+++ b/docs/architecture/frontend/map-search.md
@@ -81,10 +81,7 @@ Here's some common scenarios you might need to address with the map.
 
 ### How to Add a New Filter
 
-- [] Add the filter to the `FilterDialog` component so it appears in the UI
-- [] Add the filter key to the `initialState` in mapSearchReducer.ts.
-- [] Add logic for filter key to `SET_FILTERS` logic in mapSearchReducer.ts
-- [] Add the value in the API format matching backend protos to `UserSearchFilters` type
-- [] Add the value in state-matching format to `FilterOptions` type
-- [] Update the `hasActiveFilters` logic if needed.
-- [] Pass the new filter to the backend via the `userSearch` api call in app/web/service/search.ts
+- [] Add the filter to the `UserSearchFilterOptions` type in app/web/service/search.ts and pass it to the backend in `constructUserSearchReq` in the same file
+- [] Add the key to `initialFilters` and `filterNormalizers` in mapSearchReducers.ts (the types won't compile until you do). The normalizer maps the value the dialog produces when the filter is switched off to `undefined`, which is what makes `hasActiveFilters` and the API request treat it as unset
+- [] Add the filter to the `FilterDialog` component so it appears in the UI. An exclusive `ToggleButtonGroup` reports a deselection as `null`, convert it to `undefined` in the handler
+- [] Add the filter's active and off values to `mapSearchReducers.test.ts`


### PR DESCRIPTION
noAI: As discussed during the meeting, this is a pure-claude-slop refarctoring attempt to fix this class of bugs. I haven't had time to digest it properly, hence the draft. Happy for someone to take over or redo and we can close.

---

Stacked on #9722. The map search page enumerates its filters by hand in several places: the type definitions, the reducer's initial state and Apply handler, and the active-filter check. That is how the bugs fixed in #9717 and #9722 slipped through, since a filter missing from any one of those lists was silently ignored. This consolidates the dialog filters into a single type in the search service and types the reducer's initial state and normalizers against it, so leaving a filter out of either no longer compiles, and derives the active-filter check from the initial state instead of its own list. The duplicate filter type on the search page goes away, the provider seeds every filter key on page load, and the docs checklist for adding a filter is updated to match.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_This PR was created with the Couchers PR skill._