### PR TITLE
Fix i18n keys that cannot resolve to a string

### DIFF
--- a/app/web/features/dashboard/ReminderCarousel.tsx
+++ b/app/web/features/dashboard/ReminderCarousel.tsx
@@ -156,7 +156,7 @@ export default function ReminderCarousel() {
   return (
     <StyledContainer>
       <StyledArrow
-        aria-label={t("dashboard:carousel_scroller.left_arrow_a11y")}
+        aria-label={t("dashboard:reminder.carousel_scroller.left_arrow_a11y")}
         size={isMobile ? "small" : "medium"}
         onClick={() => scrollByCard(-1)}
         disabled={!canScrollLeft}
@@ -184,7 +184,7 @@ export default function ReminderCarousel() {
       </FadingScrollTrack>
 
       <StyledArrow
-        aria-label={t("dashboard:carousel_scroller.right_arrow_a11y")}
+        aria-label={t("dashboard:reminder.carousel_scroller.right_arrow_a11y")}
         size={isMobile ? "small" : "medium"}
         onClick={() => scrollByCard(1)}
         disabled={!canScrollRight}

--- a/app/web/features/landing/locales/en.json
+++ b/app/web/features/landing/locales/en.json
@@ -2,6 +2,7 @@
   "introduction_title": "Meet as strangers, leave as friends",
   "introduction_subtitle": "Share your world, discover theirs. Authentic couch surfing experiences, built on trust and genuine connection—not transactions.",
   "introduction_subtitle2": "Free forever. Community-led. Non-profit.",
+  "animation_error": "Error loading animation",
   "signup_header": "Join the Couchers.org community",
   "signup_description2_one": "Travel, host, and connect with {{count}} member. <aboutLink>Learn more about us</aboutLink>.",
   "signup_description2_other": "Travel, host, and connect with {{count}} members. <aboutLink>Learn more about us</aboutLink>.",

--- a/app/web/resources/locales/en.json
+++ b/app/web/resources/locales/en.json
@@ -47,6 +47,7 @@
   },
   "load_more": "Load more",
   "read_more": "Read more",
+  "tap_press_to_flip": "Tap / press to flip",
   "next": "Next",
   "previous": "Previous",
   "mod": "Moderation",


### PR DESCRIPTION
Three user-visible strings on the web frontend cannot be resolved at runtime, so the raw key is rendered instead and a missing-key warning is reported to Sentry. The reminder carousel's scroll arrows ask for a key path that does not exist in any locale file, one level above where those strings actually live; the flip card's hint and the map animation's error message were both removed from the source locale as dead strings while still being referenced. This points the carousel at the right path and restores the other two with their original English text.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._