### PR TITLE
Don't translate the push notification error twice

### DIFF
--- a/app/web/features/notifications/PushNotificationSettings.tsx
+++ b/app/web/features/notifications/PushNotificationSettings.tsx
@@ -38,7 +38,7 @@ export default function PushNotificationSettings() {
       try {
         setIsPushEnabled(await checkPushEnabled());
       } catch (e) {
-        setErrorMessage(t("notification_settings.push_notifications.error_unsupported"));
+        setErrorMessage("notifications:notification_settings.push_notifications.error_unsupported");
         Sentry.captureException(e, {
           tags: {
             component: "PushNotificationPermission",
@@ -51,7 +51,7 @@ export default function PushNotificationSettings() {
     };
 
     checkPushEnabledWrap();
-  }, [t, isNativeEmbed]);
+  }, [isNativeEmbed]);
 
   const turnPushNotificationsOnWrap = async () => {
     setIsLoading(true);


### PR DESCRIPTION
The push notification settings in account settings show an error when the browser cannot support push. That message is held in state as a translation key, which the alert resolves when it renders, but the branch that fires when the browser is unsupported stored the already-translated sentence instead. The alert then looked that sentence up as a key, which reports a missing-key warning to Sentry on every render, with the localised text as the key name. This stores the key there too.

**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [ ] Added tests where relevant
- [ ] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._