### PR TITLE
Update team/board section on /press page

### DIFF
--- a/app/web/features/press/Press.test.tsx
+++ b/app/web/features/press/Press.test.tsx
@@ -58,7 +58,7 @@ describe("Press", () => {
     expect(
       screen.getByRole("heading", {
         level: 2,
-        name: t("press:team.subheading"),
+        name: t("press:board.subheading"),
       }),
     ).toBeInTheDocument();
     expect(

--- a/app/web/features/press/Press.tsx
+++ b/app/web/features/press/Press.tsx
@@ -48,15 +48,16 @@ export default function Press() {
       <About />
       <MediaAssets />
       <SectionWrapper>
-        <SectionHeading>{t("team.subheading")}</SectionHeading>
+        <SectionHeading>{t("board.subheading")}</SectionHeading>
         <TeamSection
           variant="current"
           volunteers={volunteers.data?.currentVolunteersList}
           boardMembersOnly
           hasExtraCard
           extraCardContent={{
-            text: t("team.extra_card_text"),
-            link: t("team.extra_card_link"),
+            title: t("board.full_team_card_title"),
+            text: t("board.full_team_card_text"),
+            link: t("board.full_team_card_link"),
           }}
         />
       </SectionWrapper>

--- a/app/web/features/press/locales/en.json
+++ b/app/web/features/press/locales/en.json
@@ -26,10 +26,11 @@
     "logo_aria_label": "Download logo assets",
     "mobile_images_aria_label": "Download mobile app assets"
   },
-  "team": {
-    "subheading": "Meet the team",
-    "extra_card_text": "We are passionate couch surfers and skilled professionals committed to creating an improved, safer, and more inclusive platform.",
-    "extra_card_link": "More about the team"
+  "board": {
+    "subheading": "Meet the Board",
+    "full_team_card_title": "The full team",
+    "full_team_card_text": "We are passionate couch surfers and skilled professionals committed to creating an improved, safer, and more inclusive platform.",
+    "full_team_card_link": "See all our volunteers"
   },
   "social_media_subheading": "Follow us",
   "press_coverage_subheading": "Featured Coverage"

--- a/app/web/features/press/locales/zh_Hans.json
+++ b/app/web/features/press/locales/zh_Hans.json
@@ -26,10 +26,8 @@
     "logo_aria_label": "下载徽标资源",
     "mobile_images_aria_label": "下载移动应用素材"
   },
-  "team": {
-    "subheading": "认识团队",
-    "extra_card_text": "我们是一群热爱沙发冲浪的专业人士，致力于打造一个更完善、更安全、更包容的平台。",
-    "extra_card_link": "更多关于团队的信息"
+  "board": {
+    "full_team_card_text": "我们是一群热爱沙发冲浪的专业人士，致力于打造一个更完善、更安全、更包容的平台。"
   },
   "social_media_subheading": "关注我们",
   "press_coverage_subheading": "专题报道"

--- a/app/web/features/press/locales/zh_Hant.json
+++ b/app/web/features/press/locales/zh_Hant.json
@@ -26,10 +26,8 @@
     "logo_aria_label": "下載標誌資源",
     "mobile_images_aria_label": "下載行動應用程式素材"
   },
-  "team": {
-    "subheading": "認識團隊",
-    "extra_card_text": "我們是一群熱愛沙發衝浪的專業人士，致力於打造一個更完善、更安全、更包容的平台。",
-    "extra_card_link": "更多關於團隊的信息"
+  "board": {
+    "full_team_card_text": "我們是一群熱愛沙發衝浪的專業人士，致力於打造一個更完善、更安全、更包容的平台。"
   },
   "social_media_subheading": "關注我們",
   "press_coverage_subheading": "專題報導"

--- a/app/web/features/team/TeamSection.test.tsx
+++ b/app/web/features/team/TeamSection.test.tsx
@@ -42,12 +42,14 @@ describe("TeamSection", () => {
         volunteers={[boardMember]}
         hasExtraCard
         extraCardContent={{
+          title: "The full team",
           text: "Join our team",
           link: "More about the team",
         }}
       />,
       { wrapper },
     );
+    expect(screen.getByRole("heading", { name: "The full team" })).toBeInTheDocument();
     expect(screen.getByText("Join our team")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "More about the team" })).toBeInTheDocument();
   });

--- a/app/web/features/team/TeamSection.tsx
+++ b/app/web/features/team/TeamSection.tsx
@@ -80,11 +80,17 @@ function BoardMemberBadge() {
   );
 }
 
+type ExtraCardContent = {
+  title?: string;
+  text: string;
+  link: string;
+};
+
 interface MemberListProps {
   variant: "current" | "past";
   members: Volunteer.AsObject[] | undefined;
   hasExtraCard?: boolean;
-  extraCardContent?: { text: string; link: string };
+  extraCardContent?: ExtraCardContent;
   boardMembersOnly?: boolean;
 }
 
@@ -150,6 +156,11 @@ function MemberList({ variant, members, hasExtraCard, extraCardContent, boardMem
       {hasExtraCard && extraCardContent ? (
         <Grid key="extra" size={{ xs: 12, md: 6, lg: 4 }}>
           <ExtraCard variant="outlined">
+            {extraCardContent.title && (
+              <Typography variant="h3" component="h2">
+                {extraCardContent.title}
+              </Typography>
+            )}
             <Typography
               sx={{
                 textAlign: "center",
@@ -164,11 +175,6 @@ function MemberList({ variant, members, hasExtraCard, extraCardContent, boardMem
     </StyledGrid>
   );
 }
-
-type ExtraCardContent = {
-  text: string;
-  link: string;
-};
 
 interface TeamSectionProps {
   variant: "current" | "past";


### PR DESCRIPTION
noAI:

the press page doesn't show the full team, it just shows the board right now. so i changed the heading to say "Meet the Board", and restyled the last card that links to the full team.

runs locally:

<img width="862" height="347" alt="Screenshot 2026-09-12 at 16 20 37" src="https://github.com/user-attachments/assets/07bb7a98-bfc5-4605-a624-94faa92d165b" />

compared to develop:


<img width="818" height="341" alt="Screenshot 2026-09-12 at 16 21 22" src="https://github.com/user-attachments/assets/586ecc10-7b3c-493a-8c43-9a71a32fa7d3" />


**Web frontend checklist**
- [ ] There are no console warnings when running the app
- [x] Added tests where relevant
- [x] Clicked around my changes running locally and it works
- [ ] Checked Desktop, Mobile and Tablet screen sizes

## For maintainers
<!-- Untick the following if you'd prefer that maintainers don't push commits/merge your branch. -->
- [x] Maintainers can push commits to my branch
- [x] Maintainers can merge this PR for me

_This PR was created with the Couchers PR skill._