### PR TITLE
Always load the app-shell i18n namespaces

### DIFF
--- a/app/web/i18n/appServerSideTranslations.ts
+++ b/app/web/i18n/appServerSideTranslations.ts
@@ -1,18 +1,21 @@
 import nextI18nextConfig from "next-i18next.config";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
-import { CONNECTIONS, MESSAGES, PROFILE } from "./namespaces";
+import { CONNECTIONS, GLOBAL, MESSAGES, NOTIFICATIONS, PROFILE } from "./namespaces";
+
+const APP_SHELL_NAMESPACES = [GLOBAL, NOTIFICATIONS, PROFILE, CONNECTIONS, MESSAGES];
 
 /**
  * Drop-in replacement for serverSideTranslations that always includes the
- * namespaces required by app-shell components (ProfileSheet uses PROFILE,
- * CONNECTIONS, MESSAGES). Without this, navigating between pages that have
- * different namespace sets causes translation keys to flash in the ProfileSheet.
+ * namespaces required by app-shell components (_app renders ProfileSheet,
+ * AppRoute renders the navigation and PushNotificationBanner). Without this,
+ * navigating between pages that have different namespace sets causes
+ * translation keys to flash in those components.
  */
 export async function appServerSideTranslations(locale: string, namespacesRequired: string[]) {
   return serverSideTranslations(
     locale,
-    [...new Set([...namespacesRequired, PROFILE, CONNECTIONS, MESSAGES])],
+    [...new Set([...namespacesRequired, ...APP_SHELL_NAMESPACES])],
     nextI18nextConfig,
   );
 }

--- a/app/web/i18n/server-side-translations.ts
+++ b/app/web/i18n/server-side-translations.ts
@@ -1,15 +1,11 @@
+import { appServerSideTranslations } from "i18n/appServerSideTranslations";
 import { DEFAULT_LOCALE } from "i18n/locales";
 import { GetStaticProps } from "next";
-import nextI18NextConfig from "next-i18next.config";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-
-const serverSideTranslationProps = async (locale: string | undefined, namespaces: Array<string>) =>
-  await serverSideTranslations(locale ?? DEFAULT_LOCALE, namespaces, nextI18NextConfig);
 
 export const translationStaticProps =
   (namespaces: Array<string>): GetStaticProps =>
   async ({ locale }) => ({
     props: {
-      ...(await serverSideTranslationProps(locale, namespaces)),
+      ...(await appServerSideTranslations(locale ?? DEFAULT_LOCALE, namespaces)),
     },
   });

--- a/app/web/pages/[...slug].tsx
+++ b/app/web/pages/[...slug].tsx
@@ -2,7 +2,7 @@ import { appGetLayout } from "components/AppRoute";
 import MarkdownPage, { MarkdownPageProps } from "features/markdown/MarkdownPage";
 import { appServerSideTranslations } from "i18n/appServerSideTranslations";
 import { DEFAULT_LOCALE } from "i18n/locales";
-import { AUTH, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
+import { AUTH, COMMUNITIES, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 
 async function getMarkdownPageBySlug(slug: Array<string>): Promise<MarkdownPageProps> {
@@ -25,7 +25,7 @@ export const getStaticProps: GetStaticProps = async ({ locale, params }) => {
   try {
     return {
       props: {
-        ...(await appServerSideTranslations(locale ?? DEFAULT_LOCALE, [GLOBAL, AUTH, NOTIFICATIONS])),
+        ...(await appServerSideTranslations(locale ?? DEFAULT_LOCALE, [GLOBAL, AUTH, COMMUNITIES, NOTIFICATIONS])),
         page: await getMarkdownPageBySlug(slug),
       },
     };

--- a/app/web/pages/discussion/[id]/[slug]/edit.tsx
+++ b/app/web/pages/discussion/[id]/[slug]/edit.tsx
@@ -1,12 +1,11 @@
 import { appGetLayout } from "components/AppRoute";
 import EditDiscussionPageComponent from "features/communities/discussions/EditDiscussionPage";
 import NotFoundPage from "features/NotFoundPage";
+import { appServerSideTranslations } from "i18n/appServerSideTranslations";
 import { DEFAULT_LOCALE } from "i18n/locales";
 import { COMMUNITIES, GLOBAL, NOTIFICATIONS } from "i18n/namespaces";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
-import nextI18nextConfig from "next-i18next.config";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import stringOrFirstString from "utils/stringOrFirstString";
 
 export const getStaticPaths: GetStaticPaths = () => ({
@@ -16,11 +15,7 @@ export const getStaticPaths: GetStaticPaths = () => ({
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(
-      locale ?? DEFAULT_LOCALE,
-      [COMMUNITIES, GLOBAL, NOTIFICATIONS],
-      nextI18nextConfig,
-    )),
+    ...(await appServerSideTranslations(locale ?? DEFAULT_LOCALE, [COMMUNITIES, GLOBAL, NOTIFICATIONS])),
   },
 });
 

--- a/app/web/pages/press/index.tsx
+++ b/app/web/pages/press/index.tsx
@@ -1,18 +1,13 @@
 import { appGetLayout } from "components/AppRoute";
 import Press from "features/press/Press";
+import { appServerSideTranslations } from "i18n/appServerSideTranslations";
 import { DEFAULT_LOCALE } from "i18n/locales";
 import { DASHBOARD, GLOBAL, LANDING, NOTIFICATIONS, PRESS } from "i18n/namespaces";
 import { GetStaticProps } from "next";
-import nextI18nextConfig from "next-i18next.config";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(
-      locale ?? DEFAULT_LOCALE,
-      [DASHBOARD, GLOBAL, LANDING, NOTIFICATIONS, PRESS],
-      nextI18nextConfig,
-    )),
+    ...(await appServerSideTranslations(locale ?? DEFAULT_LOCALE, [DASHBOARD, GLOBAL, LANDING, NOTIFICATIONS, PRESS])),
   },
 });
 

--- a/app/web/pages/public-trips.tsx
+++ b/app/web/pages/public-trips.tsx
@@ -1,11 +1,10 @@
 import { useFeatureValue } from "@growthbook/growthbook-react";
 import { appGetLayout } from "components/AppRoute";
 import MyPublicTripsPage from "features/publicTrips/MyPublicTripsPage";
+import { appServerSideTranslations } from "i18n/appServerSideTranslations";
 import { DEFAULT_LOCALE } from "i18n/locales";
 import { COMMUNITIES, GLOBAL, NOTIFICATIONS, PUBLIC_TRIPS } from "i18n/namespaces";
 import { GetStaticProps } from "next";
-import nextI18nextConfig from "next-i18next.config";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const isPublicTripsEnabled = process.env.NODE_ENV !== "production";
@@ -18,11 +17,12 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
 
   return {
     props: {
-      ...(await serverSideTranslations(
-        locale ?? DEFAULT_LOCALE,
-        [GLOBAL, COMMUNITIES, NOTIFICATIONS, PUBLIC_TRIPS],
-        nextI18nextConfig,
-      )),
+      ...(await appServerSideTranslations(locale ?? DEFAULT_LOCALE, [
+        GLOBAL,
+        COMMUNITIES,
+        NOTIFICATIONS,
+        PUBLIC_TRIPS,
+      ])),
     },
   };
 };


### PR DESCRIPTION
noAI: this is trying to fix up a bunch of mising i18n keys from sentry. basically the profile sheet and a few other components can be used anywhere, so this hardcodes them into the used locale components.

---

Web translations load per page: each page declares the i18n namespaces it needs, and anything undeclared cannot be resolved in the browser, since there is no client-side backend to fetch a namespace on demand. Several components render on every page from the app shell — the mobile profile sheet, the navigation's notification feed and the push notification banner — so pages that did not declare those namespaces rendered them with unresolvable keys, which floods Sentry with missing-key warnings. Both translation helpers now apply a single app-shell namespace union, and the three pages that called next-i18next directly go through that helper instead. The markdown pages also gain the communities namespace their breadcrumb needs.

## Testing
On a mobile viewport, open a host request under `/messages` and tap the other user's avatar, then the friend request button in the profile sheet.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._